### PR TITLE
Add caching functionality (v2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -850,6 +850,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
  "parking_lot 0.11.2",
+ "serde",
 ]
 
 [[package]]
@@ -1731,6 +1732,8 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "console",
+ "csv",
+ "dashmap",
  "futures",
  "headers",
  "http",
@@ -2645,6 +2648,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-socks",
  "tokio-util",
+ "trust-dns-resolver",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -3315,6 +3319,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
+ "tokio",
  "trust-dns-proto",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,6 +1455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1737,6 +1743,7 @@ dependencies = [
  "futures",
  "headers",
  "http",
+ "humantime",
  "indicatif",
  "lazy_static",
  "lychee-lib",

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ FLAGS:
         --glob-ignore-case       Ignore case when expanding filesystem path glob inputs
         --help                   Prints help information
     -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
-        --no-cache               Do not load request cache from disk
+        --no-cache               Do not load request cache (stored in `.lycheecache`) from disk
     -n, --no-progress            Do not show progress bar.
                                  This is recommended for non-interactive shells (e.g. for continuous integration)
         --offline                Only check local files and block network requests

--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ OPTIONS:
                                                limiting [env: GITHUB_TOKEN]
     -h, --headers <headers>...                 Custom request headers
         --include <include>...                 URLs to check (supports regex). Has preference over all excludes
+        --max-cache-age <max-cache-age>         [default: 1d]
         --max-concurrency <max-concurrency>    Maximum number of concurrent network requests [default: 128]
     -m, --max-redirects <max-redirects>        Maximum number of allowed redirects [default: 5]
         --max-retries <max-retries>            Maximum number of retries per request [default: 3]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![GitHub Marketplace](https://img.shields.io/badge/Marketplace-lychee-blue.svg?colorA=24292e&colorB=0366d6&style=flat&longCache=true&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAOCAYAAAAfSC3RAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAM6wAADOsB5dZE0gAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAERSURBVCiRhZG/SsMxFEZPfsVJ61jbxaF0cRQRcRJ9hlYn30IHN/+9iquDCOIsblIrOjqKgy5aKoJQj4O3EEtbPwhJbr6Te28CmdSKeqzeqr0YbfVIrTBKakvtOl5dtTkK+v4HfA9PEyBFCY9AGVgCBLaBp1jPAyfAJ/AAdIEG0dNAiyP7+K1qIfMdonZic6+WJoBJvQlvuwDqcXadUuqPA1NKAlexbRTAIMvMOCjTbMwl1LtI/6KWJ5Q6rT6Ht1MA58AX8Apcqqt5r2qhrgAXQC3CZ6i1+KMd9TRu3MvA3aH/fFPnBodb6oe6HM8+lYHrGdRXW8M9bMZtPXUji69lmf5Cmamq7quNLFZXD9Rq7v0Bpc1o/tp0fisAAAAASUVORK5CYII=)](https://github.com/marketplace/actions/lychee-broken-link-checker)
 
 ⚡ A fast, async, stream-based link checker written in Rust.\
-Finds broken hyperlinks and mail addresses inside Markdown, HTML, reStructuredText, or any other text file or website!
+Finds broken hyperlinks and mail addresses inside Markdown, HTML,
+reStructuredText, or any other text file or website!
 
 Available as a command-line utility, a library and a [GitHub Action](https://github.com/lycheeverse/lychee-action).
 
@@ -267,7 +268,15 @@ You can exclude links from getting checked by either specifying regex patterns
 with `--exclude` (e.g. `--exclude example\.(com|org)`) or by using an "exclude
 file" (`--exclude_file`), which allows you to list multiple regular expressions
 for exclusion (one pattern per line).  
-If a file named `.lycheeignore` exists in the current working directory, its contents are excluded as well.
+If a file named `.lycheeignore` exists in the current working directory, its
+contents are excluded as well.
+
+### Caching
+
+If the `--cache` flag is set, lychee will cache responses in a file called
+`.lycheecache` in the current directory. If the file exists and the flag is set,
+then the cache will be loaded on startup. This can greatly speed up future runs.
+Note that by default lychee will not store any data on disk.
 
 ## Library usage
 
@@ -319,8 +328,10 @@ let client = lychee_lib::ClientBuilder::builder()
 ```
 
 All options that you set will be used for all link checks.
-See the [builder documentation](https://docs.rs/lychee-lib/latest/lychee_lib/struct.ClientBuilder.html) for all options.
-For more information, check out the [examples](examples) folder.
+See the [builder
+documentation](https://docs.rs/lychee-lib/latest/lychee_lib/struct.ClientBuilder.html)
+for all options. For more information, check out the [examples](examples)
+folder.
 
 ## GitHub Action Usage
 
@@ -349,10 +360,11 @@ cargo-publish-all --dry-run --yes # dry run release
 
 ## Debugging and improving async code
 
-Lychee makes heavy use of async code to be resource-friendly while still being performant.
-Async code can be difficult to troubleshoot with most tools, however.
-Therefore we provide experimental support for [tokio-console](https://github.com/tokio-rs/console).
-It provides a top(1)-like overview for async tasks!
+Lychee makes heavy use of async code to be resource-friendly while still being
+performant. Async code can be difficult to troubleshoot with most tools,
+however. Therefore we provide experimental support for
+[tokio-console](https://github.com/tokio-rs/console). It provides a top(1)-like
+overview for async tasks!
 
 If you want to give it a spin, download and start the console:
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ USAGE:
     lychee [FLAGS] [OPTIONS] <inputs>...
 
 FLAGS:
+        --cache                  Use request cache stored on disk at `.lycheecache`
         --dump                   Don't perform any link checking. Instead, dump all the links extracted from inputs that
                                  would be checked
     -E, --exclude-all-private    Exclude all private IPs from checking.
@@ -212,7 +213,6 @@ FLAGS:
         --glob-ignore-case       Ignore case when expanding filesystem path glob inputs
         --help                   Prints help information
     -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
-        --no-cache               Do not load request cache (stored in `.lycheecache`) from disk
     -n, --no-progress            Do not show progress bar.
                                  This is recommended for non-interactive shells (e.g. for continuous integration)
         --offline                Only check local files and block network requests

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ FLAGS:
         --glob-ignore-case       Ignore case when expanding filesystem path glob inputs
         --help                   Prints help information
     -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
+        --no-cache               Do not load request cache from disk
     -n, --no-progress            Do not show progress bar.
                                  This is recommended for non-interactive shells (e.g. for continuous integration)
         --offline                Only check local files and block network requests

--- a/examples/builder/builder.rs
+++ b/examples/builder/builder.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<()> {
         .build()
         .client()?;
 
-    let response = client.check("http://example.org").await?;
+    let response = client.check("https://example.org").await?;
     dbg!(&response);
     assert!(response.status().is_success());
     Ok(())

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -44,6 +44,7 @@ tokio-stream = "0.1.8"
 once_cell = "1.9.0"
 dashmap = { version = "5.0.0", features = ["serde"] }
 csv = "1.1.6"
+humantime = "2.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0.3"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -42,6 +42,8 @@ toml = "0.5.8"
 futures = "0.3.19"
 tokio-stream = "0.1.8"
 once_cell = "1.9.0"
+dashmap = { version = "5.0.0", features = ["serde"] }
+csv = "1.1.6"
 
 [dev-dependencies]
 assert_cmd = "2.0.3"

--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -25,10 +25,10 @@ impl StoreExt for Cache {
     }
 
     fn load<T: AsRef<Path>>(path: T) -> Result<Cache> {
-        let map = DashMap::new();
         let mut rdr = csv::ReaderBuilder::new()
             .has_headers(false)
             .from_path(path)?;
+        let map = DashMap::new();
         for result in rdr.deserialize() {
             let (uri, status): (Uri, CacheStatus) = result?;
             map.insert(uri, status);

--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -1,0 +1,42 @@
+use anyhow::Result;
+use dashmap::DashMap;
+use lychee_lib::{CacheStatus, Uri};
+use serde::Deserialize;
+use std::path::Path;
+
+pub(crate) type Cache = DashMap<Uri, CacheStatus>;
+
+pub(crate) trait StoreExt {
+    fn store<T: AsRef<Path>>(&self, path: T) -> Result<()>;
+    fn load<T: AsRef<Path>>(path: T) -> Result<Cache>;
+}
+
+#[derive(Debug, Deserialize)]
+struct Record {
+    uri: Uri,
+    status: CacheStatus,
+}
+
+impl StoreExt for Cache {
+    fn store<T: AsRef<Path>>(&self, path: T) -> Result<()> {
+        let mut wtr = csv::WriterBuilder::new()
+            .has_headers(false)
+            .from_path(path)?;
+        for result in self {
+            wtr.serialize((result.key(), result.value()))?
+        }
+        Ok(())
+    }
+
+    fn load<T: AsRef<Path>>(path: T) -> Result<Cache> {
+        let map = DashMap::new();
+        let mut rdr = csv::ReaderBuilder::new()
+            .has_headers(false)
+            .from_path(path)?;
+        for result in rdr.deserialize() {
+            let (uri, status): (Uri, CacheStatus) = result?;
+            map.insert(uri, status);
+        }
+        Ok(map)
+    }
+}

--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use dashmap::DashMap;
 use lychee_lib::{CacheStatus, Uri};
-use serde::Deserialize;
 use std::path::Path;
 
 pub(crate) type Cache = DashMap<Uri, CacheStatus>;
@@ -11,19 +10,13 @@ pub(crate) trait StoreExt {
     fn load<T: AsRef<Path>>(path: T) -> Result<Cache>;
 }
 
-#[derive(Debug, Deserialize)]
-struct Record {
-    uri: Uri,
-    status: CacheStatus,
-}
-
 impl StoreExt for Cache {
     fn store<T: AsRef<Path>>(&self, path: T) -> Result<()> {
         let mut wtr = csv::WriterBuilder::new()
             .has_headers(false)
             .from_path(path)?;
         for result in self {
-            wtr.serialize((result.key(), result.value()))?
+            wtr.serialize((result.key(), result.value()))?;
         }
         Ok(())
     }

--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -1,14 +1,25 @@
-use crate::time::{timestamp, Timestamp};
+use crate::time::{self, timestamp, Timestamp};
 use anyhow::Result;
 use dashmap::DashMap;
-use lychee_lib::{CacheStatus, Uri};
+use lychee_lib::{CacheStatus, Status, Uri};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+/// Describes a response status that can be serialized to disk
 #[derive(Serialize, Deserialize)]
 pub(crate) struct CacheValue {
     pub(crate) status: CacheStatus,
     pub(crate) timestamp: Timestamp,
+}
+
+impl From<&Status> for CacheValue {
+    fn from(s: &Status) -> Self {
+        let timestamp = time::timestamp();
+        CacheValue {
+            status: s.into(),
+            timestamp,
+        }
+    }
 }
 
 /// The cache stores previous response codes

--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -3,6 +3,9 @@ use dashmap::DashMap;
 use lychee_lib::{CacheStatus, Uri};
 use std::path::Path;
 
+/// The cache stores previous response codes
+/// for faster checking. At the moment it is backed by `DashMap`, but this is an
+/// implementation detail, which may change in the future.
 pub(crate) type Cache = DashMap<Uri, CacheStatus>;
 
 pub(crate) trait StoreExt {

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -109,28 +109,25 @@ where
 async fn handle(client: &Client, cache: Arc<Cache>, request: Request) -> Response {
     let uri = request.uri.clone();
     let mut modified = false;
-    let response = match cache.get(&uri) {
-        Some(v) => {
-            // Found a cached request
-            let status = if client.is_excluded(&uri) {
-                // Overwrite cache status in case the URI is excluded in the
-                // current run
-                Status::Excluded
-            } else {
-                Status::from(*v.value())
-            };
-            Response::new(uri.clone(), status, request.source)
-        }
-        None => {
-            // Request was not cached; run a normal check
-            // This can panic. See when the Url could not be parsed as a Uri.
-            // See https://github.com/servo/rust-url/issues/554
-            // See https://github.com/seanmonstar/reqwest/issues/668
-            // TODO: Handle error as soon as https://github.com/seanmonstar/reqwest/pull/1399 got merged
-            let response = client.check(request).await.expect("cannot check URI");
-            modified = true;
-            response
-        }
+    let response = if let Some(v) = cache.get(&uri) {
+        // Found a cached request
+        let status = if client.is_excluded(&uri) {
+            // Overwrite cache status in case the URI is excluded in the
+            // current run
+            Status::Excluded
+        } else {
+            Status::from(*v.value())
+        };
+        Response::new(uri.clone(), status, request.source)
+    } else {
+        // Request was not cached; run a normal check
+        // This can panic. See when the Url could not be parsed as a Uri.
+        // See https://github.com/servo/rust-url/issues/554
+        // See https://github.com/seanmonstar/reqwest/issues/668
+        // TODO: Handle error as soon as https://github.com/seanmonstar/reqwest/pull/1399 got merged
+        let response = client.check(request).await.expect("cannot check URI");
+        modified = true;
+        response
     };
 
     if modified {

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -8,8 +8,6 @@ use tokio::sync::mpsc;
 use tokio_stream::wrappers::ReceiverStream;
 use tokio_stream::StreamExt;
 
-use crate::cache::CacheValue;
-use crate::time;
 use crate::{
     cache::Cache,
     options::Config,
@@ -133,12 +131,7 @@ async fn handle(client: &Client, cache: Arc<Cache>, request: Request) -> Respons
     // Never cache filesystem access as it is fast already so caching has no
     // benefit
     if !uri.is_file() {
-        let timestamp = time::timestamp();
-        let cache_val = CacheValue {
-            status: response.status().into(),
-            timestamp,
-        };
-        cache.insert(uri, cache_val);
+        cache.insert(uri, response.status().into());
     }
     response
 }

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -127,7 +127,12 @@ async fn handle(client: &Client, cache: Arc<Cache>, request: Request) -> Respons
     // See https://github.com/seanmonstar/reqwest/issues/668
     // TODO: Handle error as soon as https://github.com/seanmonstar/reqwest/pull/1399 got merged
     let response = client.check(request).await.expect("cannot check URI");
-    cache.insert(uri, response.status().into());
+
+    // Never cache filesystem access as it is fast already so caching has no
+    // benefit
+    if !uri.is_file() {
+        cache.insert(uri, response.status().into());
+    }
     response
 }
 

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -106,6 +106,7 @@ where
     Ok((stats, cache_ref, code))
 }
 
+/// Handle a single request
 async fn handle(client: &Client, cache: Arc<Cache>, request: Request) -> Response {
     let uri = request.uri.clone();
     let mut modified = false;
@@ -135,6 +136,7 @@ async fn handle(client: &Client, cache: Arc<Cache>, request: Request) -> Respons
     }
     response
 }
+
 fn show_progress(progress_bar: &Option<ProgressBar>, response: &Response, verbose: bool) {
     let out = color_response(&response.1);
     if let Some(pb) = progress_bar {

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -15,7 +15,7 @@ where
     while let Some(request) = requests.next().await {
         let request = request?;
 
-        if client.filtered(&request.uri) {
+        if client.is_excluded(&request.uri) {
             continue;
         }
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -111,7 +111,7 @@ fn main() -> Result<()> {
     std::process::exit(exit_code);
 }
 
-// Read lines from file; ignore empty lines
+/// Read lines from file; ignore empty lines
 fn read_lines(file: &File) -> Result<Vec<String>> {
     let lines: Vec<_> = BufReader::new(file).lines().collect::<Result<_, _>>()?;
     Ok(lines.into_iter().filter(|line| !line.is_empty()).collect())
@@ -140,6 +140,7 @@ fn load_config() -> Result<LycheeOptions> {
     Ok(opts)
 }
 
+/// Set up runtime and call lychee entrypoint
 fn run_main() -> Result<i32> {
     let opts = load_config()?;
     let runtime = match opts.config.threads {
@@ -157,6 +158,7 @@ fn run_main() -> Result<i32> {
     runtime.block_on(run(&opts))
 }
 
+/// Run lychee on the given inputs
 async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs();
     let requests = Collector::new(opts.config.base.clone(), opts.config.skip_missing)
@@ -181,6 +183,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
 }
 
 #[must_use]
+/// Load cache (if any)
 fn setup_cache(no_cache: bool) -> Cache {
     if no_cache {
         return Cache::new();

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -77,6 +77,7 @@ mod commands;
 mod options;
 mod parse;
 mod stats;
+mod time;
 mod writer;
 
 use crate::{
@@ -146,6 +147,9 @@ fn load_cache(cfg: &Config) -> Option<Cache> {
         return None;
     }
 
+    // Discard entire cache if it hasn't been updated since `max_cache_age`.
+    // This is an optimization, which avoids iterating over the file and
+    // checking the age of each entry.
     match fs::metadata(LYCHEE_CACHE_FILE) {
         Err(_e) => {
             // No cache found; silently start with empty cache
@@ -165,7 +169,7 @@ fn load_cache(cfg: &Config) -> Option<Cache> {
         }
     }
 
-    let cache = Cache::load(LYCHEE_CACHE_FILE);
+    let cache = Cache::load(LYCHEE_CACHE_FILE, cfg.max_cache_age.as_secs());
     match cache {
         Ok(cache) => Some(cache),
         Err(e) => {

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -81,13 +81,10 @@ mod writer;
 
 use crate::{
     cache::{Cache, StoreExt},
-    options::{Config, Format, LycheeOptions},
+    options::{Config, Format, LycheeOptions, LYCHEE_CACHE_FILE, LYCHEE_IGNORE_FILE},
     stats::ResponseStats,
     writer::StatsWriter,
 };
-
-const LYCHEE_IGNORE_FILE: &str = ".lycheeignore";
-const LYCHEE_CACHE_FILE: &str = ".lycheecache";
 
 /// A C-like enum that can be cast to `i32` and used as process exit code.
 enum ExitCode {

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -142,7 +142,7 @@ fn load_config() -> Result<LycheeOptions> {
 /// This returns an `Option` as starting without a cache is a common scenario
 /// and we silently discard errors on purpose
 fn load_cache(cfg: &Config) -> Option<Cache> {
-    if cfg.no_cache {
+    if !cfg.cache {
         return None;
     }
 
@@ -211,7 +211,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
             commands::check(client, cache, requests, &opts.config).await?;
         write_stats(stats, &opts.config)?;
 
-        if !opts.config.no_cache {
+        if opts.config.cache {
             cache.store(LYCHEE_CACHE_FILE)?;
         }
         exit_code

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -210,7 +210,10 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         let (stats, cache, exit_code) =
             commands::check(client, cache, requests, &opts.config).await?;
         write_stats(stats, &opts.config)?;
-        cache.store(LYCHEE_CACHE_FILE)?;
+
+        if !opts.config.no_cache {
+            cache.store(LYCHEE_CACHE_FILE)?;
+        }
         exit_code
     };
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -205,7 +205,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
     let exit_code = if opts.config.dump {
         commands::dump(client, requests, opts.config.verbose).await?
     } else {
-        let cache = load_cache(&opts.config).unwrap_or(Cache::new());
+        let cache = load_cache(&opts.config).unwrap_or_default();
         let cache = Arc::new(cache);
         let (stats, cache, exit_code) =
             commands::check(client, cache, requests, &opts.config).await?;

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -22,7 +22,7 @@ lazy_static! {
     static ref MAX_REDIRECTS_STR: String = DEFAULT_MAX_REDIRECTS.to_string();
     static ref MAX_RETRIES_STR: String = DEFAULT_MAX_RETRIES.to_string();
     static ref STRUCTOPT_HELP_MSG_CACHE: String = format!(
-        "Do not load request cache (stored in `{}`) from disk",
+        "Use request cache stored on disk at `{}`",
         LYCHEE_CACHE_FILE
     );
     static ref STRUCTOPT_HELP_MSG_IGNORE_FILE: String = format!(
@@ -149,7 +149,7 @@ pub(crate) struct Config {
     #[structopt(help = &STRUCTOPT_HELP_MSG_CACHE)]
     #[structopt(long)]
     #[serde(default)]
-    pub(crate) no_cache: bool,
+    pub(crate) cache: bool,
 
     #[structopt(
         long,
@@ -337,7 +337,7 @@ impl Config {
 
             // Keys with defaults to assign
             verbose: false;
-            no_cache: false;
+            cache: false;
             no_progress: false;
             max_redirects: DEFAULT_MAX_REDIRECTS;
             max_retries: DEFAULT_MAX_RETRIES;

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -6,6 +6,7 @@ use lychee_lib::{
     Base, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, DEFAULT_USER_AGENT,
 };
 use serde::Deserialize;
+use std::time::Duration;
 use structopt::StructOpt;
 
 pub(crate) const LYCHEE_IGNORE_FILE: &str = ".lycheeignore";
@@ -149,6 +150,13 @@ pub(crate) struct Config {
     #[structopt(long)]
     #[serde(default)]
     pub(crate) no_cache: bool,
+
+    #[structopt(
+        long, 
+        parse(try_from_str = humantime::parse_duration), 
+        default_value = "1d"
+    )]
+    pub(crate) max_cache_age: Duration,
 
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -132,6 +132,11 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) no_progress: bool,
 
+    /// Do not load request cache from disk
+    #[structopt(long)]
+    #[serde(default)]
+    pub(crate) no_cache: bool,
+
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
     #[structopt(long)]
@@ -313,6 +318,7 @@ impl Config {
 
             // Keys with defaults to assign
             verbose: false;
+            no_cache: false;
             no_progress: false;
             max_redirects: DEFAULT_MAX_REDIRECTS;
             max_retries: DEFAULT_MAX_RETRIES;

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -8,16 +8,29 @@ use lychee_lib::{
 use serde::Deserialize;
 use structopt::StructOpt;
 
+pub(crate) const LYCHEE_IGNORE_FILE: &str = ".lycheeignore";
+pub(crate) const LYCHEE_CACHE_FILE: &str = ".lycheecache";
+
 const METHOD: &str = "get";
 const MAX_CONCURRENCY: usize = 128;
 
 // this exists because structopt requires `&str` type values for defaults
 // (we can't use e.g. `TIMEOUT` or `timeout()` which gets created for serde)
 lazy_static! {
-    static ref TIMEOUT_STR: String = DEFAULT_TIMEOUT.to_string();
     static ref MAX_CONCURRENCY_STR: String = MAX_CONCURRENCY.to_string();
     static ref MAX_REDIRECTS_STR: String = DEFAULT_MAX_REDIRECTS.to_string();
     static ref MAX_RETRIES_STR: String = DEFAULT_MAX_RETRIES.to_string();
+    static ref STRUCTOPT_HELP_MSG_CACHE: String = format!(
+        "Do not load request cache (stored in `{}`) from disk",
+        LYCHEE_CACHE_FILE
+    );
+    static ref STRUCTOPT_HELP_MSG_IGNORE_FILE: String = format!(
+        "File or files that contain URLs to be excluded from checking. Regular
+expressions supported; one pattern per line. Automatically excludes
+patterns from `{}` if file exists",
+        LYCHEE_IGNORE_FILE
+    );
+    static ref TIMEOUT_STR: String = DEFAULT_TIMEOUT.to_string();
 }
 
 #[derive(Debug, Deserialize)]
@@ -132,7 +145,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) no_progress: bool,
 
-    /// Do not load request cache from disk
+    #[structopt(help = &STRUCTOPT_HELP_MSG_CACHE)]
     #[structopt(long)]
     #[serde(default)]
     pub(crate) no_cache: bool,
@@ -194,9 +207,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) exclude: Vec<String>,
 
-    /// File or files that contain URLs to be excluded from checking. Regular
-    /// expressions supported; one pattern per line. Automatically excludes
-    /// patterns from `.lycheeignore` if file exists.
+    #[structopt(help = &STRUCTOPT_HELP_MSG_IGNORE_FILE)]
     #[structopt(long)]
     #[serde(default)]
     pub(crate) exclude_file: Vec<String>,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -152,8 +152,8 @@ pub(crate) struct Config {
     pub(crate) no_cache: bool,
 
     #[structopt(
-        long, 
-        parse(try_from_str = humantime::parse_duration), 
+        long,
+        parse(try_from_str = humantime::parse_duration),
         default_value = "1d"
     )]
     pub(crate) max_cache_age: Duration,

--- a/lychee-bin/src/parse.rs
+++ b/lychee-bin/src/parse.rs
@@ -49,7 +49,7 @@ pub(crate) fn parse_basic_auth(auth: &str) -> Result<Authorization<Basic>> {
 
 #[cfg(test)]
 mod test {
-    use std::{array, collections::HashSet};
+    use std::collections::HashSet;
 
     use headers::{HeaderMap, HeaderMapExt};
     use http::StatusCode;
@@ -68,7 +68,7 @@ mod test {
     #[test]
     fn test_parse_statuscodes() {
         let actual = parse_statuscodes("200,204,301").unwrap();
-        let expected = array::IntoIter::new([
+        let expected = IntoIterator::into_iter([
             StatusCode::OK,
             StatusCode::NO_CONTENT,
             StatusCode::MOVED_PERMANENTLY,

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -71,7 +71,10 @@ impl ResponseStats {
 
         if matches!(
             status,
-            Status::Error(_) | Status::Timeout(_) | Status::Redirected(_)
+            Status::Error(_)
+                | Status::Timeout(_)
+                | Status::Redirected(_)
+                | Status::Cached(CacheStatus::Fail)
         ) {
             let fail = self.fail_map.entry(source).or_default();
             fail.insert(response.1);

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -10,8 +10,9 @@ pub(crate) fn color_response(response: &ResponseBody) -> String {
         Status::Ok(_) | Status::Cached(CacheStatus::Success) => GREEN.apply_to(response),
         Status::Excluded
         | Status::Unsupported(_)
-        | Status::Cached(CacheStatus::Excluded)
-        | Status::Cached(CacheStatus::Unsupported) => DIM.apply_to(response),
+        | Status::Cached(CacheStatus::Excluded | CacheStatus::Unsupported) => {
+            DIM.apply_to(response)
+        }
         Status::Redirected(_) => NORMAL.apply_to(response),
         Status::UnknownStatusCode(_) | Status::Timeout(_) => YELLOW.apply_to(response),
         Status::Error(_) | Status::Cached(CacheStatus::Fail) => PINK.apply_to(response),
@@ -64,8 +65,7 @@ impl ResponseStats {
             match cache_status {
                 CacheStatus::Success => self.successful += 1,
                 CacheStatus::Fail => self.failures += 1,
-                CacheStatus::Excluded => self.excludes += 1,
-                CacheStatus::Unsupported => self.excludes += 1,
+                CacheStatus::Excluded | CacheStatus::Unsupported => self.excludes += 1,
             }
         }
 

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -1,17 +1,20 @@
 use std::collections::{HashMap, HashSet};
 
-use lychee_lib::{InputSource, Response, ResponseBody, Status};
+use lychee_lib::{CacheStatus, InputSource, Response, ResponseBody, Status};
 use serde::Serialize;
 
 use crate::color::{DIM, GREEN, NORMAL, PINK, YELLOW};
 
 pub(crate) fn color_response(response: &ResponseBody) -> String {
     let out = match response.status {
-        Status::Ok(_) => GREEN.apply_to(response),
-        Status::Excluded | Status::Unsupported(_) => DIM.apply_to(response),
+        Status::Ok(_) | Status::Cached(CacheStatus::Success) => GREEN.apply_to(response),
+        Status::Excluded
+        | Status::Unsupported(_)
+        | Status::Cached(CacheStatus::Excluded)
+        | Status::Cached(CacheStatus::Unsupported) => DIM.apply_to(response),
         Status::Redirected(_) => NORMAL.apply_to(response),
         Status::UnknownStatusCode(_) | Status::Timeout(_) => YELLOW.apply_to(response),
-        Status::Error(_) => PINK.apply_to(response),
+        Status::Error(_) | Status::Cached(CacheStatus::Fail) => PINK.apply_to(response),
     };
     out.to_string()
 }
@@ -26,6 +29,7 @@ pub(crate) struct ResponseStats {
     pub(crate) redirects: usize,
     pub(crate) excludes: usize,
     pub(crate) errors: usize,
+    pub(crate) cached: usize,
     pub(crate) fail_map: HashMap<InputSource, HashSet<ResponseBody>>,
 }
 
@@ -53,6 +57,16 @@ impl ResponseStats {
             Status::Redirected(_) => self.redirects += 1,
             Status::Excluded => self.excludes += 1,
             Status::Unsupported(_) => (), // Just skip unsupported URI
+            Status::Cached(_) => self.cached += 1,
+        }
+
+        if let Status::Cached(cache_status) = status {
+            match cache_status {
+                CacheStatus::Success => self.successful += 1,
+                CacheStatus::Fail => self.failures += 1,
+                CacheStatus::Excluded => self.excludes += 1,
+                CacheStatus::Unsupported => self.excludes += 1,
+            }
         }
 
         if matches!(

--- a/lychee-bin/src/time.rs
+++ b/lychee-bin/src/time.rs
@@ -1,0 +1,15 @@
+use std::time::SystemTime;
+
+pub(crate) type Timestamp = u64;
+
+/// Get the current UNIX timestamp
+///
+/// # Panics
+///
+/// Panics when the system clock is incorrectly configured
+pub(crate) fn timestamp() -> Timestamp {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("SystemTime before UNIX EPOCH!")
+        .as_secs()
+}

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -242,26 +242,28 @@ mod cli {
     }
 
     #[test]
-    #[ignore]
     // Test that two identical requests don't get executed twice.
-    // Note: This currently fails, because we currently don't cache responses. We
-    // used to, but there were issues.
-    // See https://github.com/lycheeverse/lychee/pull/349.
-    // We're planning to add back caching support at a later point in time,
-    // which is why we keep the test around.
-    fn test_caching_across_files() {
-        let mut cmd = main_command();
-        // Repetitions across multiple files shall all be checked and counted only once.
-        let test_schemes_path_1 = fixtures_path().join("TEST_REPETITION_1.txt");
-        let test_schemes_path_2 = fixtures_path().join("TEST_REPETITION_2.txt");
+    fn test_caching_across_files() -> Result<()> {
+        // Repetitions across multiple files shall all be checked only once.
+        let repeated_uris = fixtures_path().join("TEST_REPETITION_*.txt");
 
-        cmd.arg(&test_schemes_path_1)
-            .arg(&test_schemes_path_2)
-            .env_clear()
-            .assert()
-            .success()
-            .stdout(contains("1 TOTAL"))
-            .stdout(contains("1 OK"));
+        test_json_output!(
+            repeated_uris,
+            MockResponseStats {
+                total: 2,
+                cached: 1,
+                successful: 2,
+                excludes: 0,
+                ..MockResponseStats::default()
+            },
+            "--verbose",
+            // Two requests to the same URI may be executed in parallel. As a
+            // result, the response might not be cached and the test would be
+            // flaky. Therefore limit the concurrency to one request at a time.
+            "--max-concurrency",
+            "1",
+            "--no-cache"
+        )
     }
 
     #[test]

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -288,6 +288,7 @@ mod cli {
         let mock_server = mock_server!(StatusCode::OK);
 
         cmd.arg("-")
+            .arg("--no-cache")
             .write_stdin(mock_server.uri())
             .assert()
             .success();
@@ -360,6 +361,7 @@ mod cli {
         writeln!(file_b, "{}", mock_server_b.uri().as_str())?;
 
         cmd.arg(dir.path().join("*.md"))
+            .arg("--no-cache")
             .arg("--verbose")
             .assert()
             .success()
@@ -511,6 +513,7 @@ mod cli {
         let test_path = fixtures_path().join("ignore");
 
         cmd.current_dir(test_path)
+            .arg("--no-cache")
             .arg("TEST.md")
             .assert()
             .success()

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -117,8 +117,7 @@ mod cli {
                 successful: 2,
                 ..MockResponseStats::default()
             },
-            "--exclude-mail",
-            "--no-cache"
+            "--exclude-mail"
         )
     }
 
@@ -145,7 +144,6 @@ mod cli {
         // (File URIs are absolute paths, which we don't have.)
         // Nevertheless, the `file` scheme should be recognized.
         cmd.arg(test_schemes_path)
-            .arg("--no-cache")
             .arg("--exclude")
             .arg("file://")
             .env_clear()
@@ -261,8 +259,7 @@ mod cli {
             // result, the response might not be cached and the test would be
             // flaky. Therefore limit the concurrency to one request at a time.
             "--max-concurrency",
-            "1",
-            "--no-cache"
+            "1"
         )
     }
 
@@ -272,7 +269,6 @@ mod cli {
         let test_github_404_path = fixtures_path().join("TEST_GITHUB_404.md");
 
         cmd.arg(test_github_404_path)
-            .arg("--no-cache")
             .arg("--no-progress")
             .env_clear()
             .assert()
@@ -288,7 +284,6 @@ mod cli {
         let mock_server = mock_server!(StatusCode::OK);
 
         cmd.arg("-")
-            .arg("--no-cache")
             .write_stdin(mock_server.uri())
             .assert()
             .success();
@@ -300,7 +295,6 @@ mod cli {
         let mock_server = mock_server!(StatusCode::INTERNAL_SERVER_ERROR);
 
         cmd.arg("-")
-            .arg("--no-cache")
             .write_stdin(mock_server.uri())
             .assert()
             .failure()
@@ -361,7 +355,6 @@ mod cli {
         writeln!(file_b, "{}", mock_server_b.uri().as_str())?;
 
         cmd.arg(dir.path().join("*.md"))
-            .arg("--no-cache")
             .arg("--verbose")
             .assert()
             .success()
@@ -424,8 +417,7 @@ mod cli {
         let test_path = fixtures_path().join("TEST.md");
         let outfile = format!("{}.json", Uuid::new_v4());
 
-        cmd.arg("--no-cache")
-            .arg("--output")
+        cmd.arg("--output")
             .arg(&outfile)
             .arg("--format")
             .arg("json")
@@ -496,7 +488,6 @@ mod cli {
         let excludes_path2 = fixtures_path().join("TEST_EXCLUDE_2.txt");
 
         cmd.arg(test_path)
-            .arg("--no-cache")
             .arg("--exclude-file")
             .arg(excludes_path1)
             .arg(excludes_path2)
@@ -513,7 +504,6 @@ mod cli {
         let test_path = fixtures_path().join("ignore");
 
         cmd.current_dir(test_path)
-            .arg("--no-cache")
             .arg("TEST.md")
             .assert()
             .success()
@@ -548,11 +538,7 @@ mod cli {
         cmd.arg(&test_path).assert().success();
 
         let mut cmd = main_command();
-        cmd.arg("--no-cache")
-            .arg("--require-https")
-            .arg(test_path)
-            .assert()
-            .failure();
+        cmd.arg("--require-https").arg(test_path).assert().failure();
 
         Ok(())
     }

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -27,7 +27,9 @@ linkify = "0.8.0"
 openssl-sys = "0.9.72"
 pulldown-cmark = "0.9.0"
 regex = "1.5.4"
-reqwest = { version = "0.11.9", features = ["gzip"] }
+# Use trust-dns to avoid lookup failures on high concurrency
+# https://github.com/seanmonstar/reqwest/issues/296
+reqwest = { version = "0.11.9", features = ["gzip", "trust-dns"] }
 # Make build work on Apple Silicon.
 # See https://github.com/briansmith/ring/issues/1163
 # This is necessary for the homebrew build

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -211,8 +211,8 @@ impl Client {
             element: _element,
             attribute: _attribute,
         } = request.try_into()?;
-        // TODO: Allow filtering based on element and attribute
 
+        // TODO: Allow filtering based on element and attribute
         let status = if self.filter.is_excluded(&uri) {
             Status::Excluded
         } else if uri.is_file() {

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -242,7 +242,7 @@ impl Client {
 
     /// Check if the given URI is filtered by the client
     #[must_use]
-    pub fn filtered(&self, uri: &Uri) -> bool {
+    pub fn is_excluded(&self, uri: &Uri) -> bool {
         self.filter.is_excluded(uri)
     }
 
@@ -492,7 +492,7 @@ mod test {
             .build()
             .client()
             .unwrap();
-        assert!(!client.filtered(&Uri {
+        assert!(!client.is_excluded(&Uri {
             url: "mailto://mail@example.org".try_into().unwrap()
         }));
 
@@ -502,7 +502,7 @@ mod test {
             .build()
             .client()
             .unwrap();
-        assert!(client.filtered(&Uri {
+        assert!(client.is_excluded(&Uri {
             url: "mailto://mail@example.org".try_into().unwrap()
         }));
     }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -347,7 +347,12 @@ impl Client {
 /// A convenience function to check a single URI
 /// This is the most simple link check and avoids having to create a client manually.
 /// For more complex scenarios, look into using the [`ClientBuilder`] instead.
-#[allow(clippy::missing_errors_doc)]
+///
+/// # Errors
+///
+/// Returns an `Err` if:
+/// - The request client cannot be built
+/// - The request cannot be checked (see [check](Client::check) for failure cases)
 pub async fn check<T, E>(request: T) -> Result<Response>
 where
     Request: TryFrom<T, Error = E>,

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -31,7 +31,7 @@ impl Extractor {
 mod test {
     use pretty_assertions::assert_eq;
     use reqwest::Url;
-    use std::{array, collections::HashSet, convert::TryFrom, path::Path};
+    use std::{collections::HashSet, convert::TryFrom, path::Path};
 
     use super::*;
     use crate::{
@@ -81,7 +81,7 @@ mod test {
     fn test_skip_markdown_email() {
         let input = "Get in touch - [Contact Us](mailto:test@test.com)";
         let links = extract_uris(input, FileType::Markdown);
-        let expected = array::IntoIter::new([mail("test@test.com")]).collect::<HashSet<Uri>>();
+        let expected = IntoIterator::into_iter([mail("test@test.com")]).collect::<HashSet<Uri>>();
 
         assert_eq!(links, expected);
     }
@@ -99,7 +99,7 @@ mod test {
             "https://endler.dev and https://hello-rust.show/foo/bar?lol=1 at test@example.org";
         let links: HashSet<Uri> = extract_uris(input, FileType::Plaintext);
 
-        let expected = array::IntoIter::new([
+        let expected = IntoIterator::into_iter([
             website("https://endler.dev"),
             website("https://hello-rust.show/foo/bar?lol=1"),
             mail("test@example.org"),
@@ -123,7 +123,7 @@ mod test {
         let input = load_fixture("TEST_HTML5.html");
         let links = extract_uris(&input, FileType::Html);
 
-        let expected_links = array::IntoIter::new([
+        let expected_links = IntoIterator::into_iter([
             website("https://example.org/head/home"),
             website("https://example.org/css/style_full_url.css"),
             // the body links wouldn't be present if the file was parsed strictly as XML
@@ -160,7 +160,7 @@ mod test {
             .map(|raw_uri| raw_uri.text)
             .collect::<HashSet<_>>();
 
-        let expected_urls = array::IntoIter::new([
+        let expected_urls = IntoIterator::into_iter([
             String::from("https://github.com/lycheeverse/lychee/"),
             String::from("/about"),
         ])
@@ -175,8 +175,8 @@ mod test {
         let input = load_fixture("TEST_HTML5_LOWERCASE_DOCTYPE.html");
         let links = extract_uris(&input, FileType::Html);
 
-        let expected_links =
-            array::IntoIter::new([website("https://example.org/body/a")]).collect::<HashSet<Uri>>();
+        let expected_links = IntoIterator::into_iter([website("https://example.org/body/a")])
+            .collect::<HashSet<Uri>>();
 
         assert_eq!(links, expected_links);
     }
@@ -187,7 +187,7 @@ mod test {
         let input = load_fixture("TEST_HTML5_MINIFIED.html");
         let links = extract_uris(&input, FileType::Html);
 
-        let expected_links = array::IntoIter::new([
+        let expected_links = IntoIterator::into_iter([
             website("https://example.org/"),
             website("https://example.org/favicon.ico"),
             website("https://fonts.externalsite.com"),
@@ -205,8 +205,8 @@ mod test {
         let input = load_fixture("TEST_HTML5_MALFORMED_LINKS.html");
         let links = extract_uris(&input, FileType::Html);
 
-        let expected_links =
-            array::IntoIter::new([website("https://example.org/valid")]).collect::<HashSet<Uri>>();
+        let expected_links = IntoIterator::into_iter([website("https://example.org/valid")])
+            .collect::<HashSet<Uri>>();
 
         assert_eq!(links, expected_links);
     }
@@ -217,7 +217,7 @@ mod test {
         let input = load_fixture("TEST_HTML5_CUSTOM_ELEMENTS.html");
         let links = extract_uris(&input, FileType::Html);
 
-        let expected_links = array::IntoIter::new([
+        let expected_links = IntoIterator::into_iter([
             website("https://example.org/some-weird-element"),
             website("https://example.org/even-weirder-src"),
             website("https://example.org/even-weirder-href"),
@@ -234,7 +234,7 @@ mod test {
         let input = "https://example.com/@test/test http://otherdomain.com/test/@test".to_string();
         let links = extract_uris(&input, FileType::Plaintext);
 
-        let expected_links = array::IntoIter::new([
+        let expected_links = IntoIterator::into_iter([
             website("https://example.com/@test/test"),
             website("http://otherdomain.com/test/@test"),
         ])

--- a/lychee-lib/src/helpers/path.rs
+++ b/lychee-lib/src/helpers/path.rs
@@ -44,7 +44,7 @@ pub(crate) fn resolve(src: &Path, dst: &Path, base: &Option<Base>) -> Result<Opt
                 Some(parent) => parent,
                 None => return Err(ErrorKind::FileNotFound(relative.to_path_buf())),
             };
-            parent.join(relative.to_path_buf())
+            parent.join(relative)
         }
         absolute if dst.is_absolute() => {
             // Absolute local links (leading slash) require the `base_url` to

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -80,7 +80,7 @@ pub use crate::{
     collector::Collector,
     filter::{Excludes, Filter, Includes},
     types::{
-        Base, ErrorKind, FileType, Input, InputContent, InputSource, Request, Response,
-        ResponseBody, Result, Status, Uri,
+        Base, CacheStatus, ErrorKind, FileType, Input, InputContent, InputSource, Request,
+        Response, ResponseBody, Result, Status, Uri,
     },
 };

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -6,7 +6,7 @@ use crate::Status;
 
 /// Representation of the status of a cached request. This is kept simple on
 /// purpose because the type gets serialized to a cache file and might need to
-/// be parsed by other tools and edited by humans.
+/// be parsed by other tools or edited by humans.
 #[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum CacheStatus {
     /// The cached request delivered a valid response

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -33,12 +33,11 @@ impl Display for CacheStatus {
 impl From<&Status> for CacheStatus {
     fn from(s: &Status) -> Self {
         match s {
-            Status::Ok(_) => Self::Success,
-            Status::Cached(s) => s.to_owned(),
+            Status::Cached(s) => *s,
             // Reqwest treats unknown status codes as Ok(StatusCode).
             // TODO: Use accepted status codes to decide whether this is a
             // success or failure
-            Status::UnknownStatusCode(_) => Self::Success,
+            Status::Ok(_) | Status::UnknownStatusCode(_) => Self::Success,
             Status::Excluded => Self::Excluded,
             Status::Unsupported(_) => Self::Unsupported,
             Status::Redirected(_) | Status::Error(_) | Status::Timeout(_) => Self::Fail,

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -1,0 +1,47 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Status;
+
+/// Representation of the status of a cached request. This is kept simple on
+/// purpose because the type gets serialized to a cache file and might need to
+/// be parsed by other tools and edited by humans.
+#[derive(Debug, Serialize, Deserialize, Hash, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum CacheStatus {
+    /// The cached request delivered a valid response
+    Success,
+    /// The cached request failed before
+    Fail,
+    /// The request was excluded (skipped)
+    Excluded,
+    /// The protocol is not yet supported
+    Unsupported,
+}
+
+impl Display for CacheStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Success => write!(f, "Success"),
+            Self::Fail => write!(f, "Fail"),
+            Self::Excluded => write!(f, "Excluded"),
+            Self::Unsupported => write!(f, "Unsupported"),
+        }
+    }
+}
+
+impl From<&Status> for CacheStatus {
+    fn from(s: &Status) -> Self {
+        match s {
+            Status::Ok(_) => Self::Success,
+            Status::Cached(s) => s.to_owned(),
+            // Reqwest treats unknown status codes as Ok(StatusCode).
+            // TODO: Use accepted status codes to decide whether this is a
+            // success or failure
+            Status::UnknownStatusCode(_) => Self::Success,
+            Status::Excluded => Self::Excluded,
+            Status::Unsupported(_) => Self::Unsupported,
+            Status::Redirected(_) | Status::Error(_) | Status::Timeout(_) => Self::Fail,
+        }
+    }
+}

--- a/lychee-lib/src/types/mod.rs
+++ b/lychee-lib/src/types/mod.rs
@@ -1,6 +1,7 @@
 #![allow(unreachable_pub)]
 
 mod base;
+mod cache;
 mod error;
 mod file;
 mod input;
@@ -11,6 +12,7 @@ mod status;
 mod uri;
 
 pub use base::Base;
+pub use cache::CacheStatus;
 pub use error::ErrorKind;
 pub use file::FileType;
 pub use input::{Input, InputContent, InputSource};

--- a/lychee-lib/src/types/uri.rs
+++ b/lychee-lib/src/types/uri.rs
@@ -169,12 +169,14 @@ impl Uri {
     }
 
     #[inline]
+    #[must_use]
     /// Check if the URI is a valid mail address
     pub fn is_mail(&self) -> bool {
         self.scheme() == "mailto"
     }
 
     #[inline]
+    #[must_use]
     /// Check if the URI is a file
     pub fn is_file(&self) -> bool {
         self.scheme() == "file"

--- a/lychee-lib/src/types/uri.rs
+++ b/lychee-lib/src/types/uri.rs
@@ -170,13 +170,13 @@ impl Uri {
 
     #[inline]
     /// Check if the URI is a valid mail address
-    pub(crate) fn is_mail(&self) -> bool {
+    pub fn is_mail(&self) -> bool {
         self.scheme() == "mailto"
     }
 
     #[inline]
     /// Check if the URI is a file
-    pub(crate) fn is_file(&self) -> bool {
+    pub fn is_file(&self) -> bool {
         self.scheme() == "file"
     }
 }


### PR DESCRIPTION
A while ago, caching was removed due to some issues (see https://github.com/lycheeverse/lychee/pull/349).

This is a new implementation with the following improvements:

* **Architecture**: The new implementation is decoupled from the collector, which was a major issue in the last version. Now the collector has a single responsibility: collecting links. This also avoids race-conditions when running multiple `collect_links` instances, which probably was an issue before.
* **Performance**: Uses DashMap under the hood, which was noticeably faster than `Mutex<HashMap>` in my tests.
* **Simplicity**: The cache format is a CSV file with two columns: URI and status. I decided to create a new struct called `CacheStatus` for serialization, because trying to serialize the error kinds in `Status` turned out to be a bit of a nightmare and at this point I don't think it's worth the pain (and probably isn't idiomatic either).

## TODO

Open points that evolved during our discussion:

* [x] Disable writing cache to disk by default. Add a `--cache` flag to enable.
* [x] Don't cache filesystem access.
* [ ] ~Support different cache formats. E.g. a compact format using bloomfilters/xor filters.~ Can't get it to work, see https://github.com/lycheeverse/lychee/pull/443#issuecomment-1011557152.

## Follow-up after merge

* [ ] Add caching example to Github action.

## Future improvements

* Requests for the same URI can get fired in parallel, resulting in the URI getting checked multiple times &mdash; rendering the cache worthless. I think this is an acceptable trade-off for the moment because it allows us to avoid additional locking/synchronizing. In the future we might add website-based sharding. This will also help to avoid overloading the server with requests and can be nicely combined with rate-limiting.
* The [request handler](https://github.com/lycheeverse/lychee/compare/cache-3?expand=1#diff-4c70a1ea1533ced8c4b50681f5362809a8a676c8c04f41605da7d6d3bf5d4a98R110) could be refactored to use a custom`#[cache]` attribute.
* We can track the number of duplicate links and show the info when `--format=detailed` is activated.

Fixes https://github.com/lycheeverse/lychee/issues/348

@MichaIng @lebensterben @pawroman @untitaker fyi 
