### PR TITLE
Response output overhaul

### DIFF
--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -22,9 +22,10 @@ impl From<&Status> for CacheValue {
     }
 }
 
-/// The cache stores previous response codes
-/// for faster checking. At the moment it is backed by `DashMap`, but this is an
-/// implementation detail, which may change in the future.
+/// The cache stores previous response codes for faster checking.
+///
+/// At the moment it is backed by `DashMap`, but this is an
+/// implementation detail, which should not be relied upon.
 pub(crate) type Cache = DashMap<Uri, CacheValue>;
 
 pub(crate) trait StoreExt {

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -7,7 +7,7 @@ use crate::color::{DIM, GREEN, NORMAL, PINK, YELLOW};
 
 pub(crate) fn color_response(response: &ResponseBody) -> String {
     let out = match response.status {
-        Status::Ok(_) | Status::Cached(CacheStatus::Success) => GREEN.apply_to(response),
+        Status::Ok(_) | Status::Cached(CacheStatus::Ok(_)) => GREEN.apply_to(response),
         Status::Excluded
         | Status::Unsupported(_)
         | Status::Cached(CacheStatus::Excluded | CacheStatus::Unsupported) => {
@@ -15,7 +15,7 @@ pub(crate) fn color_response(response: &ResponseBody) -> String {
         }
         Status::Redirected(_) => NORMAL.apply_to(response),
         Status::UnknownStatusCode(_) | Status::Timeout(_) => YELLOW.apply_to(response),
-        Status::Error(_) | Status::Cached(CacheStatus::Fail) => PINK.apply_to(response),
+        Status::Error(_) | Status::Cached(CacheStatus::Fail(_)) => PINK.apply_to(response),
     };
     out.to_string()
 }
@@ -63,8 +63,8 @@ impl ResponseStats {
 
         if let Status::Cached(cache_status) = status {
             match cache_status {
-                CacheStatus::Success => self.successful += 1,
-                CacheStatus::Fail => self.failures += 1,
+                CacheStatus::Ok(_) => self.successful += 1,
+                CacheStatus::Fail(_) => self.failures += 1,
                 CacheStatus::Excluded | CacheStatus::Unsupported => self.excludes += 1,
             }
         }
@@ -74,7 +74,7 @@ impl ResponseStats {
             Status::Error(_)
                 | Status::Timeout(_)
                 | Status::Redirected(_)
-                | Status::Cached(CacheStatus::Fail)
+                | Status::Cached(CacheStatus::Fail(_))
         ) {
             let fail = self.fail_map.entry(source).or_default();
             fail.insert(response.1);

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -15,7 +15,7 @@ pub(crate) fn color_response(response: &ResponseBody) -> String {
         }
         Status::Redirected(_) => NORMAL.apply_to(response),
         Status::UnknownStatusCode(_) | Status::Timeout(_) => YELLOW.apply_to(response),
-        Status::Error(_) | Status::Cached(CacheStatus::Fail(_)) => PINK.apply_to(response),
+        Status::Error(_) | Status::Cached(CacheStatus::Error(_)) => PINK.apply_to(response),
     };
     out.to_string()
 }
@@ -64,7 +64,7 @@ impl ResponseStats {
         if let Status::Cached(cache_status) = status {
             match cache_status {
                 CacheStatus::Ok(_) => self.successful += 1,
-                CacheStatus::Fail(_) => self.failures += 1,
+                CacheStatus::Error(_) => self.failures += 1,
                 CacheStatus::Excluded | CacheStatus::Unsupported => self.excludes += 1,
             }
         }
@@ -74,7 +74,7 @@ impl ResponseStats {
             Status::Error(_)
                 | Status::Timeout(_)
                 | Status::Redirected(_)
-                | Status::Cached(CacheStatus::Fail(_))
+                | Status::Cached(CacheStatus::Error(_))
         ) {
             let fail = self.fail_map.entry(source).or_default();
             fail.insert(response.1);

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -2,7 +2,7 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
-use crate::Status;
+use crate::{ErrorKind, Status};
 
 /// Representation of the status of a cached request. This is kept simple on
 /// purpose because the type gets serialized to a cache file and might need to
@@ -12,7 +12,7 @@ pub enum CacheStatus {
     /// The cached request delivered a valid response
     Ok(u16),
     /// The cached request failed before
-    Fail(Option<u16>),
+    Error(Option<u16>),
     /// The request was excluded (skipped)
     Excluded,
     /// The protocol is not yet supported
@@ -22,10 +22,10 @@ pub enum CacheStatus {
 impl Display for CacheStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Ok(_) => write!(f, "OK [cached]"),
-            Self::Fail(_) => write!(f, "Fail [cached]"),
-            Self::Excluded => write!(f, "Excluded [cached]"),
-            Self::Unsupported => write!(f, "Unsupported [cached]"),
+            Self::Ok(_) => write!(f, "OK (cached)"),
+            Self::Error(_) => write!(f, "Error (cached)"),
+            Self::Excluded => write!(f, "Excluded (cached)"),
+            Self::Unsupported => write!(f, "Unsupported (cached)"),
         }
     }
 }
@@ -40,9 +40,17 @@ impl From<&Status> for CacheStatus {
             Status::Ok(code) | Status::UnknownStatusCode(code) => Self::Ok(code.as_u16()),
             Status::Excluded => Self::Excluded,
             Status::Unsupported(_) => Self::Unsupported,
-            Status::Redirected(code) => Self::Fail(Some(code.as_u16())),
-            Status::Timeout(code) => Self::Fail(code.map(|code| code.as_u16())),
-            Status::Error(_) => Self::Fail(None),
+            Status::Redirected(code) => Self::Error(Some(code.as_u16())),
+            Status::Timeout(code) => Self::Error(code.map(|code| code.as_u16())),
+            Status::Error(e) => match e {
+                ErrorKind::NetworkRequest(e)
+                | ErrorKind::ReadResponseBody(e)
+                | ErrorKind::BuildRequestClient(e) => match e.status() {
+                    Some(code) => Self::Error(Some(code.as_u16())),
+                    None => Self::Error(None),
+                },
+                _ => Self::Error(None),
+            },
         }
     }
 }

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -25,8 +25,8 @@ pub enum ErrorKind {
     /// Errors which can occur when attempting to interpret a sequence of u8 as a string
     #[error("Attempted to interpret an invalid sequence of bytes as a string")]
     Utf8(#[from] std::str::Utf8Error),
-    /// Network error while making request
-    #[error("Network error while handling request")]
+    /// Network error while handling request
+    #[error("Network error")]
     NetworkRequest(#[source] reqwest::Error),
     /// Cannot read the body of the received response
     #[error("Error reading response body")]
@@ -44,7 +44,7 @@ pub enum ErrorKind {
     #[error("Cannot parse string `{1}` as website url")]
     ParseUrl(#[source] url::ParseError, String),
     /// The given URI cannot be converted to a file path
-    #[error("Cannot find file {0}")]
+    #[error("Cannot find file")]
     InvalidFilePath(Uri),
     /// The given path cannot be converted to a URI
     #[error("Invalid path to URL conversion: {0}")]

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -159,7 +159,7 @@ impl Status {
             Status::Unsupported(_) => "IGNORED".to_string(),
             Status::Cached(cache_status) => match cache_status {
                 CacheStatus::Ok(code) => code.to_string(),
-                CacheStatus::Fail(code) => match code {
+                CacheStatus::Error(code) => match code {
                     Some(code) => code.to_string(),
                     None => "ERROR".to_string(),
                 },

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -134,6 +134,40 @@ impl Status {
             Status::Cached(_) => ICON_CACHED,
         }
     }
+
+    /// Return the HTTP status code (if any)
+    #[must_use]
+    pub fn code(&self) -> String {
+        match self {
+            Status::Ok(code) | Status::Redirected(code) | Status::UnknownStatusCode(code) => {
+                code.as_str().to_string()
+            }
+            Status::Excluded => "EXCLUDED".to_string(),
+            Status::Error(e) => match e {
+                ErrorKind::NetworkRequest(e)
+                | ErrorKind::ReadResponseBody(e)
+                | ErrorKind::BuildRequestClient(e) => match e.status() {
+                    Some(code) => code.as_str().to_string(),
+                    None => "ERROR".to_string(),
+                },
+                _ => "ERROR".to_string(),
+            },
+            Status::Timeout(code) => match code {
+                Some(code) => code.as_str().to_string(),
+                None => "TIMEOUT".to_string(),
+            },
+            Status::Unsupported(_) => "IGNORED".to_string(),
+            Status::Cached(cache_status) => match cache_status {
+                CacheStatus::Ok(code) => code.to_string(),
+                CacheStatus::Fail(code) => match code {
+                    Some(code) => code.to_string(),
+                    None => "ERROR".to_string(),
+                },
+                CacheStatus::Excluded => "EXCLUDED".to_string(),
+                CacheStatus::Unsupported => "IGNORED".to_string(),
+            },
+        }
+    }
 }
 
 impl From<ErrorKind> for Status {


### PR DESCRIPTION
This changes the way we print responses.

Before, the response and status were concatenated, e.g.

```
https://github.com/fooFail [cached].
```

This is a regression from #510.
Now there is a colon and a space in between the URL and the status and the status code is prepended

```
https://github.com/foo: Fail [cached]
```

In fact, the output is cleaner now in general.

The full output is

```
↻ [404] https://github.com/foo: Fail (cached)
```
(The status code is always in front; the explanation got shortened to the relevant parts without being too verbose)

For successes it looks like this:
```
✔ [200] https://smartbear.com/: OK
```

...and for non-cached errors

```
✗ [404] https://www.defensecode.com/web-security-scanner-dast/: Network error: Not Found
```

If there is no status code, we print a short string instead, e.g.
```
✗ [ERROR] file:///Users/mendler/Code/private/analysis-tools-dev/dynamic-analysis/data/render/templates/%7B%7Bother.
discussion.as_ref().unwrap()%7D%7D: Cannot find file
```

But the file name is no longer printed twice, which was unnecessarily verbose.

The implementation isn't the cleanest at the moment. I'm open for refactoring suggestions or separate after-the-fact PRs.

