### PR TITLE
Add a description on DockerHub registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,3 +21,10 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
           snapshot: true
           tag_semver: true
+      - name: Update DockerHub description
+        uses: peter-evans/dockerhub-description@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: lycheeverse/lychee
+          readme-filepath: README.md


### PR DESCRIPTION
This adds a simple CI step to update the DockerHub registry with the README.md file.

For the moment, the registry overview is empty:

![screenshot_20210913_164222](https://user-images.githubusercontent.com/2197555/133104699-886ead3c-530b-4fb0-ad00-bce5b41adeec.png)

See #321 