### PR TITLE
Improve Github API usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ install: ## Install project locally
 .PHONY: run
 run: ## Run project locally
 	cargo run
+
+.PHONY: docs
+docs: ## Generate and show documentation
+	cargo doc --open 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -382,7 +382,6 @@ mod test {
     #[tokio::test]
     async fn test_nonexistent_with_path() {
         let res = get_mock_client_response("http://127.0.0.1/invalid").await;
-
         assert!(res.status().is_failure());
     }
 
@@ -404,14 +403,21 @@ mod test {
     #[tokio::test]
     async fn test_github() {
         let res = get_mock_client_response("https://github.com/lycheeverse/lychee").await;
-
         assert!(res.status().is_success());
     }
 
     #[tokio::test]
-    async fn test_github_nonexistent() {
+    async fn test_github_nonexistent_repo() {
         let res = get_mock_client_response("https://github.com/lycheeverse/not-lychee").await;
+        assert!(res.status().is_failure());
+    }
 
+    #[tokio::test]
+    async fn test_github_nonexistent_file() {
+        let res = get_mock_client_response(
+            "https://github.com/lycheeverse/lychee/blob/master/NON_EXISTENT_FILE.md",
+        )
+        .await;
         assert!(res.status().is_failure());
     }
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -262,7 +262,7 @@ impl Client {
         }
         // Pull out the heavy weapons in case of a failed normal request.
         // This could be a Github URL and we run into the rate limiter.
-        if let Some((owner, repo)) = uri.extract_github() {
+        if let Some((owner, repo)) = uri.gh_org_and_repo() {
             return self.check_github(owner, repo).await;
         }
 

--- a/lychee-lib/src/types/mod.rs
+++ b/lychee-lib/src/types/mod.rs
@@ -17,7 +17,7 @@ pub use input::{Input, InputContent, InputSource};
 pub use request::Request;
 pub use response::{Response, ResponseBody};
 pub use status::Status;
-pub use uri::Uri;
+pub use uri::{GithubUri, Uri};
 
 /// The lychee `Result` type
 pub type Result<T> = std::result::Result<T, crate::ErrorKind>;

--- a/lychee-lib/src/types/uri.rs
+++ b/lychee-lib/src/types/uri.rs
@@ -27,17 +27,18 @@ lazy_static! {
 
 /// Uri path segments extracted from a Github URL
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
-pub(crate) struct GithubUri {
+pub struct GithubUri {
     /// Organization name
-    pub(crate) owner: String,
+    pub owner: String,
     /// Repository name
-    pub(crate) repo: String,
+    pub repo: String,
     /// e.g. `issues` in `/org/repo/issues`
-    pub(crate) endpoint: Option<String>,
+    pub endpoint: Option<String>,
 }
 
 impl GithubUri {
     /// Create a new Github URI without an endpoint
+    #[cfg(test)]
     fn new<T: Into<String>>(owner: T, repo: T) -> Self {
         GithubUri {
             owner: owner.into(),
@@ -46,6 +47,7 @@ impl GithubUri {
         }
     }
 
+    #[cfg(test)]
     fn with_endpoint<T: Into<String>>(owner: T, repo: T, endpoint: T) -> Self {
         GithubUri {
             owner: owner.into(),


### PR DESCRIPTION
* Strip `.git` suffix from Github URLs (#384)
* Strict handling of non-existent files inside public Github repos (#449)
* Add more false-positives to the list of Github endpoints, which will be ignored from the API checking.
* Only accept two path segments (org/repo) for Github API check if repo is public