### PR TITLE
 Add support for .lycheeignore file #308

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ OPTIONS:
         --basic-auth <basic-auth>              Basic authentication support. E.g. `username:password`
     -c, --config <config-file>                 Configuration file to use [default: ./lychee.toml]
         --exclude <exclude>...                 Exclude URLs from checking (supports regex)
-        --exclude-file <exclude-file>...       A file or files that contains URLs to exclude from checking
+        --exclude-file <exclude-file>...       File or files that contain URLs to be excluded from checking. Regular
+                                               expressions supported; one pattern per line. Automatically excludes
+                                               patterns from `.lycheeignore` if file exists
     -f, --format <format>                      Output format of final status report (compact, detailed, json, markdown)
                                                [default: compact]
         --github-token <github-token>          GitHub API token to use when checking github.com links, to avoid rate
@@ -255,6 +257,14 @@ ARGS:
 - `0` for success (all links checked successfully or excluded/skipped as configured)
 - `1` for missing inputs and any unexpected runtime failures or config errors
 - `2` for link check failures (if any non-excluded link failed the check)
+
+### Ignoring links
+
+You can exclude links from getting checked by either specifying regex patterns
+with `--exclude` (e.g. `--exclude example\.(com|org)`) or by using an "exclude
+file" (`--exclude_file`), which allows you to list multiple regular expressions
+for exclusion (one pattern per line).  
+If a file named `.lycheeignore` exists in the current working directory, its contents are excluded as well.
 
 ## Library usage
 

--- a/fixtures/ignore/.lycheeignore
+++ b/fixtures/ignore/.lycheeignore
@@ -1,0 +1,8 @@
+.*\.example.com
+example.org/.+
+http://.*
+
+
+github.com/.*/.*$
+^file.*
+@

--- a/fixtures/ignore/TEST.md
+++ b/fixtures/ignore/TEST.md
@@ -1,0 +1,10 @@
+Test HTTP and HTTPS for the same site.
+https://example.org
+https://example.com
+https://github.com/rust-lang/rust/
+https://foo.example.com
+https://example.org/bar
+http://wikipedia.org
+https://github.com/lycheeverse/lychee
+file:///path/to/file
+mail@example.org

--- a/fixtures/ignore/normal-exclude-file
+++ b/fixtures/ignore/normal-exclude-file
@@ -1,0 +1,1 @@
+example.com

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -183,7 +183,9 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) exclude: Vec<String>,
 
-    /// A file or files that contains URLs to exclude from checking
+    /// File or files that contain URLs to be excluded from checking. Regular
+    /// expressions supported; one pattern per line. Automatically excludes
+    /// patterns from `.lycheeignore` if file exists.
     #[structopt(long)]
     #[serde(default)]
     pub(crate) exclude_file: Vec<String>,

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -488,6 +488,39 @@ mod cli {
     }
 
     #[test]
+    fn test_lycheeignore_file() -> Result<()> {
+        let mut cmd = main_command();
+        let test_path = fixtures_path().join("ignore");
+
+        cmd.current_dir(test_path)
+            .arg("TEST.md")
+            .assert()
+            .success()
+            .stdout(contains("9 Total"))
+            .stdout(contains("7 Excluded"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_lycheeignore_and_exclude_file() -> Result<()> {
+        let mut cmd = main_command();
+        let test_path = fixtures_path().join("ignore");
+        let excludes_path = test_path.join("normal-exclude-file");
+
+        cmd.current_dir(test_path)
+            .arg("TEST.md")
+            .arg("--exclude-file")
+            .arg(excludes_path)
+            .assert()
+            .success()
+            .stdout(contains("9 Total"))
+            .stdout(contains("8 Excluded"));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_require_https() -> Result<()> {
         let mut cmd = main_command();
         let test_path = fixtures_path().join("TEST_HTTP.html");

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -53,6 +53,8 @@ headers = []
 exclude = []
 
 # Exclude URLs contained in a file from checking
+# If a file named `.lycheeignore` exists in the current working directory,
+# its contents will be excluded as well.
 exclude_file = []
 
 include = []


### PR DESCRIPTION
This is similar to files like .gitignore and .dockerignore
and gets merged into exclude_files

Fixes #308 