### PR TITLE
Move to downstream optimization for short strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1705,9 +1705,9 @@ checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "linkify"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbcd666d915aa3ae3c3774999a9e20b2776a018309b8159d07df062b91f45e8"
+checksum = "28d9967eb7d0bc31c39c6f52e8fce42991c0cd1f7a2078326f0b7a399a584c8d"
 dependencies = [
  "memchr",
 ]

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -545,7 +545,7 @@ where
     ErrorKind: From<E>,
 {
     let client = ClientBuilder::builder().build().client()?;
-    client.check(request).await?
+    client.check(request).await
 }
 
 #[cfg(test)]

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -1,21 +1,7 @@
 use crate::{helpers::url, types::raw_uri::RawUri};
 
-/// Shortest valid URI that lychee extracts from plaintext.
-///
-/// The shortest valid URI without a scheme might be g.cn (Google China)
-/// At least I am not aware of a shorter one. We set this as a lower threshold
-/// for parsing URIs from plaintext to avoid false-positives and as a slight
-/// performance optimization, which could add up for big files.
-/// This threshold might be adjusted in the future.
-const MIN_URI_LENGTH: usize = 4;
-
 /// Extract unparsed URL strings from plaintext
 pub(crate) fn extract_plaintext(input: &str) -> Vec<RawUri> {
-    if input.len() < MIN_URI_LENGTH {
-        // Immediately return for very small strings which cannot be valid URIs
-        return vec![];
-    }
-
     url::find_links(input)
         .map(|uri| RawUri::from(uri.as_str()))
         .collect()


### PR DESCRIPTION
Skipping to parse very short strings was merged into linkify
so our own workaround is unnecessary
https://github.com/robinst/linkify/pull/34