### PR TITLE
fix constant updating of progressbar

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -57,8 +57,10 @@ where
         ));
         bar.set_length(0);
         bar.set_message("Extracting links");
-        bar.set_draw_rate(500);
-        bar.enable_steady_tick(5000);
+        // 10 updates per second = report status at _most_ every 100ms
+        bar.set_draw_rate(10);
+        // report status _at least_ every 500ms
+        bar.enable_steady_tick(500);
         Some(bar)
     };
 

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -57,7 +57,8 @@ where
         ));
         bar.set_length(0);
         bar.set_message("Extracting links");
-        bar.enable_steady_tick(100);
+        bar.set_draw_rate(500);
+        bar.enable_steady_tick(5000);
         Some(bar)
     };
 


### PR DESCRIPTION
In other issues I've already lamented how slow lychee is when used
without `-n`. This fixes an issue where without `-n`, lychee would take
1 minute instead of 4 seconds to check sentry-docs.
