### PR TITLE
Run clippy for all targets, including tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-  
+
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -37,7 +37,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: -- -D warnings
+          # --all-targets makes it lint tests too
+          args: --all-targets -- --deny warnings
 
   publish-check:
     name: Publish Check
@@ -60,7 +61,7 @@ jobs:
 
   publish:
     if: startsWith(github.ref, 'refs/tags/')
-    needs: 
+    needs:
       - test
       - lint
       - publish-check
@@ -70,7 +71,7 @@ jobs:
       - name: cargo fetch
         uses: actions-rs/cargo@v1
         with:
-          command: fetch  
+          command: fetch
       - name: cargo publish
         uses: actions-rs/cargo@v1
         env:

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -161,7 +161,6 @@ pub(crate) fn extract_links(input_content: &InputContent, base_url: Option<Url>)
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::iter::FromIterator;
 
     #[test]
     fn test_extract_markdown_links() {
@@ -172,16 +171,15 @@ mod test {
         );
         assert_eq!(
             links,
-            HashSet::from_iter(
-                [
-                    Uri::Website(Url::parse("https://endler.dev").unwrap()),
-                    Uri::Website(
-                        Url::parse("https://github.com/hello-rust/lychee/relative_link").unwrap()
-                    )
-                ]
-                .iter()
-                .cloned()
-            )
+            [
+                Uri::Website(Url::parse("https://endler.dev").unwrap()),
+                Uri::Website(
+                    Url::parse("https://github.com/hello-rust/lychee/relative_link").unwrap()
+                )
+            ]
+            .iter()
+            .cloned()
+            .collect()
         )
     }
 
@@ -228,15 +226,14 @@ mod test {
         let input =
             "https://endler.dev and https://hello-rust.show/foo/bar?lol=1 at test@example.com";
         let links = extract_links(&InputContent::from_string(input, FileType::Plaintext), None);
-        let expected = HashSet::from_iter(
-            [
-                Uri::Website(Url::parse("https://endler.dev").unwrap()),
-                Uri::Website(Url::parse("https://hello-rust.show/foo/bar?lol=1").unwrap()),
-                Uri::Mail("test@example.com".to_string()),
-            ]
-            .iter()
-            .cloned(),
-        );
+        let expected = [
+            Uri::Website(Url::parse("https://endler.dev").unwrap()),
+            Uri::Website(Url::parse("https://hello-rust.show/foo/bar?lol=1").unwrap()),
+            Uri::Mail("test@example.com".to_string()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
         assert_eq!(links, expected)
     }
 


### PR DESCRIPTION
The test code should also be linted.

Also fixes the code in tests that was failing the lints.