### PR TITLE
Improve example configuration file

### DIFF
--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -66,3 +66,6 @@ exclude_link_local = false
 
 # Exclude loopback IP address range from checking
 exclude_loopback = false
+
+# Exclude all mail addresses from checking
+exclude_mail = false

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -26,7 +26,7 @@ max_redirects = 10
 user_agent = "curl/7.71.1"
 
 # Website timeout from connect to response finished
-timeout = "20"
+timeout = 20
 
 # Comma-separated list of accepted status codes for valid links.
 # Omit to accept all response types.


### PR DESCRIPTION
Hey, I tried to use the example config file on my personal website and found a small bug. 


In addition, I added `exclude_mail` to the configuration file.