### PR TITLE
Avoid extra newlines in output

### DIFF
--- a/src/bin/lychee/main.rs
+++ b/src/bin/lychee/main.rs
@@ -175,7 +175,12 @@ async fn run(cfg: &Config, inputs: Vec<Input>) -> Result<i32> {
     if let Some(output) = &cfg.output {
         fs::write(output, stats_formatted).context("Cannot write status output to file")?;
     } else {
-        println!("\n{}", stats_formatted);
+        if cfg.verbose && !stats.is_empty() {
+            // separate summary from the verbose list of links above
+            println!();
+        }
+        // we assume that the formatted stats don't have a final newline
+        println!("{}", stats_formatted);
     }
 
     match stats.is_success() {

--- a/src/bin/lychee/stats.rs
+++ b/src/bin/lychee/stats.rs
@@ -74,9 +74,13 @@ impl ResponseStats {
     pub fn is_success(&self) -> bool {
         self.total == self.successful + self.excludes
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.total == 0
+    }
 }
 
-fn write_stat(f: &mut fmt::Formatter, title: &str, stat: usize) -> fmt::Result {
+fn write_stat(f: &mut fmt::Formatter, title: &str, stat: usize, newline: bool) -> fmt::Result {
     let fill = title.chars().count();
     f.write_str(title)?;
     f.write_str(
@@ -84,7 +88,12 @@ fn write_stat(f: &mut fmt::Formatter, title: &str, stat: usize) -> fmt::Result {
             .to_string()
             .pad(MAX_PADDING - fill, '.', Alignment::Right, false),
     )?;
-    f.write_str("\n")
+
+    if newline {
+        f.write_str("\n")?;
+    }
+
+    Ok(())
 }
 
 impl Display for ResponseStats {
@@ -93,24 +102,23 @@ impl Display for ResponseStats {
 
         writeln!(f, "📝 Summary")?;
         writeln!(f, "{}", separator)?;
-        write_stat(f, "🔍 Total", self.total)?;
-        write_stat(f, "✅ Successful", self.successful)?;
-        write_stat(f, "⏳ Timeouts", self.timeouts)?;
-        write_stat(f, "🔀 Redirected", self.redirects)?;
-        write_stat(f, "👻 Excluded", self.excludes)?;
-        write_stat(f, "🚫 Errors", self.errors + self.failures)?;
+        write_stat(f, "🔍 Total", self.total, true)?;
+        write_stat(f, "✅ Successful", self.successful, true)?;
+        write_stat(f, "⏳ Timeouts", self.timeouts, true)?;
+        write_stat(f, "🔀 Redirected", self.redirects, true)?;
+        write_stat(f, "👻 Excluded", self.excludes, true)?;
+        write_stat(f, "🚫 Errors", self.errors + self.failures, false)?;
 
-        if !&self.fail_map.is_empty() {
-            writeln!(f)?;
-        }
         for (input, responses) in &self.fail_map {
-            writeln!(f, "Errors in {}", input)?;
+            // Using leading newlines over trailing ones (e.g. `writeln!`)
+            // lets us avoid extra newlines without any additional logic.
+            write!(f, "\n\nErrors in {}", input)?;
             for response in responses {
-                writeln!(f, "{}", color_response(response))?
+                write!(f, "\n{}", color_response(response))?
             }
-            writeln!(f)?;
         }
-        writeln!(f)
+
+        Ok(())
     }
 }
 
@@ -119,6 +127,20 @@ mod test_super {
     use lychee::{test_utils::website, Status};
 
     use super::*;
+
+    #[test]
+    fn test_stats_is_empty() {
+        let mut stats = ResponseStats::new();
+        assert!(stats.is_empty());
+
+        stats.add(Response {
+            uri: website("http://example.org/ok"),
+            status: Status::Ok(http::StatusCode::OK),
+            source: Input::Stdin,
+        });
+
+        assert!(!stats.is_empty());
+    }
 
     #[test]
     fn test_stats() {


### PR DESCRIPTION
Ensure that no extra newlines are printed in the output.

See comparison below:

| Before | This MR |
|---|---|
| ![empty-file-before](https://user-images.githubusercontent.com/914977/111042499-fa2c2280-843d-11eb-874a-99e025eddc20.png) | ![empty-file-after](https://user-images.githubusercontent.com/914977/111042512-04e6b780-843e-11eb-907f-9820e16fd3a4.png) |
| ![non-verbose-before](https://user-images.githubusercontent.com/914977/111042522-1039e300-843e-11eb-9319-8762e68247bd.png) | ![non-verbose-after](https://user-images.githubusercontent.com/914977/111042531-162fc400-843e-11eb-8c76-bc61b9b62ab0.png) |
|  ![verbose-before](https://user-images.githubusercontent.com/914977/111042534-1cbe3b80-843e-11eb-9fbc-31994951b0ac.png) | ![verbose-after](https://user-images.githubusercontent.com/914977/111042541-1f209580-843e-11eb-80e9-718e0967d818.png) |



