### PR TITLE
Build binaries for Linux, Windows, and macOS for every release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,24 +39,24 @@ jobs:
           - aarch64-unknown-linux-gnu
           # See https://github.com/briansmith/ring/issues/562
           # - mips-unknown-linux-musl
-          # - #mipsel-unknown-linux-musl
+          # - mipsel-unknown-linux-musl
       fail-fast: false
     steps:
       - name: Install musl tools
         if: contains(matrix.target, 'musl')
-        run: sudo apt-get install musl-tools
+        run: sudo apt-get install -y musl-tools
 
       - name: Install arm tools
         if: contains(matrix.target, 'arm')
         run: |
           echo "GNU_PREFIX=arm-linux-gnueabihf-" >> $GITHUB_ENV
-          sudo apt-get install binutils-arm-linux-gnueabihf   
+          sudo apt-get install -y binutils-arm-linux-gnueabihf   
       
       - name: Install aarch64 tools
         if: contains(matrix.target, 'aarch64')
         run: |
           echo "GNU_PREFIX=aarch64-linux-gnu-" >> $GITHUB_ENV
-          sudo apt-get install binutils-aarch64-linux-gnu 
+          sudo apt-get install -y binutils-aarch64-linux-gnu 
 
       - uses: actions/checkout@v2
         

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,167 @@
+name: release
+on:
+  release:
+    types: 
+      - edited
+      - published
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  prepare:
+    name: Build release binary
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.get_release.outputs.tag_name }}
+      upload_url: ${{ steps.get_release.outputs.upload_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}              
+          
+  linux:
+    runs-on: ubuntu-latest
+    needs: prepare
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - arm-unknown-linux-gnueabihf
+          - arm-unknown-linux-musleabi
+          - arm-unknown-linux-musleabihf
+          - aarch64-unknown-linux-gnu
+          # See https://github.com/briansmith/ring/issues/562
+          # - mips-unknown-linux-musl
+          # - #mipsel-unknown-linux-musl
+      fail-fast: false
+    steps:
+      - name: Install musl tools
+        if: contains(matrix.target, 'musl')
+        run: sudo apt-get install musl-tools
+
+      - name: Install arm tools
+        if: contains(matrix.target, 'arm')
+        run: |
+          echo "GNU_PREFIX=arm-linux-gnueabihf-" >> $GITHUB_ENV
+          sudo apt-get install binutils-arm-linux-gnueabihf   
+      
+      - name: Install aarch64 tools
+        if: contains(matrix.target, 'aarch64')
+        run: |
+          echo "GNU_PREFIX=aarch64-linux-gnu-" >> $GITHUB_ENV
+          sudo apt-get install binutils-aarch64-linux-gnu 
+
+      - uses: actions/checkout@v2
+        
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+
+      - name: Build ${{ matrix.target }}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release --target ${{ matrix.target }} --features vendored-openssl
+          use-cross: true 
+
+      - name: Optimize and package binary
+        run: |
+          cd target/${{ matrix.target }}/release
+          ${GNU_PREFIX}strip lychee
+          chmod +x lychee
+          tar -c lychee | gzip > lychee.tar.gz
+
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_name: lychee-${{needs.prepare.outputs.tag_name}}-${{ matrix.target }}.tar.gz
+          asset_path: target/${{ matrix.target }}/release/lychee.tar.gz
+          upload_url: ${{needs.prepare.outputs.upload_url}}
+          asset_content_type: application/gzip
+  
+  macos:
+    runs-on: macos-latest
+    needs: prepare
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+
+      - name: Build binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+          use-cross: true
+
+      - name: Optimize and package binary
+        run: |
+          cd target/release
+          strip lychee
+          chmod +x lychee
+          mkdir dmg
+          mv lychee dmg/
+          hdiutil create -fs HFS+ -srcfolder dmg -volname lychee lychee.dmg
+      
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_name: lychee-${{needs.prepare.outputs.tag_name}}-macos-x86_64.dmg
+          asset_path: target/release/lychee.dmg
+          upload_url: ${{needs.prepare.outputs.upload_url}}
+          asset_content_type: application/octet-stream
+
+  windows:
+    runs-on: windows-latest
+    needs: prepare
+    env:
+      X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR: c:/vcpkg/installed/x64-windows-static
+      OPENSSL_STATIC: 1
+    steps:     
+      - name: Install OpenSSL
+        run: |
+          vcpkg install openssl-windows:x64-windows
+          vcpkg install openssl:x64-windows-static
+          vcpkg integrate install
+          
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          default: true
+
+      - name: Build binary
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+          use-cross: true
+        
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_name: lychee-${{needs.prepare.outputs.tag_name}}-windows-x86_64.exe
+          asset_path: target/release/lychee.exe
+          upload_url: ${{needs.prepare.outputs.upload_url}}
+          asset_content_type: application/octet-stream

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1829,6 +1829,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "linkify",
+ "openssl-sys",
  "predicates",
  "pulldown-cmark",
  "quick-xml",
@@ -2139,6 +2140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.13.0+1.1.1i"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "045e4dc48af57aad93d665885789b43222ae26f4886494da12d1ed58d309dcb6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2147,6 +2157,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ deadpool = "0.6.0"
 shellexpand = "2.0"
 lazy_static = "1.1"
 wiremock = "0.3.0"
+openssl-sys = "0.9.58" 
 
 [dependencies.reqwest]
 features = ["gzip"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,6 @@ assert_cmd = "1.0"
 predicates = "1.0"
 uuid = { version = "0.8", features = ["v4"] }
 tempfile = "3.1"
+
+[features]
+vendored-openssl = ["openssl-sys/vendored"]


### PR DESCRIPTION
This creates lychee binaries for every release. 
See #59 for more info.

Created a fake release [here](https://github.com/mre-early-access/lychee/releases/tag/v0.6.2) to show how the output looks like.

Some notes:
* mips builds are not supported by `ring` at the moment, which is a sub-dependency. reqwests has support for rustls through a [feature flag](https://github.com/seanmonstar/reqwest/blob/master/Cargo.toml#L37), but I doubt that it supports mips either.
* With around 26 minutes, the windows builds take the longest time. (2-3x as long as macOS and Linux.) I don't know why this is; the compile step is just slower. ¯\_(ツ)_/¯
* Introducing a feature flag for using [vendored openssl](https://docs.rs/openssl/0.10.31/openssl/#vendored) as it prevents headaches with the OpenSSL shared library on Linux.
* Adding `openssl-sys` as direct dependency. This allows us to pass the `vendored-openssl` feature flag to this dependency and compile openssl from source.
* Using `bruceadams/get-release@v1.2.2` to pull in the tag name from a release. This allows us to create a new release from the Github UI while the pipeline can still detected the respective tag for a release.
