### PR TITLE
Print Github token error once at the end

### DIFF
--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -276,8 +276,12 @@ mod cli {
             .assert()
             .failure()
             .code(2)
-            .stdout(contains("https://github.com/mre/idiomatic-rust-doesnt-exist-man | \
-            GitHub token not specified. To check GitHub links reliably, use `--github-token` flag / `GITHUB_TOKEN` env var."));
+            .stdout(contains(
+                "https://github.com/mre/idiomatic-rust-doesnt-exist-man | Network error: Not Found",
+            ))
+            .stdout(contains(
+                "There were issues with Github URLs. You could try setting a Github token and running lychee again.",
+            ));
     }
 
     #[tokio::test]

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -270,7 +270,7 @@ impl ClientBuilder {
                 Octocrab::builder()
                     .personal_token(token.clone())
                     .build()
-                    .map_err(ErrorKind::GithubRequest)?,
+                    .map_err(ErrorKind::BuildGithubClient)?,
             ),
             _ => None,
         };
@@ -417,7 +417,12 @@ impl Client {
         // Pull out the heavy machinery in case of a failed normal request.
         // This could be a GitHub URL and we ran into the rate limiter.
         if let Some(github_uri) = uri.gh_org_and_repo() {
-            return self.check_github(github_uri).await;
+            let status = self.check_github(github_uri).await;
+            // Only return Github status in case of success
+            // Otherwise return the original error, which has more information
+            if status.is_success() {
+                return status;
+            }
         }
 
         status

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -34,9 +34,12 @@ pub enum ErrorKind {
     /// The network client required for making requests cannot be created
     #[error("Error creating request client")]
     BuildRequestClient(#[source] reqwest::Error),
+    /// The Github client required for making requests cannot be created
+    #[error("Error creating Github client")]
+    BuildGithubClient(#[source] octocrab::Error),
     /// Network error while using Github API
     #[error("Network error (GitHub client)")]
-    GithubRequest(#[from] octocrab::Error),
+    GithubRequest(#[source] octocrab::Error),
     /// Invalid Github URL
     #[error("Github URL is invalid: {0}")]
     InvalidGithubUrl(String),
@@ -136,6 +139,7 @@ impl Hash for ErrorKind {
             Self::NetworkRequest(e) => e.to_string().hash(state),
             Self::ReadResponseBody(e) => e.to_string().hash(state),
             Self::BuildRequestClient(e) => e.to_string().hash(state),
+            Self::BuildGithubClient(e) => e.to_string().hash(state),
             Self::GithubRequest(e) => e.type_id().hash(state),
             Self::InvalidGithubUrl(s) => s.hash(state),
             Self::DirTraversal(e) => e.to_string().hash(state),

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -39,7 +39,7 @@ pub enum ErrorKind {
     BuildGithubClient(#[source] octocrab::Error),
     /// Network error while using Github API
     #[error("Network error (GitHub client)")]
-    GithubRequest(#[source] octocrab::Error),
+    GithubRequest(#[from] octocrab::Error),
     /// Invalid Github URL
     #[error("Github URL is invalid: {0}")]
     InvalidGithubUrl(String),

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -190,12 +190,6 @@ impl From<reqwest::Error> for Status {
     }
 }
 
-impl From<octocrab::Error> for Status {
-    fn from(e: octocrab::Error) -> Self {
-        Self::Error(ErrorKind::GithubRequest(e))
-    }
-}
-
 impl From<CacheStatus> for Status {
     fn from(s: CacheStatus) -> Self {
         Self::Cached(s)


### PR DESCRIPTION
Print original reqwest error for every Github link.
It contains more information about the underlying error.

Only print a message about the Github token at the
end if it's not set and there were Github errors.