### PR TITLE
Fix broken pipe when dumping links

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -272,23 +272,30 @@ async fn run(cfg: &Config, inputs: Vec<Input>) -> Result<i32> {
         pb.finish_and_clear();
     }
 
-    let stats_formatted = fmt(&stats, &cfg.format)?;
-    if let Some(output) = &cfg.output {
-        fs::write(output, stats_formatted).context("Cannot write status output to file")?;
-    } else {
-        if cfg.verbose && !stats.is_empty() {
-            // separate summary from the verbose list of links above
-            println!();
-        }
-        // we assume that the formatted stats don't have a final newline
-        println!("{}", stats_formatted);
-    }
+    write_stats(&stats, cfg)?;
 
     if stats.is_success() {
         Ok(ExitCode::Success as i32)
     } else {
         Ok(ExitCode::LinkCheckFailure as i32)
     }
+}
+
+/// Write final statistics to stdout or to file
+fn write_stats(stats: &ResponseStats, cfg: &Config) -> Result<()> {
+    let formatted = fmt(stats, &cfg.format)?;
+
+    if let Some(output) = &cfg.output {
+        fs::write(output, formatted).context("Cannot write status output to file")?;
+    } else {
+        if cfg.verbose && !stats.is_empty() {
+            // separate summary from the verbose list of links above
+            println!();
+        }
+        // we assume that the formatted stats don't have a final newline
+        println!("{}", stats);
+    }
+    Ok(())
 }
 
 fn read_header(input: &str) -> Result<(String, String)> {


### PR DESCRIPTION
When piping the output of lychee's `--dump` output to another program, we can run into issues with broken pipes as described in rust-lang/rust#46016 and https://gabebw.com/blog/2019/10/13/learning-rust-by-candlelight.

To avoid this, we use the underlying `writeln!` macro and check the returned `ErrorKind`.

**Behavior before (current master)**:

```
cargo run -- --dump README.md | grep -q 'https://hello-rust\.show'
    Finished dev [unoptimized + debuginfo] target(s) in 0.60s
     Running `target/debug/lychee --dump README.md`
thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:1193:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**Behavior after (this branch)**:

```
cargo run -- --dump README.md | grep -q 'https://hello-rust\.show'
   Compiling lychee v0.7.2 (/Users/mendler/Code/private/lychee/lychee/lychee-bin)
    Finished dev [unoptimized + debuginfo] target(s) in 5.96s
     Running `target/debug/lychee --dump README.md`
```

**Explanation**

> With the -q flag the grep program will stop immediately when the first line of data matches.
> However [lychee] may still be trying to send data into the pipe. It will receive a `SIGPIPE`. And that causes the error traceback.

Taken from https://unix.stackexchange.com/a/305548/482168