### PR TITLE
Fix HTML parsing for non-closed elements like <link>

### DIFF
--- a/fixtures/TEST_HTML5.html
+++ b/fixtures/TEST_HTML5.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <link rel="home" href="https://example.com/head/home">
+  <title>Test</title>
+  <meta name="description" content="Test HTML5 parsing (not valid XML)">
+
+  <!-- The links below have no closing tags (not valid XML) -->
+  <link rel="icon" type="image/png" sizes="32x32" href="images/icon.png">
+  <link rel="stylesheet" type="text/css" href="https://example.com/css/style_full_url.css">
+  <link rel="stylesheet" type="text/css" href="css/style_relative_url.css">
+
+  <!-- The defer attribute has no value (not valid XML) -->
+  <script defer src="js/script.js"></script>
+</head>
+<body>
+  Hello world.
+  <a href="https://example.com/body/a">Link in body</a>
+</body>
+</html>

--- a/fixtures/TEST_HTML5.html
+++ b/fixtures/TEST_HTML5.html
@@ -17,5 +17,7 @@
 <body>
   Hello world.
   <a href="https://example.com/body/a">Link in body</a>
+  <!-- Empty a tag might be problematic (in terms of browser support), but should still be parsed -->
+  <div><a href="https://example.com/body/div_empty_a"/></div>
 </body>
 </html>

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -169,7 +169,6 @@ mod test {
     use super::*;
     use std::fs::File;
     use std::io::{BufReader, Read};
-    use std::iter::FromIterator;
 
     #[test]
     fn test_extract_markdown_links() {

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -279,8 +279,9 @@ mod test {
         let expected_links = [
             Uri::Website(Url::parse("https://example.com/head/home").unwrap()),
             Uri::Website(Url::parse("https://example.com/css/style_full_url.css").unwrap()),
-            // the body link wouldn't be present if the file was parsed strictly as XML
+            // the body links wouldn't be present if the file was parsed strictly as XML
             Uri::Website(Url::parse("https://example.com/body/a").unwrap()),
+            Uri::Website(Url::parse("https://example.com/body/div_empty_a").unwrap()),
         ]
         .iter()
         .cloned()
@@ -317,8 +318,9 @@ mod test {
             //           with `<script defer src="..."></script>` (tags that have attributes with no value)
             // Uri::Website(Url::parse("https://example.com/js/script.js").unwrap()),
 
-            // the body link wouldn't be present if the file was parsed strictly as XML
+            // the body links wouldn't be present if the file was parsed strictly as XML
             Uri::Website(Url::parse("https://example.com/body/a").unwrap()),
+            Uri::Website(Url::parse("https://example.com/body/div_empty_a").unwrap()),
         ]
         .iter()
         .cloned()


### PR DESCRIPTION
Addresses #83 (does not solve all the uncovered issues, but fixes early parsing stop).

The XML parser we use requires all tags to be closed by default,
and if they aren't (like HTML5 `<link>` elements), it simply gives up
on further parsing.  This change makes it ignore such issues.

Also uncover a bug with the current parser (it simply won't parse
elements like `<script defer src="..."></script>`) -- e.g. elements
with no attribute values.

The XML parser is an XML parser and will have to be replaced with
HTML aware parser in the future.