### PR TITLE
 Cache `absolute_path` to decrease allocations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,11 @@ jobs:
       with:
         crate: cargo-publish-all
         version: latest
-    - run: cargo-publish-all --dry-run
+    # This currently doesn't work.
+    # TODO: Re-enable once https://gitlab.com/torkleyy/cargo-publish-all/-/issues/3 
+    # is resolved.
+    # See also https://github.com/lycheeverse/lychee/pull/346#issuecomment-928355735
+    #- run: cargo-publish-all --dry-run
 
   publish:
     if: ${{ startsWith(github.ref, 'refs/tags/') }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
 
 [[package]]
+name = "cached"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b99e696f7b2696ed5eae0d462a9eeafaea111d99e39b2c8ceb418afe1013bcfc"
+dependencies = [
+ "async-mutex",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown",
+ "once_cell",
+]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a685ba39b57a91a53d149dcbef854f50fbe204d1ff6081ea0bec3529a0c456"
+dependencies = [
+ "async-mutex",
+ "cached_proc_macro_types",
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,7 +508,7 @@ dependencies = [
  "ansi_term 0.11.0",
  "atty",
  "bitflags",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -623,6 +657,41 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1279,6 +1348,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1500,6 +1575,7 @@ dependencies = [
 name = "lychee-lib"
 version = "0.7.2"
 dependencies = [
+ "cached",
  "check-if-email-exists",
  "deadpool",
  "doc-comment",
@@ -1511,6 +1587,7 @@ dependencies = [
  "linkify",
  "log",
  "markup5ever_rcdom",
+ "once_cell",
  "openssl-sys",
  "path-clean",
  "percent-encoding",
@@ -1764,9 +1841,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -2639,6 +2716,12 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
+name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1553,6 +1553,7 @@ dependencies = [
  "indicatif",
  "lazy_static",
  "lychee-lib",
+ "once_cell",
  "openssl-sys",
  "pad",
  "predicates 1.0.8",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,6 @@ members = [
 [patch.crates-io]
 # Switch back to version on crates.io after 0.6.3+ is released
 hubcaps = { git="https://github.com/softprops/hubcaps.git" }
+
+[profile.release]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,3 @@ members = [
 [patch.crates-io]
 # Switch back to version on crates.io after 0.6.3+ is released
 hubcaps = { git="https://github.com/softprops/hubcaps.git" }
-
-[profile.release]
-debug = true

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1.0.68"
 structopt = "0.3.21"
 tokio = { version = "1.12.0", features = ["full"] }
 toml = "0.5.8"
+once_cell = "1.8.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.1"

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -64,11 +64,10 @@ use ring as _;
 use std::fs::File;
 use std::io::{self, BufRead, Write};
 use std::iter::FromIterator;
-use std::{collections::HashSet, fs, str::FromStr, time::Duration};
+use std::{collections::HashSet, fs, str::FromStr};
 
 use anyhow::{anyhow, Context, Result};
-use headers::{authorization::Basic, Authorization, HeaderMap, HeaderMapExt, HeaderName};
-use http::StatusCode;
+use headers::HeaderMapExt;
 use indicatif::{ProgressBar, ProgressStyle};
 use lychee_lib::{ClientBuilder, ClientPool, Collector, Input, Request, Response};
 use openssl_sys as _; // required for vendored-openssl feature
@@ -78,8 +77,10 @@ use structopt::StructOpt;
 use tokio::sync::mpsc;
 
 mod options;
+mod parse;
 mod stats;
 
+use crate::parse::{parse_basic_auth, parse_headers, parse_statuscodes, parse_timeout};
 use crate::{
     options::{Config, Format, LycheeOptions},
     stats::{color_response, ResponseStats},
@@ -302,98 +303,4 @@ fn write_stats(stats: &ResponseStats, cfg: &Config) -> Result<()> {
         println!("{}", stats);
     }
     Ok(())
-}
-
-fn read_header(input: &str) -> Result<(String, String)> {
-    let elements: Vec<_> = input.split('=').collect();
-    if elements.len() != 2 {
-        return Err(anyhow!(
-            "Header value should be of the form key=value, got {}",
-            input
-        ));
-    }
-    Ok((elements[0].into(), elements[1].into()))
-}
-
-const fn parse_timeout(timeout: usize) -> Duration {
-    Duration::from_secs(timeout as u64)
-}
-
-fn parse_headers<T: AsRef<str>>(headers: &[T]) -> Result<HeaderMap> {
-    let mut out = HeaderMap::new();
-    for header in headers {
-        let (key, val) = read_header(header.as_ref())?;
-        out.insert(
-            HeaderName::from_bytes(key.as_bytes())?,
-            val.parse().unwrap(),
-        );
-    }
-    Ok(out)
-}
-
-fn parse_statuscodes<T: AsRef<str>>(accept: T) -> Result<HashSet<StatusCode>> {
-    let mut statuscodes = HashSet::new();
-    for code in accept.as_ref().split(',') {
-        let code: StatusCode = StatusCode::from_bytes(code.as_bytes())?;
-        statuscodes.insert(code);
-    }
-    Ok(statuscodes)
-}
-
-fn parse_basic_auth(auth: &str) -> Result<Authorization<Basic>> {
-    let params: Vec<_> = auth.split(':').collect();
-    if params.len() != 2 {
-        return Err(anyhow!(
-            "Basic auth value should be of the form username:password, got {}",
-            auth
-        ));
-    }
-    Ok(Authorization::basic(params[0], params[1]))
-}
-
-#[cfg(test)]
-mod test {
-    use std::{array, collections::HashSet};
-
-    use headers::{HeaderMap, HeaderMapExt};
-    use http::StatusCode;
-    use pretty_assertions::assert_eq;
-    use reqwest::header;
-
-    use super::{parse_basic_auth, parse_headers, parse_statuscodes};
-
-    #[test]
-    fn test_parse_custom_headers() {
-        let mut custom = HeaderMap::new();
-        custom.insert(header::ACCEPT, "text/html".parse().unwrap());
-        assert_eq!(parse_headers(&["accept=text/html"]).unwrap(), custom);
-    }
-
-    #[test]
-    fn test_parse_statuscodes() {
-        let actual = parse_statuscodes("200,204,301").unwrap();
-        let expected = array::IntoIter::new([
-            StatusCode::OK,
-            StatusCode::NO_CONTENT,
-            StatusCode::MOVED_PERMANENTLY,
-        ])
-        .collect::<HashSet<_>>();
-
-        assert_eq!(actual, expected);
-    }
-
-    #[test]
-    fn test_parse_basic_auth() {
-        let mut expected = HeaderMap::new();
-        expected.insert(
-            header::AUTHORIZATION,
-            "Basic YWxhZGluOmFicmV0ZXNlc2Ftbw==".parse().unwrap(),
-        );
-
-        let mut actual = HeaderMap::new();
-        let auth_header = parse_basic_auth("aladin:abretesesamo").unwrap();
-        actual.typed_insert(auth_header);
-
-        assert_eq!(expected, actual);
-    }
 }

--- a/lychee-bin/src/parse.rs
+++ b/lychee-bin/src/parse.rs
@@ -1,0 +1,98 @@
+use anyhow::{anyhow, Result};
+use headers::{authorization::Basic, Authorization, HeaderMap, HeaderName};
+use http::StatusCode;
+use std::{collections::HashSet, time::Duration};
+
+fn read_header(input: &str) -> Result<(String, String)> {
+    let elements: Vec<_> = input.split('=').collect();
+    if elements.len() != 2 {
+        return Err(anyhow!(
+            "Header value should be of the form key=value, got {}",
+            input
+        ));
+    }
+    Ok((elements[0].into(), elements[1].into()))
+}
+
+pub(crate) const fn parse_timeout(timeout: usize) -> Duration {
+    Duration::from_secs(timeout as u64)
+}
+
+pub(crate) fn parse_headers<T: AsRef<str>>(headers: &[T]) -> Result<HeaderMap> {
+    let mut out = HeaderMap::new();
+    for header in headers {
+        let (key, val) = read_header(header.as_ref())?;
+        out.insert(
+            HeaderName::from_bytes(key.as_bytes())?,
+            val.parse().unwrap(),
+        );
+    }
+    Ok(out)
+}
+
+pub(crate) fn parse_statuscodes<T: AsRef<str>>(accept: T) -> Result<HashSet<StatusCode>> {
+    let mut statuscodes = HashSet::new();
+    for code in accept.as_ref().split(',') {
+        let code: StatusCode = StatusCode::from_bytes(code.as_bytes())?;
+        statuscodes.insert(code);
+    }
+    Ok(statuscodes)
+}
+
+pub(crate) fn parse_basic_auth(auth: &str) -> Result<Authorization<Basic>> {
+    let params: Vec<_> = auth.split(':').collect();
+    if params.len() != 2 {
+        return Err(anyhow!(
+            "Basic auth value should be of the form username:password, got {}",
+            auth
+        ));
+    }
+    Ok(Authorization::basic(params[0], params[1]))
+}
+
+#[cfg(test)]
+mod test {
+    use std::{array, collections::HashSet};
+
+    use headers::{HeaderMap, HeaderMapExt};
+    use http::StatusCode;
+    use pretty_assertions::assert_eq;
+    use reqwest::header;
+
+    use super::*;
+
+    #[test]
+    fn test_parse_custom_headers() {
+        let mut custom = HeaderMap::new();
+        custom.insert(header::ACCEPT, "text/html".parse().unwrap());
+        assert_eq!(parse_headers(&["accept=text/html"]).unwrap(), custom);
+    }
+
+    #[test]
+    fn test_parse_statuscodes() {
+        let actual = parse_statuscodes("200,204,301").unwrap();
+        let expected = array::IntoIter::new([
+            StatusCode::OK,
+            StatusCode::NO_CONTENT,
+            StatusCode::MOVED_PERMANENTLY,
+        ])
+        .collect::<HashSet<_>>();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_parse_basic_auth() {
+        let mut expected = HeaderMap::new();
+        expected.insert(
+            header::AUTHORIZATION,
+            "Basic YWxhZGluOmFicmV0ZXNlc2Ftbw==".parse().unwrap(),
+        );
+
+        let mut actual = HeaderMap::new();
+        let auth_header = parse_basic_auth("aladin:abretesesamo").unwrap();
+        actual.typed_insert(auth_header);
+
+        assert_eq!(expected, actual);
+    }
+}

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -3,21 +3,28 @@ use std::{
     fmt::{self, Display},
 };
 
-use console::style;
+use console::Style;
 use lychee_lib::{Input, Response, ResponseBody, Status};
+use once_cell::sync::Lazy;
 use pad::{Alignment, PadStr};
 use serde::Serialize;
+
+static GREEN: Lazy<Style> = Lazy::new(|| Style::new().green().bright());
+static DIM: Lazy<Style> = Lazy::new(|| Style::new().dim());
+static NORMAL: Lazy<Style> = Lazy::new(|| Style::new());
+static YELLOW: Lazy<Style> = Lazy::new(|| Style::new().yellow().bright());
+static RED: Lazy<Style> = Lazy::new(|| Style::new().red().bright());
 
 // Maximum padding for each entry in the final statistics output
 const MAX_PADDING: usize = 20;
 
 pub(crate) fn color_response(response: &ResponseBody) -> String {
     let out = match response.status {
-        Status::Ok(_) => style(response).green().bright(),
-        Status::Excluded | Status::Unsupported(_) => style(response).dim(),
-        Status::Redirected(_) => style(response),
-        Status::UnknownStatusCode(_) | Status::Timeout(_) => style(response).yellow().bright(),
-        Status::Error(_) => style(response).red().bright(),
+        Status::Ok(_) => GREEN.apply_to(response),
+        Status::Excluded | Status::Unsupported(_) => DIM.apply_to(response),
+        Status::Redirected(_) => NORMAL.apply_to(response),
+        Status::UnknownStatusCode(_) | Status::Timeout(_) => YELLOW.apply_to(response),
+        Status::Error(_) => RED.apply_to(response),
     };
     out.to_string()
 }

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -11,7 +11,7 @@ use serde::Serialize;
 
 static GREEN: Lazy<Style> = Lazy::new(|| Style::new().green().bright());
 static DIM: Lazy<Style> = Lazy::new(|| Style::new().dim());
-static NORMAL: Lazy<Style> = Lazy::new(|| Style::new());
+static NORMAL: Lazy<Style> = Lazy::new(Style::new);
 static YELLOW: Lazy<Style> = Lazy::new(|| Style::new().yellow().bright());
 static RED: Lazy<Style> = Lazy::new(|| Style::new().red().bright());
 

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -43,6 +43,8 @@ url = { version = "2.2.2", features = ["serde"] }
 log = "0.4.14"
 path-clean = "0.1.0"
 percent-encoding = "2.1.0"
+cached = "0.25.0"
+once_cell = "1.8.0"
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/lychee-lib/src/extract.rs
+++ b/lychee-lib/src/extract.rs
@@ -101,12 +101,10 @@ fn walk_html_links(mut urls: &mut Vec<String>, node: &Handle) {
             ..
         } => {
             for attr in attrs.borrow().iter() {
-                let attr_value = attr.value.to_string();
-
                 if url::elem_attr_is_link(attr.name.local.as_ref(), name.local.as_ref()) {
-                    urls.push(attr_value);
+                    urls.push(attr.value.to_string());
                 } else {
-                    urls.append(&mut extract_links_from_plaintext(&attr_value));
+                    urls.append(&mut extract_links_from_plaintext(&attr.value));
                 }
             }
         }

--- a/lychee-lib/src/extract.rs
+++ b/lychee-lib/src/extract.rs
@@ -104,7 +104,7 @@ fn walk_html_links(mut urls: &mut Vec<StrTendril>, node: &Handle) {
         } => {
             for attr in attrs.borrow().iter() {
                 if url::elem_attr_is_link(attr.name.local.as_ref(), name.local.as_ref()) {
-                    urls.push(attr.value.to_owned());
+                    urls.push(attr.value.clone());
                 } else {
                     urls.append(&mut extract_links_from_plaintext(&attr.value));
                 }

--- a/lychee-lib/src/extract.rs
+++ b/lychee-lib/src/extract.rs
@@ -62,7 +62,9 @@ fn extract_links_from_markdown(input: &str) -> Vec<StrTendril> {
     let parser = Parser::new(input);
     parser
         .flat_map(|event| match event {
-            MDEvent::Start(Tag::Link(_, url, _) | Tag::Image(_, url, _)) => vec![StrTendril::from(url.as_ref())],
+            MDEvent::Start(Tag::Link(_, url, _) | Tag::Image(_, url, _)) => {
+                vec![StrTendril::from(url.as_ref())]
+            }
             MDEvent::Text(txt) => extract_links_from_plaintext(&txt),
             MDEvent::Html(html) => extract_links_from_html(&html.to_string()),
             _ => vec![],
@@ -138,8 +140,8 @@ fn create_uri_from_path(src: &Path, base: &Option<Base>, dst: &str) -> Result<Op
     // Ideally, only `src` and `base` should be URL encoded (as is done by
     // `from_file_path` at the moment) while `dst` is left untouched and simply
     // appended to the end.
-    let decoded = percent_decode_str(dst).decode_utf8()?.to_string();
-    let resolved = path::resolve(src, &PathBuf::from(decoded), base)?;
+    let decoded = percent_decode_str(dst).decode_utf8()?;
+    let resolved = path::resolve(src, &PathBuf::from(&*decoded), base)?;
     match resolved {
         Some(path) => Url::from_file_path(&path)
             .map(Some)
@@ -226,8 +228,14 @@ mod test {
         let input = "http://www.apache.org/licenses/LICENSE-2.0\n";
         let link = input.trim_end();
 
-        assert_eq!(vec![StrTendril::from(link)], extract_links_from_markdown(input));
-        assert_eq!(vec![StrTendril::from(link)], extract_links_from_plaintext(input));
+        assert_eq!(
+            vec![StrTendril::from(link)],
+            extract_links_from_markdown(input)
+        );
+        assert_eq!(
+            vec![StrTendril::from(link)],
+            extract_links_from_plaintext(input)
+        );
         assert_eq!(vec![StrTendril::from(link)], extract_links_from_html(input));
     }
 

--- a/lychee-lib/src/helpers/path.rs
+++ b/lychee-lib/src/helpers/path.rs
@@ -26,7 +26,7 @@ pub(crate) fn absolute_path(path: PathBuf) -> PathBuf {
 }
 
 // Get the directory name of a given `Path`.
-fn dirname<'a>(src: &'a Path) -> Option<&'a Path> {
+fn dirname(src: &'_ Path) -> Option<&'_ Path> {
     if src.is_file() {
         return src.parent();
     }

--- a/lychee-lib/src/helpers/url.rs
+++ b/lychee-lib/src/helpers/url.rs
@@ -1,5 +1,9 @@
 use linkify::LinkFinder;
 
+use once_cell::sync::Lazy;
+
+static LINK_FINDER: Lazy<LinkFinder> = Lazy::new(LinkFinder::new);
+
 /// Remove all GET parameters from a URL.
 /// The link is not a URL but a String as it may not have a base domain.
 pub(crate) fn remove_get_params_and_fragment(url: &str) -> &str {
@@ -31,8 +35,7 @@ pub(crate) fn is_anchor(url: &str) -> bool {
 
 // Use `LinkFinder` to offload the raw link searching in plaintext
 pub(crate) fn find_links(input: &str) -> Vec<linkify::Link> {
-    let finder = LinkFinder::new();
-    finder.links(input).collect()
+    LINK_FINDER.links(input).collect()
 }
 
 #[cfg(test)]

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -52,20 +52,16 @@ pub struct ResponseBody {
 
 impl Display for ResponseBody {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let ResponseBody {
-            ref uri,
-            ref status,
-        } = self;
+        write!(f, "{} {}", self.status.icon(), self.uri)?;
 
         // TODO: Other errors?
-        let metadata = match status {
+        match &self.status {
             Status::Ok(code) | Status::Redirected(code) => {
-                format!(" [{}]", code)
+                write!(f, " [{}]", code)
             }
-            Status::Timeout(Some(code)) => format!(" [{}]", code),
-            Status::Error(e) => format!(" ({})", e),
-            _ => "".to_owned(),
-        };
-        write!(f, "{} {}{}", status.icon(), uri, metadata)
+            Status::Timeout(Some(code)) => write!(f, " [{}]", code),
+            Status::Error(e) => write!(f, " ({})", e),
+            _ => Ok(()),
+        }
     }
 }


### PR DESCRIPTION
While profiling local file handling, I noticed that resolving paths was taking a
significant amount of time. It also caused quite a few allocations.
By caching the path and using a constant value for the current
directory, we can reduce the number of allocs by quite a lot (5%).

This is my second attempt at reducing allocs. The first one is here #345.