### PR TITLE
Skip Docker login on PRs from forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,14 +51,14 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to DockerHub
-        if: ${{ github.repository_owner == 'lycheeverse' && github.actor != 'dependabot[bot]' }}
+        if: github.repository_owner == 'lycheeverse' && github.actor != 'dependabot[bot]' && ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login )
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Push Image
-        if: ${{ github.repository_owner == 'lycheeverse' }}
+        if: github.repository_owner == 'lycheeverse'
         uses: docker/build-push-action@v2
         with:
           context: .


### PR DESCRIPTION
Since github.repository_owner refers to the base repository on pull request events, while secrets need to exist on the head repository, the Docker Hub login fails for pull requests opened from forks. This commit assures that this step in case of pull request events only runs for internal pull requests, i.e. when head and base repository are the same.

For the actual Docker Hub upload, no change is required: The build can run in every case, the upload is not done on pull request events in general.