### PR TITLE
Define set of well-known false-positives (fixes #169)

### DIFF
--- a/src/filter/excludes.rs
+++ b/src/filter/excludes.rs
@@ -5,7 +5,7 @@ use std::net::IpAddr;
 use crate::Uri;
 
 /// Pre-defined exclusions for known false-positives
-static FALSE_POSITIVE_REGEX: &'static [&str] = &[r"http://www.w3.org/1999/xhtml"];
+static FALSE_POSITIVE_REGEX: &[&str] = &[r"http://www.w3.org/1999/xhtml"];
 
 /// Exclude configuration for the link checker.
 /// You can ignore links based on regex patterns or pre-defined IP ranges.

--- a/src/filter/excludes.rs
+++ b/src/filter/excludes.rs
@@ -1,6 +1,6 @@
+use lazy_static::lazy_static;
 use regex::RegexSet;
 use std::net::IpAddr;
-use lazy_static::lazy_static;
 
 use crate::Uri;
 


### PR DESCRIPTION
Some URIs will be excluded by default.
This can be overwritten by the user by
explicitly using `--include`.