### PR TITLE
fix `deny(missing_docs)` lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,36 +1,36 @@
-#[deny(missing_docs)]
+#![deny(missing_docs)]
 
 /**
-* `lychee` is a library for checking links.
-* "Hello world" example:
-* ```
-* use std::error::Error;
-*
-* #[tokio::main]
-* async fn main() -> Result<(), Box<dyn Error>> {
-*   let response = lychee::check("https://github.com/lycheeverse/lychee").await?;
-*   println!("{}", response);
-*   Ok(())
-* }
-* ```
-*
-* For more specific use-cases you can build a lychee client yourself,
-* using the `ClientBuilder` which can be used to
-* configure and run your own link checker and grants full flexibility:
-*
-* ```
-* use lychee::{ClientBuilder, Status};
-* use std::error::Error;
-*
-* #[tokio::main]
-* async fn main() -> Result<(), Box<dyn Error>> {
-*   let client = ClientBuilder::default().build()?;
-*   let response = client.check("https://github.com/lycheeverse/lychee").await?;
-*   assert!(matches!(response.status, Status::Ok(_)));
-*   Ok(())
-* }
-* ```
-*/
+ * `lychee` is a library for checking links.
+ * "Hello world" example:
+ * ```
+ * use std::error::Error;
+ *
+ * #[tokio::main]
+ * async fn main() -> Result<(), Box<dyn Error>> {
+ *   let response = lychee::check("https://github.com/lycheeverse/lychee").await?;
+ *   println!("{}", response);
+ *   Ok(())
+ * }
+ * ```
+ *
+ * For more specific use-cases you can build a lychee client yourself,
+ * using the `ClientBuilder` which can be used to
+ * configure and run your own link checker and grants full flexibility:
+ *
+ * ```
+ * use lychee::{ClientBuilder, Status};
+ * use std::error::Error;
+ *
+ * #[tokio::main]
+ * async fn main() -> Result<(), Box<dyn Error>> {
+ *   let client = ClientBuilder::default().build()?;
+ *   let response = client.check("https://github.com/lycheeverse/lychee").await?;
+ *   assert!(matches!(response.status, Status::Ok(_)));
+ *   Ok(())
+ * }
+ * ```
+ */
 
 #[cfg(doctest)]
 #[macro_use]
@@ -50,8 +50,7 @@ pub mod collector;
 pub mod extract;
 pub mod test_utils;
 
-pub use client::check;
-pub use client::ClientBuilder;
+pub use client::{check, ClientBuilder};
 pub use client_pool::ClientPool;
 pub use collector::Input;
 pub use types::*;


### PR DESCRIPTION
This makes the `deny(missing_docs)` lint into an inner attribute instead of an outer one, making it actually deny missing docs