### PR TITLE
lychee-bin: replace lazy_static by const_format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -623,6 +623,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22bc6cd49b0ec407b680c3e380182b6ac63b73991cb7602de350352fc309b614"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef196d5d972878a48da7decb7686eded338b4858fbabeed513d63a7c98b2b82d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1750,6 +1770,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "console",
+ "const_format",
  "csv",
  "dashmap",
  "futures",
@@ -1757,7 +1778,6 @@ dependencies = [
  "http",
  "humantime",
  "indicatif",
- "lazy_static",
  "lychee-lib",
  "once_cell",
  "openssl-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "examples/*",
     "benches",
 ]
+resolver = "2"
 
 [patch.crates-io]
 # Switch back to version on crates.io after 0.6.3+ is released

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -17,13 +17,13 @@ repository = "https://github.com/lycheeverse/lychee"
 version = "0.8.2"
 
 [dependencies]
-lychee-lib = { path = "../lychee-lib", version = "0.8.2" }
+lychee-lib = { path = "../lychee-lib", version = "0.8.2", default-features = false }
 anyhow = "1.0.53"
 console = "0.15.0"
+const_format = "0.2.22"
 headers = "0.3.6"
 http = "0.2.6"
 indicatif = "0.16.2"
-lazy_static = "1.4.0"
 openssl-sys = "0.9.72"
 pad = "0.1.6"
 regex = "1.5.4"

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -1,12 +1,11 @@
-use std::{convert::TryFrom, fs, io::ErrorKind, path::PathBuf, str::FromStr};
+use std::{convert::TryFrom, fs, io::ErrorKind, path::PathBuf, str::FromStr, time::Duration};
 
 use anyhow::{anyhow, Error, Result};
-use lazy_static::lazy_static;
+use const_format::concatcp;
 use lychee_lib::{
     Base, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, DEFAULT_USER_AGENT,
 };
 use serde::Deserialize;
-use std::time::Duration;
 use structopt::StructOpt;
 
 pub(crate) const LYCHEE_IGNORE_FILE: &str = ".lycheeignore";
@@ -17,22 +16,19 @@ const MAX_CONCURRENCY: usize = 128;
 
 // this exists because structopt requires `&str` type values for defaults
 // (we can't use e.g. `TIMEOUT` or `timeout()` which gets created for serde)
-lazy_static! {
-    static ref MAX_CONCURRENCY_STR: String = MAX_CONCURRENCY.to_string();
-    static ref MAX_REDIRECTS_STR: String = DEFAULT_MAX_REDIRECTS.to_string();
-    static ref MAX_RETRIES_STR: String = DEFAULT_MAX_RETRIES.to_string();
-    static ref STRUCTOPT_HELP_MSG_CACHE: String = format!(
-        "Use request cache stored on disk at `{}`",
-        LYCHEE_CACHE_FILE
-    );
-    static ref STRUCTOPT_HELP_MSG_IGNORE_FILE: String = format!(
-        "File or files that contain URLs to be excluded from checking. Regular
+const MAX_CONCURRENCY_STR: &str = concatcp!(MAX_CONCURRENCY);
+const MAX_REDIRECTS_STR: &str = concatcp!(DEFAULT_MAX_REDIRECTS);
+const MAX_RETRIES_STR: &str = concatcp!(DEFAULT_MAX_RETRIES);
+const STRUCTOPT_HELP_MSG_CACHE: &str =
+    concatcp!("Use request cache stored on disk at ", LYCHEE_CACHE_FILE);
+const STRUCTOPT_HELP_MSG_IGNORE_FILE: &str = concatcp!(
+    "File or files that contain URLs to be excluded from checking. Regular
 expressions supported; one pattern per line. Automatically excludes
-patterns from `{}` if file exists",
-        LYCHEE_IGNORE_FILE
-    );
-    static ref TIMEOUT_STR: String = DEFAULT_TIMEOUT.to_string();
-}
+patterns from ",
+    LYCHEE_IGNORE_FILE,
+    " if file exists"
+);
+const TIMEOUT_STR: &str = concatcp!(DEFAULT_TIMEOUT);
 
 #[derive(Debug, Deserialize)]
 pub(crate) enum Format {

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -1,7 +1,7 @@
 use std::{convert::TryFrom, fs, io::ErrorKind, path::PathBuf, str::FromStr, time::Duration};
 
 use anyhow::{anyhow, Error, Result};
-use const_format::concatcp;
+use const_format::{concatcp, formatcp};
 use lychee_lib::{
     Base, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, DEFAULT_USER_AGENT,
 };
@@ -19,14 +19,15 @@ const MAX_CONCURRENCY: usize = 128;
 const MAX_CONCURRENCY_STR: &str = concatcp!(MAX_CONCURRENCY);
 const MAX_REDIRECTS_STR: &str = concatcp!(DEFAULT_MAX_REDIRECTS);
 const MAX_RETRIES_STR: &str = concatcp!(DEFAULT_MAX_RETRIES);
-const STRUCTOPT_HELP_MSG_CACHE: &str =
-    concatcp!("Use request cache stored on disk at ", LYCHEE_CACHE_FILE);
-const STRUCTOPT_HELP_MSG_IGNORE_FILE: &str = concatcp!(
+const STRUCTOPT_HELP_MSG_CACHE: &str = formatcp!(
+    "Use request cache stored on disk at `{}`",
+    LYCHEE_CACHE_FILE,
+);
+const STRUCTOPT_HELP_MSG_IGNORE_FILE: &str = formatcp!(
     "File or files that contain URLs to be excluded from checking. Regular
 expressions supported; one pattern per line. Automatically excludes
-patterns from ",
+patterns from `{}` if file exists",
     LYCHEE_IGNORE_FILE,
-    " if file exists"
 );
 const TIMEOUT_STR: &str = concatcp!(DEFAULT_TIMEOUT);
 


### PR DESCRIPTION
This commit replaced the use of `lazy_static` by
`const_format` in `lychee-bin`.

Currently `lazy_static` is used to generate static
String at runtime. With `const_format` we can instead
make constant String at compile time.