### PR TITLE
Allow input URLs without scheme (fixes #567)

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -220,7 +220,7 @@ fn underlying_io_error_kind(error: &Error) -> Option<io::ErrorKind> {
 
 /// Run lychee on the given inputs
 async fn run(opts: &LycheeOptions) -> Result<i32> {
-    let inputs = opts.inputs();
+    let inputs = opts.inputs()?;
     let requests = Collector::new(opts.config.base.clone())
         .skip_missing_inputs(opts.config.skip_missing)
         // File a bug if you rely on this envvar! It's going to go away eventually.

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -1,6 +1,6 @@
 use std::{convert::TryFrom, fs, io::ErrorKind, path::PathBuf, str::FromStr, time::Duration};
 
-use anyhow::{anyhow, Error, Result};
+use anyhow::{anyhow, Context, Error, Result};
 use const_format::{concatcp, formatcp};
 use lychee_lib::{
     Base, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS,
@@ -129,11 +129,12 @@ impl LycheeOptions {
     // accept a `Vec<Input>` in `LycheeOptions` and do the conversion there,
     // but we'd get no access to `glob_ignore_case`.
     /// Get parsed inputs from options.
-    pub(crate) fn inputs(&self) -> Vec<Input> {
+    pub(crate) fn inputs(&self) -> Result<Vec<Input>> {
         self.raw_inputs
             .iter()
             .map(|s| Input::new(s, None, self.config.glob_ignore_case))
-            .collect()
+            .collect::<Result<_, _>>()
+            .context("Cannot parse inputs from arguments")
     }
 }
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -324,23 +324,6 @@ mod cli {
     }
 
     #[test]
-    fn test_missing_file_error() {
-        let mut cmd = main_command();
-        let filename = format!("non-existing-file-{}", uuid::Uuid::new_v4());
-
-        cmd.arg(&filename)
-            .assert()
-            .failure()
-            .code(1)
-            .stderr(contains(format!(
-                "Cannot read input content from file `{filename}`"
-            )))
-            .stderr(contains(
-                "No such file or directory (os error 2)".to_string(),
-            ));
-    }
-
-    #[test]
     fn test_missing_file_ok_if_skip_missing() {
         let mut cmd = main_command();
         let filename = format!("non-existing-file-{}", uuid::Uuid::new_v4());

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -632,4 +632,18 @@ mod cli {
 
         Ok(())
     }
+
+    #[test]
+    fn test_inputs_without_scheme() -> Result<()> {
+        let test_path = fixtures_path().join("TEST_HTTP.html");
+        let mut cmd = main_command();
+
+        cmd.arg("--dump")
+            .arg("example.com")
+            .arg(&test_path)
+            .arg("https://example.org")
+            .assert()
+            .success();
+        Ok(())
+    }
 }

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -110,7 +110,7 @@ mod test {
         // Treat as plaintext file (no extension)
         let file_path = temp_dir.path().join("README");
         let _file = File::create(&file_path).unwrap();
-        let input = Input::new(&file_path.as_path().display().to_string(), None, true);
+        let input = Input::new(&file_path.as_path().display().to_string(), None, true)?;
         let contents: Vec<_> = input.get_contents(true).await.collect::<Vec<_>>().await;
 
         assert_eq!(contents.len(), 1);
@@ -120,7 +120,7 @@ mod test {
 
     #[tokio::test]
     async fn test_url_without_extension_is_html() -> Result<()> {
-        let input = Input::new("https://example.com/", None, true);
+        let input = Input::new("https://example.com/", None, true)?;
         let contents: Vec<_> = input.get_contents(true).await.collect::<Vec<_>>().await;
 
         assert_eq!(contents.len(), 1);

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -143,7 +143,7 @@ impl Input {
             } else {
                 let path = PathBuf::from(value);
                 if path.exists() {
-                    InputSource::FsPath(value.into())
+                    InputSource::FsPath(path)
                 } else {
                     // Invalid path; check if a valid URL can be constructed from the input
                     // by prefixing it with a `http://` scheme.

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -176,8 +176,12 @@ impl Input {
         try_stream! {
             match self.source {
                 InputSource::RemoteUrl(ref url) => {
-                    let contents: InputContent = Self::url_contents(url).await?;
-                    yield contents;
+                    let content = Self::url_contents(url).await;
+                    match content {
+                        Err(_) if skip_missing => (),
+                        Err(e) => Err(e)?,
+                        Ok(content) => yield content,
+                    }
                 },
                 InputSource::FsGlob {
                     ref pattern,


### PR DESCRIPTION
This requires `Input::new` to return a `Result`, because the URL
parsing could fail when prepending `http://`.

We use http instead of https, because curl does as well:
https://github.com/curl/curl/blob/70ac27604a2abfa809a7b2736506af0da8c3c8a9/lib/urlapi.c#L1104-L1124