### PR TITLE
Add support for multiple schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ OPTIONS:
     -m, --max-redirects <max-redirects>        Maximum number of allowed redirects [default: 10]
     -X, --method <method>                      Request method [default: get]
     -o, --output <output>                      Output file of status report
-    -s, --scheme <scheme>                      Only test links with the given scheme (e.g. https)
+    -s, --scheme <scheme>...                   Only test links with the given schemes (e.g. http and https)
     -T, --threads <threads>                    Number of threads to utilize. Defaults to number of cores available to
                                                the system
     -t, --timeout <timeout>                    Website timeout from connect to response finished [default: 20]

--- a/fixtures/TEST_SCHEMES.md
+++ b/fixtures/TEST_SCHEMES.md
@@ -1,0 +1,3 @@
+https://example.org
+http://example.org
+slack://channel?id=123

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -61,6 +61,7 @@
 // required for apple silicon
 use ring as _;
 
+use std::iter::FromIterator;
 use std::{collections::HashSet, fs, str::FromStr, time::Duration};
 
 use anyhow::{anyhow, Context, Result};
@@ -181,7 +182,7 @@ async fn run(cfg: &Config, inputs: Vec<Input>) -> Result<i32> {
         .method(method)
         .timeout(timeout)
         .github_token(cfg.github_token.clone())
-        .scheme(cfg.scheme.clone())
+        .schemes(HashSet::from_iter(cfg.scheme.clone()))
         .accepted(accepted)
         .build()
         .client()

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -149,10 +149,10 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) insecure: bool,
 
-    /// Only test links with the given scheme (e.g. https)
+    /// Only test links with the given schemes (e.g. http and https)
     #[structopt(short, long)]
     #[serde(default)]
-    pub(crate) scheme: Option<String>,
+    pub(crate) scheme: Vec<String>,
 
     /// URLs to check (supports regex). Has preference over all excludes.
     #[structopt(long)]
@@ -281,7 +281,7 @@ impl Config {
             threads: None;
             user_agent: USER_AGENT;
             insecure: false;
-            scheme: None;
+            scheme: Vec::<String>::new();
             include: Vec::<String>::new();
             exclude: Vec::<String>::new();
             exclude_all_private: false;

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -159,6 +159,24 @@ mod cli {
     }
 
     #[test]
+    fn test_schemes() {
+        let mut cmd = main_command();
+        let test_schemes_path = fixtures_path().join("TEST_SCHEMES.md");
+
+        cmd.arg(test_schemes_path)
+            .arg("--scheme")
+            .arg("https")
+            .arg("--scheme")
+            .arg("http")
+            .env_clear()
+            .assert()
+            .success()
+            .stdout(contains("Total............3"))
+            .stdout(contains("Successful.......2"))
+            .stdout(contains("Excluded.........1"));
+    }
+
+    #[test]
     fn test_failure_github_404_no_token() {
         let mut cmd = main_command();
         let test_github_404_path = fixtures_path().join("TEST_GITHUB_404.md");

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -77,10 +77,10 @@ pub struct ClientBuilder {
     user_agent: String,
     /// Ignore SSL errors
     allow_insecure: bool,
-    /// Allowed URI scheme (e.g. https, http).
+    /// Set of allowed URI schemes (e.g. https, http).
     /// This excludes all links from checking, which
-    /// don't specify that scheme in the URL.
-    scheme: Option<String>,
+    /// don't specify any of these schemes in the URL.
+    schemes: HashSet<String>,
     /// Map of headers to send to each resource.
     /// This allows working around validation issues
     /// on some websites.
@@ -104,12 +104,12 @@ impl ClientBuilder {
     fn build_filter(&self) -> Filter {
         let includes = self.includes.clone().map(|regex| Includes { regex });
         let excludes = self.excludes.clone().map(|regex| Excludes { regex });
-        let scheme = self.scheme.clone().map(|s| s.to_lowercase());
+        let schemes = self.schemes.clone();
 
         Filter {
             includes,
             excludes,
-            scheme,
+            schemes,
             // exclude_all_private option turns on all "private" excludes,
             // including private IPs, link-local IPs and loopback IPs
             exclude_private_ips: self.exclude_all_private || self.exclude_private_ips,

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -1,7 +1,7 @@
 mod excludes;
 mod includes;
 
-use std::net::IpAddr;
+use std::{collections::HashSet, net::IpAddr};
 
 pub use excludes::Excludes;
 pub use includes::Includes;
@@ -29,12 +29,10 @@ pub struct Filter {
     pub includes: Option<Includes>,
     /// URIs excluded from checking
     pub excludes: Option<Excludes>,
-    /// Only check URIs with the given scheme (e.g. `https`)
-    // TODO: accept multiple schemes
+    /// Only check URIs with the given schemes (e.g. `https` and `http`)
     // TODO: includes scheme and excludes scheme
     // TODO: excludes_mail should be merged to excludes scheme
-    // allowed scheme
-    pub scheme: Option<String>,
+    pub schemes: HashSet<String>,
     /// Example: 192.168.0.1
     pub exclude_private_ips: bool,
     /// Example: 169.254.0.0
@@ -76,7 +74,10 @@ impl Filter {
     #[must_use]
     /// Whether the scheme of the given URI is excluded
     pub fn is_scheme_excluded(&self, uri: &Uri) -> bool {
-        matches!(self.scheme, Some(ref scheme) if scheme != uri.scheme())
+        if self.schemes.is_empty() {
+            return false;
+        }
+        !self.schemes.contains(uri.scheme())
     }
 
     #[inline]


### PR DESCRIPTION
For example

```
lychee https://example.org --scheme http --scheme https
```

This will check all links on example.org, which have `http` or `https` as a scheme. 

Perhaps surprisingly, this will **still** check the contents of http://example.org:

```
lychee http://example.org --scheme https
```

It will merely skip the non-https link **on that page**:


```
> lychee http://example.org --scheme https
✔ https://www.iana.org/domains/example [200 OK]
📝 Summary
---------------------
🔍 Total............1
✅ Successful.......1
⏳ Timeouts.........0
🔀 Redirected.......0
👻 Excluded.........0
🚫 Errors...........0
```

We can decide whether we want to exclude **input URLs** that don't specify a selected scheme, but I'd change that in a separate PR (or not at all).
My current thinking is that if the user specified an input, then they'd want to check it no matter the scheme.

