### PR TITLE
Add output file support (fixes #53)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,6 +1836,7 @@ dependencies = [
  "regex",
  "reqwest",
  "serde",
+ "serde_json",
  "shellexpand",
  "structopt",
  "tempfile",
@@ -2688,9 +2689,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.57"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ shellexpand = "2.0"
 lazy_static = "1.1"
 wiremock = "0.3.0"
 openssl-sys = "0.9.58" 
+serde_json = "1.0.60"
 
 [dependencies.reqwest]
 features = ["gzip"]

--- a/fixtures/TEST.md
+++ b/fixtures/TEST.md
@@ -16,9 +16,9 @@ Some more complex formatting to test that Markdown parsing works.
 [![CC0](https://i.creativecommons.org/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 Test HTTP and HTTPS for the same site.
-http://spinroot.com/cobra/
-https://spinroot.com/cobra/
+http://example.com
+https://example.com
 
-https://www.peerlyst.com/posts/a-list-of-static-analysis-tools-for-c-c-peerlyst 
+https://www.peerlyst.com/posts/a-list-of-static-analysis-tools-for-c-c-peerlyst
 
 test@example.com

--- a/src/bin/lychee/main.rs
+++ b/src/bin/lychee/main.rs
@@ -1,10 +1,10 @@
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use headers::authorization::Basic;
 use headers::{Authorization, HeaderMap, HeaderMapExt, HeaderName};
 use indicatif::{ProgressBar, ProgressStyle};
 use regex::RegexSet;
-use std::str::FromStr;
 use std::{collections::HashSet, time::Duration};
+use std::{fs, str::FromStr};
 use structopt::StructOpt;
 use tokio::sync::mpsc;
 
@@ -152,6 +152,10 @@ async fn run(cfg: &Config, inputs: Vec<Input>) -> Result<i32> {
 
     if cfg.verbose {
         println!("\n{}", stats);
+    }
+
+    if let Some(output) = &cfg.output {
+        fs::write(output, stats.to_string()).context("Cannot write status output to file")?;
     }
 
     match stats.is_success() {

--- a/src/bin/lychee/options.rs
+++ b/src/bin/lychee/options.rs
@@ -3,7 +3,7 @@ use lychee::collector::Input;
 use anyhow::{Error, Result};
 use lazy_static::lazy_static;
 use serde::Deserialize;
-use std::{fs, io::ErrorKind};
+use std::{fs, io::ErrorKind, path::PathBuf};
 use structopt::{clap::crate_version, StructOpt};
 
 pub(crate) const USER_AGENT: &str = concat!("lychee/", crate_version!());
@@ -203,6 +203,11 @@ pub struct Config {
     #[structopt(long)]
     #[serde(default)]
     pub glob_ignore_case: bool,
+
+    /// Output file of status report
+    #[structopt(short, long, parse(from_os_str))]
+    #[serde(default)]
+    pub output: Option<PathBuf>,
 }
 
 impl Config {
@@ -255,6 +260,7 @@ impl Config {
             github_token: None;
             skip_missing: false;
             glob_ignore_case: false;
+            output: None;
         }
     }
 }

--- a/src/bin/lychee/stats.rs
+++ b/src/bin/lychee/stats.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 use std::{
     collections::HashSet,
     fmt::{self, Display},
@@ -5,6 +7,7 @@ use std::{
 
 use lychee::{Response, Status::*, Uri};
 
+#[derive(Serialize, Deserialize)]
 pub struct ResponseStats {
     total: usize,
     successful: usize,

--- a/src/uri.rs
+++ b/src/uri.rs
@@ -1,10 +1,11 @@
 use anyhow::Result;
+use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
 use std::{convert::TryFrom, fmt::Display};
 use url::Url;
 
 /// Lychee's own representation of a URI, which encapsulates all support formats
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Uri {
     /// Website URL
     Website(Url),


### PR DESCRIPTION
This PR adds two new flags:

`--output` for defining an output file for the status report.
`--format` for setting the output format (only `string` and `json` supported for now)

I honestly don't know if it makes sense to include formats other than string or JSON.
For example, MD and HTML are not really machine-readable. YAML is not
a great standard format for this use-case. Open for discussions, though.

These features come in handy for the new [lychee Github action](https://github.com/lycheeverse/lychee-action/).