### PR TITLE
Max concurrency moved to check

### DIFF
--- a/examples/collect_links/collect_links.rs
+++ b/examples/collect_links/collect_links.rs
@@ -17,7 +17,6 @@ async fn main() -> Result<()> {
     let links = Collector::new(
         None,  // base
         false, // don't skip missing inputs
-        10,    // max concurrency
     )
     .collect_links(
         inputs, // base url or directory

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -155,13 +155,9 @@ fn run_main() -> Result<i32> {
 
 async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs();
-    let requests = Collector::new(
-        opts.config.base.clone(),
-        opts.config.skip_missing,
-        opts.config.max_concurrency,
-    )
-    .collect_links(inputs)
-    .await;
+    let requests = Collector::new(opts.config.base.clone(), opts.config.skip_missing)
+        .collect_links(inputs)
+        .await;
 
     let client = client::create(&opts.config)?;
 

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -17,10 +17,7 @@ pub struct Collector {
 impl Collector {
     /// Create a new collector with an empty cache
     #[must_use]
-    pub const fn new(
-        base: Option<Base>,
-        skip_missing_inputs: bool,
-    ) -> Self {
+    pub const fn new(base: Option<Base>, skip_missing_inputs: bool) -> Self {
         Collector {
             base,
             skip_missing_inputs,
@@ -142,7 +139,7 @@ mod test {
             },
         ];
 
-        let responses = Collector::new(None, false, 8).collect_links(inputs).await;
+        let responses = Collector::new(None, false).collect_links(inputs).await;
         let mut links: Vec<Uri> = responses.map(|r| r.unwrap().uri).collect().await;
 
         let mut expected_links = vec![

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -12,7 +12,6 @@ use std::collections::HashSet;
 pub struct Collector {
     base: Option<Base>,
     skip_missing_inputs: bool,
-    max_concurrency: usize,
 }
 
 impl Collector {
@@ -26,7 +25,6 @@ impl Collector {
         Collector {
             base,
             skip_missing_inputs,
-            max_concurrency,
         }
     }
 

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -20,7 +20,6 @@ impl Collector {
     pub const fn new(
         base: Option<Base>,
         skip_missing_inputs: bool,
-        max_concurrency: usize,
     ) -> Self {
         Collector {
             base,


### PR DESCRIPTION
Concurrency is defined by the channel size consuming
from the request stream in  `check`