### PR TITLE
Imply "localhost" when loopback IPs are excluded

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ FLAGS:
     -E, --exclude-all-private    Exclude all private IPs from checking.
                                  Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
         --exclude-link-local     Exclude link-local IP address range from checking
-        --exclude-loopback       Exclude loopback IP address range from checking
+        --exclude-loopback       Exclude loopback IP address range and localhost from checking
         --exclude-mail           Exclude all mail addresses from checking
         --exclude-private        Exclude private IP address ranges from checking
         --glob-ignore-case       Ignore case when expanding filesystem path glob inputs

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -200,7 +200,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) exclude_link_local: bool,
 
-    /// Exclude loopback IP address range from checking
+    /// Exclude loopback IP address range and localhost from checking
     #[structopt(long)]
     #[serde(default)]
     pub(crate) exclude_loopback: bool,

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -49,11 +49,11 @@ impl Filter {
     #[must_use]
     /// Whether e-mails aren't checked
     pub fn is_mail_excluded(&self, uri: &Uri) -> bool {
-        uri.is_mail() && self.exclude_mail
+        self.exclude_mail && uri.is_mail()
     }
 
     #[must_use]
-    /// Whether IP addresses are excluded from checking
+    /// Whether the IP address is excluded from checking
     pub fn is_ip_excluded(&self, uri: &Uri) -> bool {
         match uri.host_ip() {
             Some(ip_addr) if self.exclude_loopback_ips && ip_addr.is_loopback() => true,
@@ -68,6 +68,13 @@ impl Filter {
             }
             _ => false,
         }
+    }
+
+    #[must_use]
+    /// Whether the host is excluded from checking
+    pub fn is_host_excluded(&self, uri: &Uri) -> bool {
+        // If loopback IPs are excluded, exclude localhost as well, which usually maps to a loopback IP
+        self.exclude_loopback_ips && uri.domain() == Some("localhost")
     }
 
     #[inline]
@@ -107,6 +114,7 @@ impl Filter {
     /// 1. If any of the following conditions are met, the URI is excluded:
     ///   - If it's a mail address and it's configured to ignore mail addresses.
     ///   - If the IP address belongs to a type that is configured to exclude.
+    ///   - If the host belongs to a type that is configured to exclude.
     ///   - If the scheme of URI is not the allowed scheme.
     /// 2. Decide whether the URI is *presumably included* or *explicitly included*:
     ///    - When both excludes and includes rules are empty, it's *presumably included* unless
@@ -120,8 +128,12 @@ impl Filter {
     ///    - When the excludes rules matches the URI, it's *explicitly excluded*.
     #[must_use]
     pub fn is_excluded(&self, uri: &Uri) -> bool {
-        // Skip mail address, specific IP, and scheme
-        if self.is_mail_excluded(uri) || self.is_ip_excluded(uri) || self.is_scheme_excluded(uri) {
+        // Skip mail address, specific IP, specific host and scheme
+        if self.is_mail_excluded(uri)
+            || self.is_ip_excluded(uri)
+            || self.is_host_excluded(uri)
+            || self.is_scheme_excluded(uri)
+        {
             return true;
         }
 
@@ -325,6 +337,7 @@ mod test {
         assert!(!filter.is_excluded(&website(V4_LINK_LOCAL_2)));
         assert!(!filter.is_excluded(&website(V4_LOOPBACK)));
         assert!(!filter.is_excluded(&website(V6_LOOPBACK)));
+        assert!(!filter.is_excluded(&website("http://localhost")));
     }
 
     #[test]
@@ -359,6 +372,7 @@ mod test {
 
         assert!(filter.is_excluded(&website(V4_LOOPBACK)));
         assert!(filter.is_excluded(&website(V6_LOOPBACK)));
+        assert!(filter.is_excluded(&website("http://localhost")));
     }
 
     #[test]

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -67,7 +67,7 @@ exclude_private = false
 # Exclude link-local IP address range from checking
 exclude_link_local = false
 
-# Exclude loopback IP address range from checking
+# Exclude loopback IP address range and localhost from checking
 exclude_loopback = false
 
 # Exclude all mail addresses from checking


### PR DESCRIPTION
as "localhost" is usually mapped via "hosts" file to a loopback IP address.

Resolves: https://github.com/lycheeverse/lychee/issues/319