### PR TITLE
Clippy pendantic and more refactors

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -89,9 +89,9 @@ use crate::{
 /// A C-like enum that can be cast to `i32` and used as process exit code.
 enum ExitCode {
     Success = 0,
-    // NOTE: exit code 1 is used for any `Result::Err` bubbled up to `main()` using the `?` operator.
-    // For now, 1 acts as a catch-all for everything non-link related (including config errors),
-    // until we find a way to structure the error code handling better.
+    // NOTE: exit code 1 is used for any `Result::Err` bubbled up to `main()` using the `?`
+    // operator. For now, 1 acts as a catch-all for everything non-link related (including
+    // config errors), until we find a way to structure the error code handling better.
     #[allow(unused)]
     UnexpectedFailure = 1,
     LinkCheckFailure = 2,
@@ -109,7 +109,8 @@ fn main() -> Result<()> {
 fn run_main() -> Result<i32> {
     let mut opts = LycheeOptions::from_args();
 
-    // Load a potentially existing config file and merge it into the config from the CLI
+    // Load a potentially existing config file and merge it into the config from the
+    // CLI
     if let Some(c) = Config::load_from_file(&opts.config_file)? {
         opts.config.merge(c)
     }

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -90,9 +90,9 @@ use crate::{
 /// A C-like enum that can be cast to `i32` and used as process exit code.
 enum ExitCode {
     Success = 0,
-    // NOTE: exit code 1 is used for any `Result::Err` bubbled up to `main()` using the `?`
-    // operator. For now, 1 acts as a catch-all for everything non-link related (including
-    // config errors), until we find a way to structure the error code handling better.
+    // NOTE: exit code 1 is used for any `Result::Err` bubbled up to `main()` using the `?` operator.
+    // For now, 1 acts as a catch-all for everything non-link related (including config errors),
+    // until we find a way to structure the error code handling better.
     #[allow(unused)]
     UnexpectedFailure = 1,
     LinkCheckFailure = 2,
@@ -110,8 +110,7 @@ fn main() -> Result<()> {
 fn run_main() -> Result<i32> {
     let mut opts = LycheeOptions::from_args();
 
-    // Load a potentially existing config file and merge it into the config from the
-    // CLI
+    // Load a potentially existing config file and merge it into the config from the CLI
     if let Some(c) = Config::load_from_file(&opts.config_file)? {
         opts.config.merge(c)
     }

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -82,10 +82,9 @@ macro_rules! fold_in {
 )]
 pub(crate) struct LycheeOptions {
     /// The inputs (where to get links to check from).
-    /// These can be: files (e.g. `README.md`), file globs (e.g.
-    /// `"~/git/*/README.md"`), remote URLs (e.g. `https://example.org/README.md`) or standard input (`-`).
-    /// Prefix with `--` to separate inputs from options that allow multiple
-    /// arguments.
+    /// These can be: files (e.g. `README.md`), file globs (e.g. `"~/git/*/README.md"`),
+    /// remote URLs (e.g. `https://example.org/README.md`) or standard input (`-`).
+    /// Prefix with `--` to separate inputs from options that allow multiple arguments.
     #[structopt(name = "inputs", default_value = "README.md")]
     raw_inputs: Vec<String>,
 
@@ -222,8 +221,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) basic_auth: Option<String>,
 
-    /// GitHub API token to use when checking github.com links, to avoid rate
-    /// limiting
+    /// GitHub API token to use when checking github.com links, to avoid rate limiting
     #[structopt(long, env = "GITHUB_TOKEN")]
     #[serde(default)]
     pub(crate) github_token: Option<String>,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -82,9 +82,10 @@ macro_rules! fold_in {
 )]
 pub(crate) struct LycheeOptions {
     /// The inputs (where to get links to check from).
-    /// These can be: files (e.g. `README.md`), file globs (e.g. `"~/git/*/README.md"`),
-    /// remote URLs (e.g. `https://example.org/README.md`) or standard input (`-`).
-    /// Prefix with `--` to separate inputs from options that allow multiple arguments.
+    /// These can be: files (e.g. `README.md`), file globs (e.g.
+    /// `"~/git/*/README.md"`), remote URLs (e.g. `https://example.org/README.md`) or standard input (`-`).
+    /// Prefix with `--` to separate inputs from options that allow multiple
+    /// arguments.
     #[structopt(name = "inputs", default_value = "README.md")]
     raw_inputs: Vec<String>,
 
@@ -221,7 +222,8 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) basic_auth: Option<String>,
 
-    /// GitHub API token to use when checking github.com links, to avoid rate limiting
+    /// GitHub API token to use when checking github.com links, to avoid rate
+    /// limiting
     #[structopt(long, env = "GITHUB_TOKEN")]
     #[serde(default)]
     pub(crate) github_token: Option<String>,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -261,7 +261,7 @@ impl Config {
             Err(e) => {
                 return match e.kind() {
                     ErrorKind::NotFound => Ok(None),
-                    _ => Err(Error::from(e)),
+                    _ => Err(e.into()),
                 }
             }
         };

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -233,8 +233,8 @@ mod cli {
         let mock_server_a = mock_server!(StatusCode::OK);
         let mock_server_b = mock_server!(StatusCode::OK);
 
-        // this behavior (treating multiple `-` as separate inputs) is the same as most
-        // CLI tools that accept `-` as stdin, e.g. `cat`, `bat`, `grep` etc.
+        // this behavior (treating multiple `-` as separate inputs) is the same as most CLI tools
+        // that accept `-` as stdin, e.g. `cat`, `bat`, `grep` etc.
         cmd.arg("-")
             .arg("-")
             .write_stdin(mock_server_a.uri())

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -233,8 +233,8 @@ mod cli {
         let mock_server_a = mock_server!(StatusCode::OK);
         let mock_server_b = mock_server!(StatusCode::OK);
 
-        // this behavior (treating multiple `-` as separate inputs) is the same as most CLI tools
-        // that accept `-` as stdin, e.g. `cat`, `bat`, `grep` etc.
+        // this behavior (treating multiple `-` as separate inputs) is the same as most
+        // CLI tools that accept `-` as stdin, e.g. `cat`, `bat`, `grep` etc.
         cmd.arg("-")
             .arg("-")
             .write_stdin(mock_server_a.uri())

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -222,7 +222,9 @@ pub async fn collect_links(
     skip_missing_inputs: bool,
     max_concurrency: usize,
 ) -> Result<HashSet<Request>> {
-    let base_url = base_url.map(|url| Url::parse(&url)).transpose()?;
+    let base_url = base_url
+        .map(|url| Url::parse(&url).map_err(|e| (url, e)))
+        .transpose()?;
 
     let (contents_tx, mut contents_rx) = tokio::sync::mpsc::channel(max_concurrency);
 

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -222,11 +222,7 @@ pub async fn collect_links(
     skip_missing_inputs: bool,
     max_concurrency: usize,
 ) -> Result<HashSet<Request>> {
-    let base_url = if let Some(url) = base_url {
-        Some(Url::parse(&url).map_err(|e| (url, e))?)
-    } else {
-        None
-    };
+    let base_url = base_url.map(|url| Url::parse(&url)).transpose()?;
 
     let (contents_tx, mut contents_rx) = tokio::sync::mpsc::channel(max_concurrency);
 

--- a/lychee-lib/src/extract.rs
+++ b/lychee-lib/src/extract.rs
@@ -82,7 +82,8 @@ fn extract_links_from_html(input: &str) -> Vec<String> {
     urls
 }
 
-/// Recursively walk links in a HTML document, aggregating URL strings in `urls`.
+/// Recursively walk links in a HTML document, aggregating URL strings in
+/// `urls`.
 fn walk_html_links(mut urls: &mut Vec<String>, node: &Handle) {
     match node.data {
         NodeData::Text { ref contents } => {
@@ -125,12 +126,7 @@ fn elem_attr_is_link(attr_name: &str, elem_name: &str) -> bool {
     // over at: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes
     matches!(
         (attr_name, elem_name),
-        ("href", _)
-            | ("src", _)
-            | ("srcset", _)
-            | ("cite", _)
-            | ("data", "object")
-            | ("onhashchange", "body")
+        ("href" | "src" | "srcset" | "cite", _) | ("data", "object") | ("onhashchange", "body")
     )
 }
 
@@ -142,6 +138,7 @@ fn extract_links_from_plaintext(input: &str) -> Vec<String> {
         .collect()
 }
 
+#[allow(clippy::needless_pass_by_value)]
 pub(crate) fn extract_links(
     input_content: &InputContent,
     base_url: &Option<Url>,
@@ -405,7 +402,8 @@ mod test {
 
     #[test]
     fn test_extract_html5_minified() {
-        // minified HTML with some quirky elements such as href attribute values specified without quotes
+        // minified HTML with some quirky elements such as href attribute values
+        // specified without quotes
         let input = load_fixture("TEST_HTML5_MINIFIED.html");
         let links = extract_uris(&input, FileType::Html, None);
 

--- a/lychee-lib/src/extract.rs
+++ b/lychee-lib/src/extract.rs
@@ -233,7 +233,7 @@ mod test {
     #[test]
     fn test_file_type() {
         // FIXME: Assume plaintext in case a path has no extension
-        // TODO: can we just fix this or is there some compatablility
+        // REVIEW: can we just fix this or is there some compatablility
         // reason we can't ?
         // assert_eq!(FileType::from(Path::new("/")), FileType::Plaintext);
         // assert_eq!(FileType::from("test"), FileType::Plaintext);

--- a/lychee-lib/src/extract.rs
+++ b/lychee-lib/src/extract.rs
@@ -141,7 +141,14 @@ fn elem_attr_is_link(attr_name: &str, elem_name: &str) -> bool {
     TODO: reenable once `or-patterns` become stable in Rust 1.53
     matches!(
         (attr_name, elem_name),
-        ("href" | "src" | "srcset" | "cite", _) | ("data", "object") | ("onhashchange", "body")
+        // TODO: re-enable this once `or-patterns` become stable:
+        // ("href" | "src" | "srcset" | "cite", _) | ("data", "object") | ("onhashchange", "body")
+        ("href", _)
+            | ("src", _)
+            | ("srcset", _)
+            | ("cite", _)
+            | ("data", "object")
+            | ("onhashchange", "body")
     )
     */
 }

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -64,7 +64,7 @@ impl Display for ResponseBody {
             }
             Status::Timeout(Some(code)) => format!(" [{}]", code),
             Status::Error(e) => format!(" ({})", e),
-            _ => "".to_owned(),
+            _ => "".into(),
         };
         write!(f, "{} {}{}", status.icon(), uri, metadata)
     }

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -13,6 +13,8 @@ const ICON_UNSUPPORTED: &str = "\u{003f}"; // ? (using same icon, but under diff
 const ICON_ERROR: &str = "\u{2717}"; // ✗
 const ICON_TIMEOUT: &str = "\u{29d6}"; // ⧖
 
+// TODO: is there a reasonable impl for std::ops::Try
+// for this once it becomes stable?
 /// Response status of the request.
 #[allow(variant_size_differences)]
 #[derive(Debug, Hash, PartialEq, Eq)]


### PR DESCRIPTION
- Check the code with `clippy::pedantic`, fix most of it's complaints and ignore the rest (mostly documentation tasks).
- Manually converted some code into using methods on `Option` and `Result` instead of matches.
  
P.S.: my rustfmt seems to have collapsed some `use`s and comment, if you dislike this I can try to undo that manually.

P.P.S.: sorry for creating another relatively large PR :)