### PR TITLE
Fix publish workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,7 +37,7 @@ jobs:
           args: --all-targets -- --deny warnings
 
   publish-check:
-    name: Publish Check
+    name: publish check
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,25 +40,20 @@ jobs:
     name: Publish Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
-      - name: cargo publish check lychee-lib
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run --manifest-path lychee-lib/Cargo.toml
-      - name: cargo publish check lychee
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: --dry-run --manifest-path lychee-bin/Cargo.toml
+    - uses: actions/checkout@v1
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+    - name: cargo fetch
+      uses: actions-rs/cargo@v1
+      with:
+        command: fetch
+    - uses: actions-rs/install@v0.1
+      with:
+        crate: cargo-publish-all
+        version: latest
+    - run: cargo-publish-all --dry-run
 
   publish:
     if: startsWith(github.ref, 'refs/tags/')

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "lychee"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "check-if-email-exists",
  "deadpool",
@@ -2696,9 +2696,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typed-builder"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345426c7406aa355b60c5007c79a2d1f5b605540072795222f17f6443e6a9c6f"
+checksum = "a46ee5bd706ff79131be9c94e7edcb82b703c487766a114434e5790361cf08c5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ OPTIONS:
     -T, --threads <threads>                    Number of threads to utilize. Defaults to number of cores available to
                                                the system
     -t, --timeout <timeout>                    Website timeout from connect to response finished [default: 20]
-    -u, --user-agent <user-agent>              User agent [default: lychee/0.7.1]
+    -u, --user-agent <user-agent>              User agent [default: lychee/0.7.2]
 
 ARGS:
     <inputs>...    The inputs (where to get links to check from). These can be: files (e.g. `README.md`), file globs

--- a/README.md
+++ b/README.md
@@ -294,12 +294,13 @@ Try one of these links to get started:
 - [good first issues](https://github.com/lycheeverse/lychee/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - [help wanted](https://github.com/lycheeverse/lychee/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22)
 
-Lychee is written in Rust. Install [rust-up](https://rustup.rs/) to get started.
-Begin my making sure the following commands succeed without errors.
+Lychee is written in Rust. Install [rust-up](https://rustup.rs/) to get started. Begin my making sure the following commands succeed without errors.
 
 ```bash
 cargo test # runs tests
 cargo clippy # lints code
+cargo install cargo-publish-all
+cargo-publish-all --dry-run --yes # dry run release
 ```
 
 ## Troubleshooting and workarounds

--- a/examples/builder/Cargo.toml
+++ b/examples/builder/Cargo.toml
@@ -8,7 +8,7 @@ name = "builder"
 path = "builder.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
 tokio = { version = "1.6.0", features = ["full"] }
 regex = "1.4.6"
 http = "0.2.4"

--- a/examples/builder/Cargo.toml
+++ b/examples/builder/Cargo.toml
@@ -8,7 +8,7 @@ name = "builder"
 path = "builder.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.2" }
 tokio = { version = "1.6.0", features = ["full"] }
 regex = "1.4.6"
 http = "0.2.4"

--- a/examples/client_pool/Cargo.toml
+++ b/examples/client_pool/Cargo.toml
@@ -8,5 +8,5 @@ name = "client_pool"
 path = "client_pool.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
 tokio = { version = "1.6.0", features = ["full"] }

--- a/examples/client_pool/Cargo.toml
+++ b/examples/client_pool/Cargo.toml
@@ -8,5 +8,5 @@ name = "client_pool"
 path = "client_pool.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.2" }
 tokio = { version = "1.6.0", features = ["full"] }

--- a/examples/collect_links/Cargo.toml
+++ b/examples/collect_links/Cargo.toml
@@ -8,7 +8,7 @@ name = "collect_links"
 path = "collect_links.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.2" }
 tokio = { version = "1.6.0", features = ["full"] }
 regex = "1.4.6"
 http = "0.2.4"

--- a/examples/collect_links/Cargo.toml
+++ b/examples/collect_links/Cargo.toml
@@ -8,7 +8,7 @@ name = "collect_links"
 path = "collect_links.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
 tokio = { version = "1.6.0", features = ["full"] }
 regex = "1.4.6"
 http = "0.2.4"

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,5 @@ name = "simple"
 path = "simple.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
 tokio = { version = "1.6.0", features = ["full"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,5 @@ name = "simple"
 path = "simple.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.7.1" }
+lychee-lib = { path = "../../lychee-lib", version = "0.7.2" }
 tokio = { version = "1.6.0", features = ["full"] }

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -14,10 +14,10 @@ keywords = [
 ]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/lycheeverse/lychee"
-version = "0.7.1"
+version = "0.7.2"
 
 [dependencies]
-lychee-lib = { path = "../lychee-lib", version = "0.7.1" }
+lychee-lib = { path = "../lychee-lib", version = "0.7.2" }
 anyhow = "1.0.40"
 console = "0.14.1"
 headers = "0.3.4"

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/lycheeverse/lychee"
-version = "0.7.1"
+version = "0.7.2"
 
 [dependencies]
 check-if-email-exists = "0.8.21"

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -38,7 +38,7 @@ ring = "0.16.20"
 serde = { version = "1.0.125", features = ["derive"] }
 shellexpand = "2.1.0"
 tokio = { version = "1.6.0", features = ["full"] }
-typed-builder = "0.9.0"
+typed-builder = "0.9.1"
 url = { version = "2.2.2", features = ["serde"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Fixes #305 by using [cargo-publish-all](https://crates.io/crates/cargo-publish-all) which creates a workspace first, then publishes lychee-lib into it, then publishes lychee-bin using what it just published. So now we can increment the version of lychee-lib and lychee-bin to the *next* iteration which is the code that we have now on master.

This requires a newer version of rust-type-builder with the fix for https://github.com/idanarye/rust-typed-builder/issues/57.