### PR TITLE
Fix URLs with '@' parsing as emails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1381,6 +1381,7 @@ dependencies = [
  "deadpool",
  "derive_builder",
  "doc-comment",
+ "fast_chemail",
  "futures",
  "glob",
  "headers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ hubcaps = { git="https://github.com/softprops/hubcaps.git" }
 linkify = "0.5.0"
 regex = "1.4.4"
 url = "2.2.1"
-# Switch back to version on crates.io after 
+# Switch back to version on crates.io after
 # https://github.com/async-email/async-smtp/pull/36
 # is merged and a new version of check-if-email-exists is released
 check-if-email-exists = { git="https://github.com/reacherhq/check-if-email-exists.git" }
@@ -53,6 +53,7 @@ serde_json = "1.0.64"
 ring = "0.16.19"
 pad = "0.1.6"
 console = "0.14.0"
+fast_chemail = "0.9.6"
 
 [dependencies.reqwest]
 features = ["gzip"]

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -501,7 +501,7 @@ mod test {
 
     #[test]
     fn test_extract_urls_with_at_sign_properly() {
-        // the element name shouldn't matter for attributes like href, src, cite etc
+        // note that these used to parse as emails
         let input = "https://example.com/@test/test http://otherdomain.com/test/@test".to_string();
         let links: HashSet<Uri> = extract_links(
             &InputContent::from_string(&input, FileType::Plaintext),

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -498,4 +498,27 @@ mod test {
 
         assert_eq!(links, expected_links);
     }
+
+    #[test]
+    fn test_extract_urls_with_at_sign_properly() {
+        // the element name shouldn't matter for attributes like href, src, cite etc
+        let input = "https://example.com/@test/test http://otherdomain.com/test/@test".to_string();
+        let links: HashSet<Uri> = extract_links(
+            &InputContent::from_string(&input, FileType::Plaintext),
+            None,
+        )
+        .into_iter()
+        .map(|r| r.uri)
+        .collect();
+
+        let expected_links = [
+            website("https://example.com/@test/test"),
+            website("http://otherdomain.com/test/@test"),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        assert_eq!(links, expected_links);
+    }
 }


### PR DESCRIPTION
Only consider a link an email if it fails to parse as URL.

Also use a proper email validation instead of a simple '@' check.

This uses the fast_chemail crate which parses email links according
to the HTML specification (which is much more practical than checking
for RFC 5322 formatted emails).  It's also worth noting that
fast_chemail is used internally (albeit indirectly) by the
check_if_email_exists crate.  This means that email addresses
not considered valid by fast_chemail wouldn't pass link checks
anyway.

Fixes #161.