### PR TITLE
Implement excluding code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ FLAGS:
         --exclude-loopback       Exclude loopback IP address range and localhost from checking
         --exclude-mail           Exclude all mail addresses from checking
         --exclude-private        Exclude private IP address ranges from checking
+        --exclude-verbatim       Skip all verbatim links inside pre- and code blocks
         --glob-ignore-case       Ignore case when expanding filesystem path glob inputs
         --help                   Prints help information
     -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
@@ -220,7 +221,6 @@ FLAGS:
                                  This is recommended for non-interactive shells (e.g. for continuous integration)
         --offline                Only check local files and block network requests
         --require-https          When HTTPS is available, treat HTTP links as errors
-        --skip-code-blocks       Skip Markdown code blocks
         --skip-missing           Skip missing input files (default is to error if they don't exist)
     -V, --version                Prints version information
     -v, --verbose                Verbose program output

--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ FLAGS:
         --exclude-loopback       Exclude loopback IP address range and localhost from checking
         --exclude-mail           Exclude all mail addresses from checking
         --exclude-private        Exclude private IP address ranges from checking
-        --exclude-verbatim       Skip all verbatim links inside pre- and code blocks
         --glob-ignore-case       Ignore case when expanding filesystem path glob inputs
         --help                   Prints help information
+        --include-verbatim       Find links in verbatim sections like `pre`- and `code` blocks
     -i, --insecure               Proceed for server connections considered insecure (invalid TLS)
     -n, --no-progress            Do not show progress bar.
                                  This is recommended for non-interactive shells (e.g. for continuous integration)

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ FLAGS:
                                  This is recommended for non-interactive shells (e.g. for continuous integration)
         --offline                Only check local files and block network requests
         --require-https          When HTTPS is available, treat HTTP links as errors
+        --skip-code-blocks       Skip Markdown code blocks
         --skip-missing           Skip missing input files (default is to error if they don't exist)
     -V, --version                Prints version information
     -v, --verbose                Verbose program output

--- a/benches/src/extract.rs
+++ b/benches/src/extract.rs
@@ -6,7 +6,8 @@ use std::path::PathBuf;
 fn extract(paths: &[PathBuf]) {
     for path in paths {
         let content: InputContent = path.try_into().unwrap();
-        let extracted = Extractor::extract(&content);
+        let extractor = Extractor::default();
+        let extracted = extractor.extract(&content);
         println!("{}", extracted.len());
     }
 }

--- a/examples/extract/extract.rs
+++ b/examples/extract/extract.rs
@@ -6,7 +6,8 @@ use std::fs;
 #[tokio::main]
 async fn main() -> Result<()> {
     let input = fs::read_to_string("fixtures/elvis.html").unwrap();
-    let links = Extractor::extract(&InputContent::from_string(&input, FileType::Html));
+    let extractor = Extractor::default();
+    let links = extractor.extract(&InputContent::from_string(&input, FileType::Html));
     println!("{links:#?}");
 
     Ok(())

--- a/fixtures/TEST_CODE_BLOCKS.md
+++ b/fixtures/TEST_CODE_BLOCKS.md
@@ -1,9 +1,21 @@
-# Test
+# Test Links In Code
 
-Code:
-
-```bash
-https://example.com
+```
+http://127.0.0.1/block
 ```
 
-[localhost](http://127.0.0.1)
+```bash
+http://127.0.0.1/bash
+```
+
+`http://127.0.0.1/inline` will also be excluded by default
+
+<pre>
+And this: http://127.0.0.1/pre
+</pre>
+
+<code>
+Also
+http://127.0.0.1/code
+in code blocks
+</code>

--- a/fixtures/TEST_CODE_BLOCKS.md
+++ b/fixtures/TEST_CODE_BLOCKS.md
@@ -1,0 +1,9 @@
+# Test
+
+Code:
+
+```bash
+https://example.com
+```
+
+[localhost](http://127.0.0.1)

--- a/fixtures/TEST_CODE_BLOCKS.md
+++ b/fixtures/TEST_CODE_BLOCKS.md
@@ -9,13 +9,3 @@ http://127.0.0.1/bash
 ```
 
 `http://127.0.0.1/inline` will also be excluded by default
-
-<pre>
-And this: http://127.0.0.1/pre
-</pre>
-
-<code>
-Also
-http://127.0.0.1/code
-in code blocks
-</code>

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -202,7 +202,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs();
     let requests = Collector::new(opts.config.base.clone())
         .skip_missing_inputs(opts.config.skip_missing)
-        .exclude_verbatim(opts.config.exclude_verbatim)
+        .include_verbatim(opts.config.include_verbatim)
         // File a bug if you rely on this envvar! It's going to go away eventually.
         .use_html5ever(std::env::var("LYCHEE_USE_HTML5EVER").map_or(false, |x| x == "1"))
         .collect_links(inputs)

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -202,6 +202,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs();
     let requests = Collector::new(opts.config.base.clone())
         .skip_missing_inputs(opts.config.skip_missing)
+        .skip_code_blocks(opts.config.skip_code_blocks)
         // File a bug if you rely on this envvar! It's going to go away eventually.
         .use_html5ever(std::env::var("LYCHEE_USE_HTML5EVER").map_or(false, |x| x == "1"))
         .collect_links(inputs)

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -202,7 +202,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs();
     let requests = Collector::new(opts.config.base.clone())
         .skip_missing_inputs(opts.config.skip_missing)
-        .skip_code_blocks(opts.config.skip_code_blocks)
+        .exclude_verbatim(opts.config.exclude_verbatim)
         // File a bug if you rely on this envvar! It's going to go away eventually.
         .use_html5ever(std::env::var("LYCHEE_USE_HTML5EVER").map_or(false, |x| x == "1"))
         .collect_links(inputs)

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -292,10 +292,10 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) skip_missing: bool,
 
-    /// Skip all verbatim links inside pre- and code blocks
+    /// Find links in verbatim sections like `pre`- and `code` blocks
     #[structopt(long)]
     #[serde(default)]
-    pub(crate) exclude_verbatim: bool,
+    pub(crate) include_verbatim: bool,
 
     /// Ignore case when expanding filesystem path glob inputs
     #[structopt(long)]
@@ -371,7 +371,7 @@ impl Config {
             base: None;
             basic_auth: None;
             skip_missing: false;
-            exclude_verbatim: true;
+            include_verbatim: false;
             glob_ignore_case: false;
             output: None;
             require_https: false;

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -292,10 +292,10 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) skip_missing: bool,
 
-    /// Skip Markdown code blocks
+    /// Skip all verbatim links inside pre- and code blocks
     #[structopt(long)]
     #[serde(default)]
-    pub(crate) skip_code_blocks: bool,
+    pub(crate) exclude_verbatim: bool,
 
     /// Ignore case when expanding filesystem path glob inputs
     #[structopt(long)]
@@ -371,7 +371,7 @@ impl Config {
             base: None;
             basic_auth: None;
             skip_missing: false;
-            skip_code_blocks: true;
+            exclude_verbatim: true;
             glob_ignore_case: false;
             output: None;
             require_https: false;

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -292,6 +292,11 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) skip_missing: bool,
 
+    /// Skip Markdown code blocks
+    #[structopt(long)]
+    #[serde(default)]
+    pub(crate) skip_code_blocks: bool,
+
     /// Ignore case when expanding filesystem path glob inputs
     #[structopt(long)]
     #[serde(default)]
@@ -366,6 +371,7 @@ impl Config {
             base: None;
             basic_auth: None;
             skip_missing: false;
+            skip_code_blocks: true;
             glob_ignore_case: false;
             output: None;
             require_https: false;

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -9,7 +9,7 @@ mod cli {
 
     use assert_cmd::Command;
     use http::StatusCode;
-    use predicates::str::contains;
+    use predicates::str::{contains, is_empty};
     use pretty_assertions::assert_eq;
     use uuid::Uuid;
 
@@ -600,16 +600,33 @@ mod cli {
     }
 
     #[test]
+    fn test_include_verbatim() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("TEST_CODE_BLOCKS.md");
+
+        cmd.arg("--include-verbatim")
+            .arg(input)
+            .arg("--dump")
+            .assert()
+            .success()
+            .stdout(contains("http://127.0.0.1/pre"))
+            .stdout(contains("http://127.0.0.1/block"))
+            .stdout(contains("http://127.0.0.1/code"))
+            .stdout(contains("http://127.0.0.1/bash"));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_exclude_verbatim() -> Result<()> {
         let mut cmd = main_command();
         let input = fixtures_path().join("TEST_CODE_BLOCKS.md");
 
-        cmd.arg("--exclude-all-private")
-            .arg("--exclude-verbatim")
-            .arg(input)
+        cmd.arg(input)
+            .arg("--dump")
             .assert()
             .success()
-            .stdout(contains("1 Total"));
+            .stdout(is_empty());
 
         Ok(())
     }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -600,6 +600,21 @@ mod cli {
     }
 
     #[test]
+    fn test_skip_code_blocks() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("TEST_CODE_BLOCKS.md");
+
+        cmd.arg("--exclude-all-private")
+            .arg("--skip-code-blocks")
+            .arg(input)
+            .assert()
+            .success()
+            .stdout(contains("1 Total"));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_require_https() -> Result<()> {
         let mut cmd = main_command();
         let test_path = fixtures_path().join("TEST_HTTP.html");

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -600,12 +600,12 @@ mod cli {
     }
 
     #[test]
-    fn test_skip_code_blocks() -> Result<()> {
+    fn test_exclude_verbatim() -> Result<()> {
         let mut cmd = main_command();
         let input = fixtures_path().join("TEST_CODE_BLOCKS.md");
 
         cmd.arg("--exclude-all-private")
-            .arg("--skip-code-blocks")
+            .arg("--exclude-verbatim")
             .arg(input)
             .assert()
             .success()

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -609,9 +609,8 @@ mod cli {
             .arg("--dump")
             .assert()
             .success()
-            .stdout(contains("http://127.0.0.1/pre"))
             .stdout(contains("http://127.0.0.1/block"))
-            .stdout(contains("http://127.0.0.1/code"))
+            .stdout(contains("http://127.0.0.1/inline"))
             .stdout(contains("http://127.0.0.1/bash"));
 
         Ok(())

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -13,7 +13,7 @@ use par_stream::ParStreamExt;
 pub struct Collector {
     base: Option<Base>,
     skip_missing_inputs: bool,
-    skip_code_blocks: bool,
+    exclude_verbatim: bool,
     use_html5ever: bool,
 }
 
@@ -25,7 +25,7 @@ impl Collector {
             base,
             skip_missing_inputs: false,
             use_html5ever: false,
-            skip_code_blocks: false,
+            exclude_verbatim: false,
         }
     }
 
@@ -43,10 +43,10 @@ impl Collector {
         self
     }
 
-    /// Skip over Markdown code blocks when parsing
+    /// Skip over links in verbatim sections (like Markdown code blocks)
     #[must_use]
-    pub const fn skip_code_blocks(mut self, yes: bool) -> Self {
-        self.skip_code_blocks = yes;
+    pub const fn exclude_verbatim(mut self, yes: bool) -> Self {
+        self.exclude_verbatim = yes;
         self
     }
 
@@ -72,7 +72,7 @@ impl Collector {
                 let base = base.clone();
                 async move {
                     let content = content?;
-                    let extractor = Extractor::new(self.use_html5ever, self.skip_code_blocks);
+                    let extractor = Extractor::new(self.use_html5ever, self.exclude_verbatim);
                     let uris: Vec<RawUri> = extractor.extract(&content);
                     let requests = request::create(uris, &content, &base)?;
                     Result::Ok(stream::iter(requests.into_iter().map(Ok)))

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -13,7 +13,7 @@ use par_stream::ParStreamExt;
 pub struct Collector {
     base: Option<Base>,
     skip_missing_inputs: bool,
-    exclude_verbatim: bool,
+    include_verbatim: bool,
     use_html5ever: bool,
 }
 
@@ -25,7 +25,7 @@ impl Collector {
             base,
             skip_missing_inputs: false,
             use_html5ever: false,
-            exclude_verbatim: false,
+            include_verbatim: false,
         }
     }
 
@@ -45,8 +45,8 @@ impl Collector {
 
     /// Skip over links in verbatim sections (like Markdown code blocks)
     #[must_use]
-    pub const fn exclude_verbatim(mut self, yes: bool) -> Self {
-        self.exclude_verbatim = yes;
+    pub const fn include_verbatim(mut self, yes: bool) -> Self {
+        self.include_verbatim = yes;
         self
     }
 
@@ -72,7 +72,7 @@ impl Collector {
                 let base = base.clone();
                 async move {
                     let content = content?;
-                    let extractor = Extractor::new(self.use_html5ever, self.exclude_verbatim);
+                    let extractor = Extractor::new(self.use_html5ever, self.include_verbatim);
                     let uris: Vec<RawUri> = extractor.extract(&content);
                     let requests = request::create(uris, &content, &base)?;
                     Result::Ok(stream::iter(requests.into_iter().map(Ok)))

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -13,6 +13,7 @@ use par_stream::ParStreamExt;
 pub struct Collector {
     base: Option<Base>,
     skip_missing_inputs: bool,
+    skip_code_blocks: bool,
     use_html5ever: bool,
 }
 
@@ -24,6 +25,7 @@ impl Collector {
             base,
             skip_missing_inputs: false,
             use_html5ever: false,
+            skip_code_blocks: false,
         }
     }
 
@@ -38,6 +40,13 @@ impl Collector {
     #[must_use]
     pub const fn use_html5ever(mut self, yes: bool) -> Self {
         self.use_html5ever = yes;
+        self
+    }
+
+    /// Skip over Markdown code blocks when parsing
+    #[must_use]
+    pub const fn skip_code_blocks(mut self, yes: bool) -> Self {
+        self.skip_code_blocks = yes;
         self
     }
 
@@ -63,11 +72,8 @@ impl Collector {
                 let base = base.clone();
                 async move {
                     let content = content?;
-                    let uris: Vec<RawUri> = if self.use_html5ever {
-                        Extractor::extract_html5ever(&content)
-                    } else {
-                        Extractor::extract(&content)
-                    };
+                    let extractor = Extractor::new(self.use_html5ever, self.skip_code_blocks);
+                    let uris: Vec<RawUri> = extractor.extract(&content);
                     let requests = request::create(uris, &content, &base)?;
                     Result::Ok(stream::iter(requests.into_iter().map(Ok)))
                 }

--- a/lychee-lib/src/extract/html5ever.rs
+++ b/lychee-lib/src/extract/html5ever.rs
@@ -24,7 +24,7 @@ impl TokenSink for LinkExtractor {
                 if self.inside_excluded_element {
                     return TokenSinkResult::Continue;
                 }
-                self.links.extend(extract_plaintext(&raw))
+                self.links.extend(extract_plaintext(&raw));
             }
             Token::TagToken(tag) => {
                 let Tag {
@@ -73,7 +73,7 @@ impl TokenSink for LinkExtractor {
 }
 
 impl LinkExtractor {
-    pub(crate) fn new(include_verbatim: bool) -> Self {
+    pub(crate) const fn new(include_verbatim: bool) -> Self {
         Self {
             links: vec![],
             include_verbatim,

--- a/lychee-lib/src/extract/html5ever.rs
+++ b/lychee-lib/src/extract/html5ever.rs
@@ -1,16 +1,17 @@
 use html5ever::{
     buffer_queue::BufferQueue,
     tendril::StrTendril,
-    tokenizer::{Tag, Token, TokenSink, TokenSinkResult, Tokenizer, TokenizerOpts},
+    tokenizer::{Tag, TagKind, Token, TokenSink, TokenSinkResult, Tokenizer, TokenizerOpts},
 };
 
-use super::plaintext::extract_plaintext;
+use super::{is_verbatim_elem, plaintext::extract_plaintext};
 use crate::types::raw_uri::RawUri;
 
 #[derive(Clone, Default)]
 struct LinkExtractor {
     links: Vec<RawUri>,
     include_verbatim: bool,
+    inside_excluded_element: bool,
 }
 
 impl TokenSink for LinkExtractor {
@@ -19,21 +20,30 @@ impl TokenSink for LinkExtractor {
     #[allow(clippy::match_same_arms)]
     fn process_token(&mut self, token: Token, _line_number: u64) -> TokenSinkResult<()> {
         match token {
-            Token::CharacterTokens(raw) => self.links.extend(extract_plaintext(&raw)),
+            Token::CharacterTokens(raw) => {
+                if self.inside_excluded_element {
+                    return TokenSinkResult::Continue;
+                }
+                self.links.extend(extract_plaintext(&raw))
+            }
             Token::TagToken(tag) => {
                 let Tag {
-                    kind: _kind,
+                    kind,
                     name,
                     self_closing: _self_closing,
                     attrs,
                 } = tag;
+                if !self.include_verbatim && is_verbatim_elem(&name) {
+                    // Skip content inside excluded elements until we see the end tag.
+                    self.inside_excluded_element = matches!(kind, TagKind::StartTag);
+                    return TokenSinkResult::Continue;
+                }
 
                 for attr in attrs {
                     let urls = LinkExtractor::extract_urls_from_elem_attr(
-                        self.include_verbatim,
-                        attr.name.local.as_ref(),
-                        name.as_ref(),
-                        attr.value.as_ref(),
+                        &attr.name.local,
+                        &name,
+                        &attr.value,
                     );
 
                     let new_urls = match urls {
@@ -67,13 +77,13 @@ impl LinkExtractor {
         Self {
             links: vec![],
             include_verbatim,
+            inside_excluded_element: false,
         }
     }
 
     /// Extract all semantically known links from a given html attribute.
     #[allow(clippy::unnested_or_patterns)]
     pub(crate) fn extract_urls_from_elem_attr<'a>(
-        include_verbatim: bool,
         attr_name: &str,
         elem_name: &str,
         attr_value: &'a str,
@@ -81,12 +91,6 @@ impl LinkExtractor {
         // For a comprehensive list of elements that might contain URLs/URIs
         // see https://www.w3.org/TR/REC-html40/index/attributes.html
         // and https://html.spec.whatwg.org/multipage/indices.html#attributes-1
-
-        if !include_verbatim {
-            if elem_name == "pre" || elem_name == "code" {
-                return None;
-            }
-        }
 
         match (elem_name, attr_name) {
             // Common element/attribute combinations for links
@@ -140,4 +144,63 @@ pub(crate) fn extract_html(buf: &str, include_verbatim: bool) -> Vec<RawUri> {
     tokenizer.end();
 
     tokenizer.sink.links
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const HTML_INPUT: &str = r#"
+<html>
+    <body>
+        <p>This is a paragraph with some inline <code>https://example.com</code> and a normal <a href="https://example.org">example</a></p>
+        <pre>
+        Some random text
+        https://foo.com and http://bar.com/some/path
+        Something else
+        </pre>
+        <p><b>bold</b></p>
+    </body>
+</html>"#;
+
+    #[test]
+    fn test_skip_verbatim() {
+        let expected = vec![RawUri {
+            text: "https://example.org".to_string(),
+            element: Some("a".to_string()),
+            attribute: Some("href".to_string()),
+        }];
+
+        let uris = extract_html(HTML_INPUT, false);
+        assert_eq!(uris, expected);
+    }
+
+    #[test]
+    fn test_include_verbatim() {
+        let expected = vec![
+            RawUri {
+                text: "https://example.com".to_string(),
+                element: None,
+                attribute: None,
+            },
+            RawUri {
+                text: "https://example.org".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+            },
+            RawUri {
+                text: "https://foo.com".to_string(),
+                element: None,
+                attribute: None,
+            },
+            RawUri {
+                text: "http://bar.com/some/path".to_string(),
+                element: None,
+                attribute: None,
+            },
+        ];
+
+        let uris = extract_html(HTML_INPUT, true);
+        assert_eq!(uris, expected);
+    }
 }

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -2,7 +2,7 @@ use pulldown_cmark::{Event, Parser, Tag};
 
 use crate::{extract::plaintext::extract_plaintext, types::raw_uri::RawUri};
 
-use super::html::extract_html;
+use super::html5ever::extract_html;
 
 /// Extract unparsed URL strings from a Markdown string.
 pub(crate) fn extract_markdown(input: &str, include_verbatim: bool) -> Vec<RawUri> {

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -1,35 +1,131 @@
-use pulldown_cmark::{Event as MDEvent, Parser, Tag};
+use pulldown_cmark::{Event, Parser, Tag};
 
 use crate::{extract::plaintext::extract_plaintext, types::raw_uri::RawUri};
 
 /// Extract unparsed URL strings from a Markdown string.
-pub(crate) fn extract_markdown(input: &str) -> Vec<RawUri> {
+pub(crate) fn extract_markdown(input: &str, skip_code_blocks: bool) -> Vec<RawUri> {
+    // In some cases it is undesirable to extract links from within code blocks,
+    // which is why we keep track of entries and exits while traversing the input.
+    let mut inside_code_block = false;
+
     let parser = Parser::new(input);
     parser
-        .flat_map(|event| match event {
-            MDEvent::Start(Tag::Link(_, uri, _)) => {
-                vec![RawUri {
+        .filter_map(|event| match event {
+            // A link. The first field is the link type, the second the destination URL and the third is a title.
+            Event::Start(Tag::Link(_, uri, _)) => {
+                Some(vec![RawUri {
                     text: uri.to_string(),
                     // Emulate `<a href="...">` tag here to be compatible with
                     // HTML links. We might consider using the actual Markdown
                     // `LinkType` for better granularity in the future
                     element: Some("a".to_string()),
                     attribute: Some("href".to_string()),
-                }]
+                }])
             }
-            MDEvent::Start(Tag::Image(_, uri, _)) => {
-                vec![RawUri {
+            // An image. The first field is the link type, the second the destination URL and the third is a title.
+            Event::Start(Tag::Image(_, uri, _)) => {
+                Some(vec![RawUri {
                     text: uri.to_string(),
                     // Emulate `<img src="...">` tag here to be compatible with
                     // HTML links. We might consider using the actual Markdown
                     // `LinkType` for better granularity in the future
                     element: Some("img".to_string()),
                     attribute: Some("src".to_string()),
-                }]
+                }])
             }
-            MDEvent::Text(txt) => extract_plaintext(&txt),
-            MDEvent::Html(html) => extract_plaintext(&html.to_string()),
-            _ => vec![],
+            // A code block (inline or fenced).
+            Event::Start(Tag::CodeBlock(_)) => {
+                inside_code_block = true;
+                None
+            }
+            Event::End(Tag::CodeBlock(_)) => {
+                inside_code_block = false;
+                None
+            }
+
+            // A text node.
+            Event::Text(txt) => {
+                if inside_code_block && skip_code_blocks {
+                    None
+                } else {
+                    Some(extract_plaintext(&txt))
+                }
+            }
+
+            // An HTML node
+            Event::Html(html) => Some(extract_plaintext(&html.to_string())),
+
+            // An inline code node.
+            Event::Code(code) => {
+                println!("found code block: {code}");
+                None
+            }
+
+            // Silently skip over other events
+            _ => None,
         })
+        .flatten()
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MD_INPUT: &str = r#"
+# Test
+
+Some link in text [here](https://foo.com)
+
+Code:
+
+```bash
+https://bar.com/123
+```
+
+[example](http://example.com)
+        "#;
+
+    #[test]
+    fn test_skip_code_block() {
+        let links = vec![
+            RawUri {
+                text: "https://foo.com".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+            },
+            RawUri {
+                text: "http://example.com".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+            },
+        ];
+
+        let uris = extract_markdown(MD_INPUT, true);
+        assert_eq!(uris, links);
+    }
+
+    #[test]
+    fn test_code_block() {
+        let links = vec![
+            RawUri {
+                text: "https://foo.com".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+            },
+            RawUri {
+                text: "https://bar.com/123".to_string(),
+                element: None,
+                attribute: None,
+            },
+            RawUri {
+                text: "http://example.com".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+            },
+        ];
+
+        let uris = extract_markdown(MD_INPUT, false);
+        assert_eq!(uris, links);
+    }
 }

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -56,10 +56,7 @@ pub(crate) fn extract_markdown(input: &str, skip_code_blocks: bool) -> Vec<RawUr
             Event::Html(html) => Some(extract_plaintext(&html.to_string())),
 
             // An inline code node.
-            Event::Code(code) => {
-                println!("found code block: {code}");
-                None
-            }
+            Event::Code(code) => None,
 
             // Silently skip over other events
             _ => None,

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -13,8 +13,17 @@ use plaintext::extract_plaintext;
 
 /// HTML elements that are deemed verbatim (i.e. preformatted).
 /// These will be excluded from link checking by default.
-static VERBATIM_ELEMENTS: Lazy<HashSet<String>> =
-    Lazy::new(|| HashSet::from_iter(["pre".into(), "code".into()]));
+static VERBATIM_ELEMENTS: Lazy<HashSet<String>> = Lazy::new(|| {
+    HashSet::from_iter([
+        "pre".into(),
+        "code".into(),
+        "textarea".into(),
+        "samp".into(),
+        "xmp".into(),
+        "plaintext".into(),
+        "listing".into(),
+    ])
+});
 
 /// Check if the given element is in the list of preformatted tags
 pub(crate) fn is_verbatim_elem(name: &str) -> bool {

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -14,7 +14,7 @@ use plaintext::extract_plaintext;
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Extractor {
     use_html5ever: bool,
-    exclude_verbatim: bool,
+    include_verbatim: bool,
 }
 
 impl Extractor {
@@ -26,15 +26,15 @@ impl Extractor {
     ///   is also used in the Servo browser by Mozilla.
     ///   The default is `html5gum`, which is more performant and well maintained.
     ///
-    /// - `exclude_verbatim` ignores links inside Markdown code blocks.
+    /// - `include_verbatim` ignores links inside Markdown code blocks.
     ///   These can be denoted as a block starting with three backticks or an indented block.
     ///   For more information, consult the `pulldown_cmark` documentation about code blocks
     ///   [here](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.CodeBlockKind.html)
     #[must_use]
-    pub const fn new(use_html5ever: bool, exclude_verbatim: bool) -> Self {
+    pub const fn new(use_html5ever: bool, include_verbatim: bool) -> Self {
         Self {
             use_html5ever,
-            exclude_verbatim,
+            include_verbatim,
         }
     }
 
@@ -43,12 +43,12 @@ impl Extractor {
     #[must_use]
     pub fn extract(&self, input_content: &InputContent) -> Vec<RawUri> {
         match input_content.file_type {
-            FileType::Markdown => extract_markdown(&input_content.content, self.exclude_verbatim),
+            FileType::Markdown => extract_markdown(&input_content.content, self.include_verbatim),
             FileType::Html => {
                 if self.use_html5ever {
-                    html::extract_html(&input_content.content)
+                    html::extract_html(&input_content.content, self.include_verbatim)
                 } else {
-                    html5gum::extract_html(&input_content.content)
+                    html5gum::extract_html(&input_content.content, self.include_verbatim)
                 }
             }
             FileType::Plaintext => extract_plaintext(&input_content.content),

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -14,7 +14,7 @@ use plaintext::extract_plaintext;
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Extractor {
     use_html5ever: bool,
-    skip_code_blocks: bool,
+    exclude_verbatim: bool,
 }
 
 impl Extractor {
@@ -26,15 +26,15 @@ impl Extractor {
     ///   is also used in the Servo browser by Mozilla.
     ///   The default is `html5gum`, which is more performant and well maintained.
     ///
-    /// - `skip_code_blocks` ignores links inside Markdown code blocks.
+    /// - `exclude_verbatim` ignores links inside Markdown code blocks.
     ///   These can be denoted as a block starting with three backticks or an indented block.
     ///   For more information, consult the `pulldown_cmark` documentation about code blocks
     ///   [here](https://docs.rs/pulldown-cmark/latest/pulldown_cmark/enum.CodeBlockKind.html)
     #[must_use]
-    pub const fn new(use_html5ever: bool, skip_code_blocks: bool) -> Self {
+    pub const fn new(use_html5ever: bool, exclude_verbatim: bool) -> Self {
         Self {
             use_html5ever,
-            skip_code_blocks,
+            exclude_verbatim,
         }
     }
 
@@ -43,7 +43,7 @@ impl Extractor {
     #[must_use]
     pub fn extract(&self, input_content: &InputContent) -> Vec<RawUri> {
         match input_content.file_type {
-            FileType::Markdown => extract_markdown(&input_content.content, self.skip_code_blocks),
+            FileType::Markdown => extract_markdown(&input_content.content, self.exclude_verbatim),
             FileType::Html => {
                 if self.use_html5ever {
                     html::extract_html(&input_content.content)


### PR DESCRIPTION
This adds support for ignoring Markdown code blocks with `--skip-code-blocks`.
We should make this the default at some point, but I'm not sure if we should do it right away.
I doubt that anyone currently depends on checking links inside code blocks, though.

I added this to the pulldown_cmark extractor to avoid unnecessary
allocations. The same can be done for the HTML extractor in the future.

I'm wondering if we should stick to our established nomenclature and rename
`--skip-code-blocks` to `--exclude-code-blocks`.
Or, even better, implement that functionality for HTML, too, so we can use something like
`--exclude-elements code,pre`. (This won't work for plaintext of course and will be ignored, which we should document in the help output.)
