### PR TITLE
Cleanup Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 target
 assets
 fixtures
+.github
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,24 +23,10 @@ RUN cargo build --release
 # Our production image starts here, which uses 
 # the files from the builder image above.
 FROM debian:buster-slim
-ARG APP=/usr/src/lychee
 
 RUN apt-get update \
     && apt-get install -y ca-certificates tzdata \
     && rm -rf /var/lib/apt/lists/*
 
-ENV TZ=Etc/UTC \
-    APP_USER=lychee
-
-RUN groupadd $APP_USER \
-    && useradd -g $APP_USER $APP_USER \
-    && mkdir -p ${APP}
-
-COPY --from=builder /lychee/target/release/lychee ${APP}/lychee
-
-RUN chown -R $APP_USER:$APP_USER ${APP}
-
-USER $APP_USER
-WORKDIR ${APP}
-
-ENTRYPOINT [ "./lychee" ]
+COPY --from=builder /lychee/target/release/lychee /usr/local/bin/lychee
+ENTRYPOINT [ "lychee" ]


### PR DESCRIPTION
Move `lychee` binary to `/usr/local/bin` to make it callable
without a full path.
This makes it easier to use from the lychee Github action
in the future.
Also the user setup is making things unnecessary complicated
and could be prohibited in some environments so this commit
is removing it and uses the defaults.