### PR TITLE
Replace plain String with SecretString for GitHub token

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1818,6 +1818,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "secrecy",
  "serde",
  "serde_json",
  "structopt",
@@ -1860,6 +1861,7 @@ dependencies = [
  "regex",
  "reqwest",
  "ring",
+ "secrecy",
  "serde",
  "shellexpand",
  "tempfile",
@@ -2851,6 +2853,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "secrecy"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd1c54ea06cfd2f6b63219704de0b9b4f72dcc2b8fdef820be6cd799780e91e"
+dependencies = [
+ "serde",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3881,3 +3893,9 @@ dependencies = [
  "serde_json",
  "tokio",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -45,6 +45,7 @@ once_cell = "1.9.0"
 dashmap = { version = "5.1.0", features = ["serde"] }
 csv = "1.1.6"
 humantime = "2.1.0"
+secrecy = { version = "0.8.0", features = ["serde"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -5,6 +5,7 @@ use const_format::{concatcp, formatcp};
 use lychee_lib::{
     Base, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_TIMEOUT, DEFAULT_USER_AGENT,
 };
+use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
 use structopt::StructOpt;
 
@@ -284,7 +285,7 @@ pub(crate) struct Config {
     /// GitHub API token to use when checking github.com links, to avoid rate limiting
     #[structopt(long, env = "GITHUB_TOKEN", hide_env_values = true)]
     #[serde(default)]
-    pub(crate) github_token: Option<String>,
+    pub(crate) github_token: Option<SecretString>,
 
     /// Skip missing input files (default is to error if they don't exist)
     #[structopt(long)]
@@ -364,11 +365,24 @@ impl Config {
             method: DEFAULT_METHOD;
             base: None;
             basic_auth: None;
-            github_token: None;
             skip_missing: false;
             glob_ignore_case: false;
             output: None;
             require_https: false;
+        }
+
+        if self
+            .github_token
+            .as_ref()
+            .map(ExposeSecret::expose_secret)
+            .is_none()
+            && !toml
+                .github_token
+                .as_ref()
+                .map(ExposeSecret::expose_secret)
+                .is_none()
+        {
+            self.github_token = toml.github_token;
         }
     }
 }

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -51,6 +51,7 @@ lazy_static = "1.4.0"
 html5ever = "0.25.1"
 html5gum = "0.4.0"
 octocrab = "0.15.4"
+secrecy = "0.8.0"
 
 [dependencies.par-stream]
 version = "0.10.0"


### PR DESCRIPTION
This commit changed the type of `lychee-lib::ClientBuilder::github_token` from
`String` to `secrecy::SecretString` to fortify the secret management within our
program.

Note that this won't affect TOML configuration of `lychee-bin` because
`serde::Deserialize` is still implemented for `SecretString`.

closes #508