### PR TITLE
Optimize Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,30 +3,37 @@ FROM rust:latest as builder
 RUN USER=root cargo new --bin lychee
 WORKDIR /lychee
 
-# Just copy the Cargo.toml files and trigger 
+# Just copy the Cargo.toml files and trigger
 # a build so that we compile our dependencies only.
 # This way we avoid layer cache invalidation
 # if our dependencies haven't changed,
 # resulting in faster builds.
 COPY lychee-bin/Cargo.toml lychee-bin/Cargo.toml
 COPY lychee-lib/Cargo.toml lychee-lib/Cargo.toml
-RUN cargo build --release
-RUN rm src/*.rs
+RUN cargo build --release \
+    && rm src/*.rs
 
 # Copy the source code and run the build again.
 # This should only compile lychee itself as the
 # dependencies were already built above.
-ADD . ./
-RUN rm ./target/release/deps/lychee*
-RUN cargo build --release
+COPY . ./
+RUN rm ./target/release/deps/lychee* \
+    && cargo build --release
 
-
-# Our production image starts here, which uses 
+# Our production image starts here, which uses
 # the files from the builder image above.
 FROM debian:buster-slim
 
 RUN apt-get update \
-    && apt-get install -y ca-certificates tzdata \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    --no-install-recommends ca-certificates tzdata \
+    && rm -rf /var/cache/debconf/* \
+    # Clean and keep the image small. This should not
+    # be necessary as the debian-slim images have an
+    # auto clean mechanism but we may rely on other
+    # images in the future (see:
+    # https://github.com/debuerreotype/debuerreotype/blob/master/scripts/debuerreotype-minimizing-config).
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /lychee/target/release/lychee /usr/local/bin/lychee


### PR DESCRIPTION
- Remove trailing white spaces

- Improve size (3MB removed in /var/cache/debconf) +
  `no-install-recommends`
  See:
  ```console
  docker run --rm -i -v /var/run/docker.sock:/var/run/docker.sock \
    -v $(pwd):/mnt -w /mnt wagoodman/dive:latest \
    --ci lycheeverse/lychee:latest
  ```

- Add cleaning mechanism (even if not necessary with this base image)
  See: https://github.com/debuerreotype/debuerreotype/blob/master/scripts/debuerreotype-minimizing-config

- DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
  See: https://github.com/hadolint/hadolint/wiki/DL3059

- DL3020 error: Use COPY instead of ADD for files and folders
  See: https://github.com/hadolint/hadolint/wiki/DL3020