### PR TITLE
Make retry wait time configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,13 @@ OPTIONS:
         --max-retries <max-retries>            Maximum number of retries per request [default: 3]
     -X, --method <method>                      Request method [default: get]
     -o, --output <output>                      Output file of status report
+    -r, --retry-wait-time <retry-wait-time>    Minimum wait time in seconds between retries of failed requests [default:
+                                               1]
     -s, --scheme <scheme>...                   Only test links with the given schemes (e.g. http and https)
     -T, --threads <threads>                    Number of threads to utilize. Defaults to number of cores available to
                                                the system
-    -t, --timeout <timeout>                    Website timeout from connect to response finished [default: 20]
+    -t, --timeout <timeout>                    Website timeout in seconds from connect to response finished [default:
+                                               20]
     -u, --user-agent <user-agent>              User agent [default: lychee/0.8.2]
 
 ARGS:

--- a/lychee-bin/src/parse.rs
+++ b/lychee-bin/src/parse.rs
@@ -14,8 +14,8 @@ fn read_header(input: &str) -> Result<(String, String)> {
     Ok((elements[0].into(), elements[1].into()))
 }
 
-pub(crate) const fn parse_timeout(timeout: usize) -> Duration {
-    Duration::from_secs(timeout as u64)
+pub(crate) const fn parse_duration_secs(secs: usize) -> Duration {
+    Duration::from_secs(secs as u64)
 }
 
 pub(crate) fn parse_headers<T: AsRef<str>>(headers: &[T]) -> Result<HeaderMap> {

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -79,7 +79,7 @@ pub use crate::{
     // Constants get exposed so that the CLI can use the same defaults as the library
     client::{
         check, Client, ClientBuilder, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES,
-        DEFAULT_RETRY_WAIT_TIME, DEFAULT_TIMEOUT, DEFAULT_USER_AGENT,
+        DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS, DEFAULT_USER_AGENT,
     },
     collector::Collector,
     filter::{Excludes, Filter, Includes},


### PR DESCRIPTION
This was always hardwired to 1 second until now, but it makes sense to make it configurable.

See #474.