### PR TITLE
Use captured identifiers in format strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ use lychee_lib::Result;
 #[tokio::main]
 async fn main() -> Result<()> {
   let response = lychee_lib::check("https://github.com/lycheeverse/lychee").await?;
-  println!("{}", response);
+  println!("{response}");
   Ok(())
 }
 ```

--- a/examples/client_pool/client_pool.rs
+++ b/examples/client_pool/client_pool.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
 
     // Finally, listen to incoming responses from lychee
     while let Some(response) = recv_resp.recv().await {
-        println!("{}", response);
+        println!("{response}");
     }
 
     Ok(())

--- a/examples/extract/extract.rs
+++ b/examples/extract/extract.rs
@@ -7,7 +7,7 @@ use std::fs;
 async fn main() -> Result<()> {
     let input = fs::read_to_string("fixtures/elvis.html").unwrap();
     let links = Extractor::extract(&InputContent::from_string(&input, FileType::Html));
-    println!("{:#?}", links);
+    println!("{links:#?}");
 
     Ok(())
 }

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -151,6 +151,6 @@ fn show_progress(progress_bar: &Option<ProgressBar>, response: &Response, verbos
         if (response.status().is_success() || response.status().is_excluded()) && !verbose {
             return;
         }
-        println!("{}", out);
+        println!("{out}");
     }
 }

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -25,7 +25,7 @@ where
         // to another program like `grep`.
         if let Err(e) = write(&request, verbose) {
             if e.kind() != io::ErrorKind::BrokenPipe {
-                eprintln!("{}", e);
+                eprintln!("{e}");
                 return Ok(ExitCode::UnexpectedFailure);
             }
         }

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -173,7 +173,7 @@ fn load_cache(cfg: &Config) -> Option<Cache> {
     match cache {
         Ok(cache) => Some(cache),
         Err(e) => {
-            println!("Error while loading cache: {}. Continuing without.", e);
+            println!("Error while loading cache: {e}. Continuing without.");
             None
         }
     }
@@ -247,7 +247,7 @@ fn write_stats(stats: ResponseStats, cfg: &Config) -> Result<()> {
             println!();
         }
         // we assume that the formatted stats don't have a final newline
-        println!("{}", formatted);
+        println!("{formatted}");
     }
     Ok(())
 }

--- a/lychee-bin/src/writer/compact.rs
+++ b/lychee-bin/src/writer/compact.rs
@@ -26,7 +26,7 @@ pub(crate) fn print_errors(stats: &ResponseStats) -> String {
     let mut err: Vec<_> = errors
         .into_iter()
         .filter(|(_, v)| *v > 0)
-        .map(|(k, v)| format!("{}:{}", k, v))
+        .map(|(k, v)| format!("{k}:{v}"))
         .collect();
     err.sort();
     err.join("|")
@@ -37,10 +37,16 @@ impl Display for CompactResponseStats {
         let stats = &self.0;
 
         if !stats.fail_map.is_empty() {
+            let input = if stats.fail_map.len() == 1 {
+                "input"
+            } else {
+                "inputs"
+            };
+
             color!(
                 f,
                 BOLD_PINK,
-                "Issues found in {} input(s). Find details below.\n\n",
+                "Issues found in {} {input}. Find details below.\n\n",
                 stats.fail_map.len()
             )?;
         }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -327,8 +327,7 @@ mod cli {
             .failure()
             .code(1)
             .stderr(contains(format!(
-            "Error: Failed to read from path: `{}`, reason: No such file or directory (os error 2)",
-            filename
+            "Error: Failed to read from path: `{filename}`, reason: No such file or directory (os error 2)"
         )));
     }
 

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -330,7 +330,7 @@ mod test {
 
         let expected_urls = HashSet::from_iter([
             website("https://github.com/lycheeverse/lychee/"),
-            website(&format!("{}about", server_uri)),
+            website(&format!("{server_uri}about")),
         ]);
 
         assert_eq!(links, expected_urls);

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -6,7 +6,7 @@
 //! #[tokio::main]
 //! async fn main() -> Result<()> {
 //!   let response = lychee_lib::check("https://github.com/lycheeverse/lychee").await?;
-//!   println!("{}", response);
+//!   println!("{response}");
 //!   Ok(())
 //! }
 //! ```

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -63,8 +63,7 @@ impl Default for Quirks {
                     let mut out = request;
                     if let Some(id) = query(&out).get("v") {
                         *out.url_mut() =
-                            Url::parse(&format!("https://img.youtube.com/vi/{id}/0.jpg"))
-                                .unwrap();
+                            Url::parse(&format!("https://img.youtube.com/vi/{id}/0.jpg")).unwrap();
                     }
                     out
                 },

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -63,7 +63,7 @@ impl Default for Quirks {
                     let mut out = request;
                     if let Some(id) = query(&out).get("v") {
                         *out.url_mut() =
-                            Url::parse(&format!("https://img.youtube.com/vi/{}/0.jpg", &id))
+                            Url::parse(&format!("https://img.youtube.com/vi/{id}/0.jpg"))
                                 .unwrap();
                     }
                     out

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -263,7 +263,7 @@ impl Input {
                         let content: InputContent = Self::path_content(&path).await?;
                         yield content;
                     }
-                    Err(e) => println!("{:?}", e),
+                    Err(e) => println!("{e:?}"),
                 }
             }
         }

--- a/lychee-lib/src/types/mail.rs
+++ b/lychee-lib/src/types/mail.rs
@@ -6,9 +6,9 @@ pub(crate) fn error_from_output(o: &CheckEmailOutput) -> String {
     if let Err(_e) = o.misc.as_ref() {
         return "Error occurred connecting to this email server via SMTP".to_string();
     } else if let Err(e) = &o.smtp {
-        return format!("{:?}", e);
+        return format!("{e:?}");
     } else if let Err(e) = &o.mx {
-        return format!("{:?}", e);
+        return format!("{e:?}");
     }
     match &o.is_reachable {
         Reachable::Safe => "Safe: The email is safe to send",


### PR DESCRIPTION
Makes for arguably cleaner-looking code.
The downside is that the MSRV is 1.58
https://blog.rust-lang.org/2022/01/13/Rust-1.58.0.html

Given that nobody uses lychee as a library yet
and we have precompiled binaries, it's an acceptable
tradeoff.
My little research revealed that this is a much-liked
feature: https://twitter.com/matthiasendler/status/1483895557621960715