### PR TITLE
Cache verbosity issue (fixes #562)

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -156,6 +156,7 @@ fn show_progress(
             pb.println(out);
         }
     } else {
+        #[allow(clippy::collapsible_if)]
         if !verbose {
             if response.status().is_success() || response.status().is_excluded() {
                 return Ok(());

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -180,7 +180,7 @@ mod tests {
                 status: Status::Cached(CacheStatus::Ok(200)),
             },
         );
-        show_progress(&mut buf, &None, &response, true).unwrap();
+        show_progress(&mut buf, &None, &response, false).unwrap();
 
         println!("{:?}", String::from_utf8_lossy(&buf));
         assert!(buf.is_empty());

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -156,7 +156,7 @@ fn show_progress(
             pb.println(out);
         }
     } else {
-        if !verbose && (response.status().is_success() || response.status().is_excluded()) {
+        if verbose || !(response.status().is_success() || response.status().is_excluded()) {
             return Ok(());
         }
         writeln!(output, "{out}")?;

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -156,8 +156,10 @@ fn show_progress(
             pb.println(out);
         }
     } else {
-        if verbose || !(response.status().is_success() || response.status().is_excluded()) {
-            return Ok(());
+        if !verbose {
+            if response.status().is_success() || response.status().is_excluded() {
+                return Ok(());
+            }
         }
         writeln!(output, "{out}")?;
     }

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -88,21 +88,27 @@ impl Status {
     #[must_use]
     /// Returns `true` if the check was successful
     pub const fn is_success(&self) -> bool {
-        matches!(self, Status::Ok(_))
+        matches!(self, Status::Ok(_) | Status::Cached(CacheStatus::Ok(_)))
     }
 
     #[inline]
     #[must_use]
     /// Returns `true` if the check was not successful
     pub const fn is_failure(&self) -> bool {
-        matches!(self, Status::Error(_))
+        matches!(
+            self,
+            Status::Error(_) | Status::Cached(CacheStatus::Error(_))
+        )
     }
 
     #[inline]
     #[must_use]
     /// Returns `true` if the check was excluded
     pub const fn is_excluded(&self) -> bool {
-        matches!(self, Status::Excluded)
+        matches!(
+            self,
+            Status::Excluded | Status::Cached(CacheStatus::Excluded)
+        )
     }
 
     #[inline]
@@ -116,7 +122,10 @@ impl Status {
     #[must_use]
     /// Returns `true` if a URI is unsupported
     pub const fn is_unsupported(&self) -> bool {
-        matches!(self, Status::Unsupported(_))
+        matches!(
+            self,
+            Status::Unsupported(_) | Status::Cached(CacheStatus::Unsupported)
+        )
     }
 
     #[must_use]


### PR DESCRIPTION
Don't print cached status output when not in verbose mode