### PR TITLE
Add support for comments in `.lycheeignore`

### DIFF
--- a/fixtures/ignore/.lycheeignore
+++ b/fixtures/ignore/.lycheeignore
@@ -2,6 +2,10 @@
 example.org/.+
 http://.*
 
+# This is just a comment.
+# The following line should be ignored,
+# so the URL still gets checked.
+#https://example.net
 
 github.com/.*/.*$
 ^file.*

--- a/fixtures/ignore/TEST.md
+++ b/fixtures/ignore/TEST.md
@@ -2,6 +2,7 @@ https://example.com
 https://foo.example.com
 https://example.com/bar
 http://wikipedia.org
+https://example.net
 https://github.com/lycheeverse/lychee
 file:///path/to/file
 mail@example.com

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -102,6 +102,9 @@ enum ExitCode {
     LinkCheckFailure = 2,
 }
 
+/// Ignore lines starting with this marker in `.lycheeignore` files
+const LYCHEEINGORE_COMMENT_MARKER: &str = "#";
+
 fn main() -> Result<()> {
     #[cfg(feature = "tokio-console")]
     console_subscriber::init();
@@ -116,7 +119,12 @@ fn main() -> Result<()> {
 /// Read lines from file; ignore empty lines
 fn read_lines(file: &File) -> Result<Vec<String>> {
     let lines: Vec<_> = BufReader::new(file).lines().collect::<Result<_, _>>()?;
-    Ok(lines.into_iter().filter(|line| !line.is_empty()).collect())
+    Ok(lines
+        .into_iter()
+        .filter(|line| {
+            !line.is_empty() && !line.trim_start().starts_with(LYCHEEINGORE_COMMENT_MARKER)
+        })
+        .collect())
 }
 
 /// Merge all provided config options into one This includes a potential config

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -558,11 +558,18 @@ mod cli {
         let mut cmd = main_command();
         let test_path = fixtures_path().join("ignore");
 
-        cmd.current_dir(test_path)
+        let cmd = cmd
+            .current_dir(test_path)
+            .arg("--dump")
             .arg("TEST.md")
             .assert()
-            .stdout(contains("7 Total"))
-            .stdout(contains("5 Excluded"));
+            .stdout(contains("https://example.com"))
+            .stdout(contains("https://example.com/bar"))
+            .stdout(contains("https://example.net"));
+
+        let output = cmd.get_output();
+        let output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(output.lines().count(), 3);
 
         Ok(())
     }
@@ -579,7 +586,7 @@ mod cli {
             .arg(excludes_path)
             .assert()
             .success()
-            .stdout(contains("7 Total"))
+            .stdout(contains("8 Total"))
             .stdout(contains("6 Excluded"));
 
         Ok(())


### PR DESCRIPTION
Lines starting with the comment character (`#`) inside the
.lycheeignore file will be ignored.
Whitespace at the beginning of each line will be ignored, so
even an indented comment character will work.

#### Example `.lycheeignore` file

```markdown
.*\.example.com
example.org/.+
http://.*

# This is just a comment.
# The following line should be ignored,
# so the URL still gets checked.
#https://example.net

github.com/.*/.*$
^file.*
@
```

Fixes #585.