### PR TITLE
Also dump excluded links

### DIFF
--- a/fixtures/TEST_DUMP_EXCLUDE.txt
+++ b/fixtures/TEST_DUMP_EXCLUDE.txt
@@ -1,0 +1,3 @@
+https://example.com
+https://example.org
+https://example.com/foo/bar

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -659,4 +659,33 @@ mod cli {
             .success();
         Ok(())
     }
+
+    #[test]
+    fn test_print_excluded_links_in_verbose_mode() -> Result<()> {
+        let test_path = fixtures_path().join("TEST_DUMP_EXCLUDE.txt");
+        let mut cmd = main_command();
+
+        cmd.arg("--dump")
+            .arg("--verbose")
+            .arg("--exclude")
+            .arg("example.com*")
+            .arg("--")
+            .arg(&test_path)
+            .assert()
+            .success()
+            .stdout(contains(format!(
+                "https://example.com/ ({}) [excluded]",
+                test_path.display()
+            )))
+            .stdout(contains(format!(
+                "https://example.org/ ({})",
+                test_path.display()
+            )))
+            .stdout(contains(format!(
+                "https://example.com/foo/bar ({}) [excluded]",
+                test_path.display()
+            )));
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
This is a minimally invasive version, which allows to grep for `[excluded]`.
The reason for exclusion would require more work and it's debatable if
it adds any value, because it might make grepping harder and the source
of exclusion is easily deducatable from the commandline parameters
or the `.lycheeignore` file.

Excluded links will only printed in verbose mode.

Example:
```
> lychee --exclude github --dump --verbose -- README.md
...
https://rustup.rs/ (README.md)
file:///Users/mendler/Code/private/lychee/lychee/assets/logo.svg (README.md)
https://github.com/pingcap/docs (README.md) [excluded]
https://github.com/raviqqe/liche/issues/13 (README.md) [excluded]
https://docs.rs/lychee-lib (README.md)
...
```

Fixes #587.