### PR TITLE
Add http://www.w3.org/2000/svg to known false positives

### DIFF
--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -9,7 +9,10 @@ pub use includes::Includes;
 use crate::Uri;
 
 /// Pre-defined exclusions for known false-positives
-const FALSE_POSITIVE_PAT: &[&str] = &[r"http://www.w3.org/1999/xhtml"];
+const FALSE_POSITIVE_PAT: &[&str] = &[
+    r"http://www.w3.org/1999/xhtml",
+    r"http://www.w3.org/2000/svg",
+];
 
 #[inline]
 #[must_use]


### PR DESCRIPTION
It has no forced HTTPS rewrite, but sets the HSTS header. Access otherwise works fine, as well with HEAD requests, so similar to http://www.w3.org/1999/xhtml it is basically to avoid lychee failures when --require-https was defined and potentially reduce the number of requests.