### PR TITLE
Add support for URI remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ OPTIONS:
         --max-retries <max-retries>            Maximum number of retries per request [default: 3]
     -X, --method <method>                      Request method [default: get]
     -o, --output <output>                      Output file of status report
+        --remap <remap>...                     Remap URI matching pattern to different URI
     -r, --retry-wait-time <retry-wait-time>    Minimum wait time in seconds between retries of failed requests [default:
                                                1]
     -s, --scheme <scheme>...                   Only test links with the given schemes (e.g. http and https)

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -16,7 +16,14 @@ where
     tokio::pin!(requests);
 
     while let Some(request) = requests.next().await {
-        let request = request?;
+        let mut request = request?;
+
+        if params.client.is_excluded(&request.uri) {
+            continue;
+        }
+
+        // Apply URI remappings (if any)
+        request.uri = params.client.remap(request.uri)?;
 
         // Avoid panic on broken pipe.
         // See https://github.com/rust-lang/rust/issues/46016

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -18,10 +18,6 @@ where
     while let Some(request) = requests.next().await {
         let mut request = request?;
 
-        if params.client.is_excluded(&request.uri) {
-            continue;
-        }
-
         // Apply URI remappings (if any)
         request.uri = params.client.remap(request.uri)?;
 

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -256,6 +256,11 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) exclude_mail: bool,
 
+    /// Remap URI matching pattern to different URI
+    #[serde(default)]
+    #[structopt(long)]
+    pub(crate) remap: Vec<String>,
+
     /// Custom request headers
     #[structopt(short, long)]
     #[serde(default)]
@@ -375,6 +380,7 @@ impl Config {
             exclude_link_local: false;
             exclude_loopback: false;
             exclude_mail: false;
+            remap: Vec::<String>::new();
             headers: Vec::<String>::new();
             accept: None;
             timeout: DEFAULT_TIMEOUT_SECS;

--- a/lychee-bin/src/parse.rs
+++ b/lychee-bin/src/parse.rs
@@ -6,21 +6,24 @@ use regex::Regex;
 use reqwest::Url;
 use std::{collections::HashSet, time::Duration};
 
+/// Split a single HTTP header into a (key, value) tuple
 fn read_header(input: &str) -> Result<(String, String)> {
     let elements: Vec<_> = input.split('=').collect();
     if elements.len() != 2 {
         return Err(anyhow!(
-            "Header value should be of the form key=value, got {}",
+            "Header value must be of the form key=value, got {}",
             input
         ));
     }
     Ok((elements[0].into(), elements[1].into()))
 }
 
+/// Parse seconds into a `Duration`
 pub(crate) const fn parse_duration_secs(secs: usize) -> Duration {
     Duration::from_secs(secs as u64)
 }
 
+/// Parse HTTP headers into a `HeaderMap`
 pub(crate) fn parse_headers<T: AsRef<str>>(headers: &[T]) -> Result<HeaderMap> {
     let mut out = HeaderMap::new();
     for header in headers {
@@ -30,6 +33,7 @@ pub(crate) fn parse_headers<T: AsRef<str>>(headers: &[T]) -> Result<HeaderMap> {
     Ok(out)
 }
 
+/// Parse HTTP status codes into a set of `StatusCode`
 pub(crate) fn parse_statuscodes<T: AsRef<str>>(accept: T) -> Result<HashSet<StatusCode>> {
     let mut statuscodes = HashSet::new();
     for code in accept.as_ref().split(',') {
@@ -47,7 +51,7 @@ pub(crate) fn parse_remaps(remaps: &[String]) -> Result<Remaps> {
         let params: Vec<_> = remap.split_whitespace().collect();
         if params.len() != 2 {
             return Err(anyhow!(
-                "Remap values must be of the form `pattern url`, got {}",
+                "Remap rules must be of the form `pattern url` (separated by whitespace), got {}",
                 remap
             ));
         }
@@ -57,14 +61,15 @@ pub(crate) fn parse_remaps(remaps: &[String]) -> Result<Remaps> {
         parsed.push((pattern, url))
     }
 
-    Ok(parsed)
+    Ok(Remaps::new(parsed))
 }
 
+/// Parse a HTTP basic auth header into username and password
 pub(crate) fn parse_basic_auth(auth: &str) -> Result<Authorization<Basic>> {
     let params: Vec<_> = auth.split(':').collect();
     if params.len() != 2 {
         return Err(anyhow!(
-            "Basic auth value should be of the form username:password, got {}",
+            "Basic auth value must be of the form username:password, got {}",
             auth
         ));
     }

--- a/lychee-bin/src/parse.rs
+++ b/lychee-bin/src/parse.rs
@@ -58,7 +58,7 @@ pub(crate) fn parse_remaps(remaps: &[String]) -> Result<Remaps> {
 
         let pattern = Regex::new(params[0])?;
         let url = Url::try_from(params[1])?;
-        parsed.push((pattern, url))
+        parsed.push((pattern, url));
     }
 
     Ok(Remaps::new(parsed))

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -704,15 +704,19 @@ mod cli {
             .arg("https://example.com http://127.0.0.1:8080")
             .arg("--remap")
             .arg("https://example.org https://staging.example.com")
+            .arg("--remap")
+            .arg("../../issues https://github.com/usnistgov/OSCAL/issues")
             .arg("--")
             .arg("-")
-            .write_stdin("https://example.com\nhttps://example.org\nhttps://example.net")
+            .write_stdin("file://../../issues\nhttps://example.com\nhttps://example.org\nhttps://example.net\n")
             .env_clear()
             .assert()
             .success()
+            .stdout(contains("https://github.com/usnistgov/OSCAL/issues"))
             .stdout(contains("http://127.0.0.1:8080/"))
             .stdout(contains("https://staging.example.com/"))
             .stdout(contains("https://example.net/"));
+
         Ok(())
     }
 }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -675,7 +675,7 @@ mod cli {
         cmd.arg("--dump")
             .arg("--verbose")
             .arg("--exclude")
-            .arg("example.com*")
+            .arg("example.com")
             .arg("--")
             .arg(&test_path)
             .assert()

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -692,7 +692,27 @@ mod cli {
                 "https://example.com/foo/bar ({}) [excluded]",
                 test_path.display()
             )));
+        Ok(())
+    }
 
+    #[test]
+    fn test_remap_uri() -> Result<()> {
+        let mut cmd = main_command();
+
+        cmd.arg("--dump")
+            .arg("--remap")
+            .arg("https://example.com http://127.0.0.1:8080")
+            .arg("--remap")
+            .arg("https://example.org https://staging.example.com")
+            .arg("--")
+            .arg("-")
+            .write_stdin("https://example.com\nhttps://example.org\nhttps://example.net")
+            .env_clear()
+            .assert()
+            .success()
+            .stdout(contains("http://127.0.0.1:8080/"))
+            .stdout(contains("https://staging.example.com/"))
+            .stdout(contains("https://example.net/"));
         Ok(())
     }
 }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -30,6 +30,7 @@ use typed_builder::TypedBuilder;
 use crate::{
     filter::{Excludes, Filter, Includes},
     quirks::Quirks,
+    remap::Remaps,
     types::{mail, GithubUri},
     ErrorKind, Request, Response, Result, Status, Uri,
 };
@@ -74,6 +75,18 @@ pub struct ClientBuilder {
     /// As of Feb 2022, it's 60 per hour without GitHub token v.s.
     /// 5000 per hour with token.
     github_token: Option<SecretString>,
+
+    /// Remap URIs matching a pattern to a different URI
+    ///
+    /// This makes it possible to remap any HTTP/HTTPS endpoint to a different
+    /// HTTP/HTTPS endpoint. Also, this feature could also be used to proxy
+    /// certain requests.
+    ///
+    /// Use with caution because a large set of remapping rules may cause
+    /// performance issues. Furthermore rules are executed in order and multiple
+    /// mappings for the same URI are allowed, so there is no guarantee that the
+    /// rules may not conflict with each other.
+    remaps: Option<Remaps>,
 
     /// Links matching this set of regular expressions are **always** checked.
     ///
@@ -242,6 +255,7 @@ impl ClientBuilder {
     pub fn client(self) -> Result<Client> {
         let Self {
             github_token,
+            remaps,
             includes,
             excludes,
             user_agent,
@@ -305,6 +319,7 @@ impl ClientBuilder {
         Ok(Client {
             reqwest_client,
             github_client,
+            remaps,
             filter,
             max_retries: self.max_retries,
             retry_wait_time,
@@ -326,6 +341,9 @@ pub struct Client {
 
     /// Github client.
     github_client: Option<Octocrab>,
+
+    /// Optional remapping rules for URIs matching pattern
+    remaps: Option<Remaps>,
 
     /// Rules to decided whether each link would be checked or ignored.
     filter: Filter,
@@ -372,6 +390,8 @@ impl Client {
     {
         let Request { uri, source, .. } = request.try_into()?;
 
+        let uri = self.remap(uri)?;
+
         // TODO: Allow filtering based on element and attribute
         let status = if self.filter.is_excluded(&uri) {
             Status::Excluded
@@ -396,7 +416,23 @@ impl Client {
             }
         };
 
-        Ok(Response::new(uri, status, source))
+        Ok(Response::new(uri.to_owned(), status, source))
+    }
+
+    /// Remap URI using the client-defined remap patterns
+    #[must_use]
+    pub fn remap(&self, uri: Uri) -> Result<Uri> {
+        let remaps = match self.remaps {
+            Some(ref remaps) => remaps,
+            None => return Ok(uri),
+        };
+        let mut uri = uri;
+        for (pattern, new_url) in remaps {
+            if pattern.is_match(uri.as_str()) {
+                uri = Uri::try_from(new_url.to_owned())?
+            }
+        }
+        Ok(uri)
     }
 
     /// Returns whether the given `uri` should be ignored from checking.

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -79,7 +79,7 @@ pub struct ClientBuilder {
     /// Remap URIs matching a pattern to a different URI
     ///
     /// This makes it possible to remap any HTTP/HTTPS endpoint to a different
-    /// HTTP/HTTPS endpoint. Also, this feature could also be used to proxy
+    /// HTTP/HTTPS endpoint. This feature could also be used to proxy
     /// certain requests.
     ///
     /// Use with caution because a large set of remapping rules may cause

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -422,17 +422,10 @@ impl Client {
     /// Remap URI using the client-defined remap patterns
     #[must_use]
     pub fn remap(&self, uri: Uri) -> Result<Uri> {
-        let remaps = match self.remaps {
-            Some(ref remaps) => remaps,
-            None => return Ok(uri),
-        };
-        let mut uri = uri;
-        for (pattern, new_url) in remaps {
-            if pattern.is_match(uri.as_str()) {
-                uri = Uri::try_from(new_url.to_owned())?
-            }
+        match self.remaps {
+            Some(ref remaps) => remaps.remap(uri),
+            None => Ok(uri),
         }
-        Ok(uri)
     }
 
     /// Returns whether the given `uri` should be ignored from checking.

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -416,11 +416,14 @@ impl Client {
             }
         };
 
-        Ok(Response::new(uri.to_owned(), status, source))
+        Ok(Response::new(uri.clone(), status, source))
     }
 
     /// Remap URI using the client-defined remap patterns
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the remapping value is not a URI
     pub fn remap(&self, uri: Uri) -> Result<Uri> {
         match self.remaps {
             Some(ref remaps) => remaps.remap(uri),

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -60,6 +60,10 @@ mod types;
 /// Functionality to extract URIs from inputs
 pub mod extract;
 
+/// Remapping rules which allow to map URIs matching a pattern to a different
+/// URI. Use in moderation as there are no safety- or performance guarantees.
+pub mod remap;
+
 /// Filters are a way to define behavior when encountering
 /// URIs that need to be treated differently, such as
 /// local IPs or e-mail addresses

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -1,0 +1,14 @@
+use regex::Regex;
+use reqwest::Url;
+
+/// Remaps allow mapping from a URI pattern to a different URI
+///
+/// Some use-cases are
+/// - Testing URIs prior to production deployment
+/// - Testing URIs behind a proxy
+///
+/// Be careful when using this feature because checking every link against a
+/// large set of regular expressions has a performance impact. Also there are no
+/// constraints on the URI mapping, so the rules might contradict with each
+/// other.
+pub type Remaps = Vec<(Regex, Url)>;

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -1,5 +1,10 @@
+use std::ops::Index;
+
+use crate::Result;
 use regex::Regex;
 use reqwest::Url;
+
+use crate::Uri;
 
 /// Remaps allow mapping from a URI pattern to a different URI
 ///
@@ -11,4 +16,66 @@ use reqwest::Url;
 /// large set of regular expressions has a performance impact. Also there are no
 /// constraints on the URI mapping, so the rules might contradict with each
 /// other.
-pub type Remaps = Vec<(Regex, Url)>;
+#[derive(Debug, Clone)]
+pub struct Remaps(Vec<(Regex, Url)>);
+
+impl Remaps {
+    /// Create a new remapper
+    pub fn new(patterns: Vec<(Regex, Url)>) -> Self {
+        Self(patterns)
+    }
+
+    /// Remap URI using the client-defined remap patterns
+    #[must_use]
+    pub fn remap(&self, uri: Uri) -> Result<Uri> {
+        let mut uri = uri;
+        for (pattern, new_url) in &self.0 {
+            if pattern.is_match(uri.as_str()) {
+                uri = Uri::try_from(new_url.to_owned())?
+            }
+        }
+        Ok(uri)
+    }
+
+    /// Get the number of defined remap rules
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Index<usize> for Remaps {
+    type Output = (Regex, Url);
+
+    fn index(&self, index: usize) -> &(regex::Regex, url::Url) {
+        &self.0[index]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_remap() {
+        let pattern = Regex::new("https://example.com").unwrap();
+        let uri = Uri::try_from("http://127.0.0.1:8080").unwrap();
+        let remaps = Remaps::new(vec![(pattern, uri.clone().url)]);
+
+        let input = Uri::try_from("https://example.com").unwrap();
+        let remapped = remaps.remap(input).unwrap();
+
+        assert_eq!(remapped, uri);
+    }
+
+    #[test]
+    fn test_remap_path() {
+        let pattern = Regex::new("../../issues").unwrap();
+        let uri = Uri::try_from("https://example.com").unwrap();
+        let remaps = Remaps::new(vec![(pattern, uri.clone().url)]);
+
+        let input = Uri::try_from("../../issues").unwrap();
+        let remapped = remaps.remap(input).unwrap();
+
+        assert_eq!(remapped, uri);
+    }
+}

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -21,23 +21,34 @@ pub struct Remaps(Vec<(Regex, Url)>);
 
 impl Remaps {
     /// Create a new remapper
+    #[must_use]
     pub fn new(patterns: Vec<(Regex, Url)>) -> Self {
         Self(patterns)
     }
 
     /// Remap URI using the client-defined remap patterns
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the remapping value is not a URI
     pub fn remap(&self, uri: Uri) -> Result<Uri> {
         let mut uri = uri;
-        for (pattern, new_url) in &self.0 {
+        for (pattern, new_uri) in &self.0 {
             if pattern.is_match(uri.as_str()) {
-                uri = Uri::try_from(new_url.to_owned())?
+                uri = Uri::try_from(new_uri.clone())?;
             }
         }
         Ok(uri)
     }
 
+    /// Returns `true` if there are no remappings defined.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Get the number of defined remap rules
+    #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
     }

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -64,7 +64,7 @@ pub enum ErrorKind {
     #[error("Error with base dir `{0}` : {1}")]
     InvalidBase(String, String),
     /// The given input can not be parsed into a valid URI remapping
-    #[error("Error with URI remap expression `{0}`")]
+    #[error("Error handling URI remap expression. Cannot parse into URI remapping: `{0}`")]
     InvalidUriRemap(String),
     /// The given path does not resolve to a valid file
     #[error("Cannot find local file {0}")]

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -44,7 +44,7 @@ pub enum ErrorKind {
     #[error("Github URL is invalid: {0}")]
     InvalidGithubUrl(String),
     /// The given string can not be parsed into a valid URL, e-mail address, or file path
-    #[error("Cannot parse string `{1}` as website url")]
+    #[error("Cannot parse string `{1}` as website url: {0}")]
     ParseUrl(#[source] url::ParseError, String),
     /// The given URI cannot be converted to a file path
     #[error("Cannot find file")]
@@ -65,7 +65,7 @@ pub enum ErrorKind {
     InvalidBase(String, String),
     /// The given input can not be parsed into a valid URI remapping
     #[error("Error with URI remap expression `{0}`")]
-    InvalidUrlRemap(String),
+    InvalidUriRemap(String),
     /// The given path does not resolve to a valid file
     #[error("Cannot find local file {0}")]
     FileNotFound(PathBuf),
@@ -188,7 +188,7 @@ impl Hash for ErrorKind {
             Self::UnreachableEmailAddress(u, ..) => u.hash(state),
             Self::InsecureURL(u, ..) => u.hash(state),
             Self::InvalidBase(base, e) => (base, e).hash(state),
-            Self::InvalidUrlRemap(remap) => (remap).hash(state),
+            Self::InvalidUriRemap(remap) => (remap).hash(state),
             Self::InvalidHeader(e) => e.to_string().hash(state),
             Self::InvalidGlobPattern(e) => e.to_string().hash(state),
             Self::Channel(e) => e.to_string().hash(state),

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -63,6 +63,9 @@ pub enum ErrorKind {
     /// The given string can not be parsed into a valid base URL or base directory
     #[error("Error with base dir `{0}` : {1}")]
     InvalidBase(String, String),
+    /// The given input can not be parsed into a valid URI remapping
+    #[error("Error with URI remap expression `{0}`")]
+    InvalidUrlRemap(String),
     /// The given path does not resolve to a valid file
     #[error("Cannot find local file {0}")]
     FileNotFound(PathBuf),
@@ -185,6 +188,7 @@ impl Hash for ErrorKind {
             Self::UnreachableEmailAddress(u, ..) => u.hash(state),
             Self::InsecureURL(u, ..) => u.hash(state),
             Self::InvalidBase(base, e) => (base, e).hash(state),
+            Self::InvalidUrlRemap(remap) => (remap).hash(state),
             Self::InvalidHeader(e) => e.to_string().hash(state),
             Self::InvalidGlobPattern(e) => e.to_string().hash(state),
             Self::Channel(e) => e.to_string().hash(state),


### PR DESCRIPTION
Allow users to remap URIs. Regular expressions are supported. Remappings get evaluated in order of definition. Multiple remappings are allowed.  
The format is similar to that of `markdown-link-check`.

## How it works ⚙️

Consider the following input:

```markdown
file://../../issues
https://example.com
https://example.org
https://example.net
```

Let's remap these inputs using the `--remap` parameter:

```sh
lychee --remap 'https://example.com http://127.0.0.1:8080' \
       --remap 'https://example.org https://staging.example.com' \
       --remap '../../issues https://github.com/usnistgov/OSCAL/issues' \
       -- input.md
```

This would check the following URIs:

```
https://github.com/usnistgov/OSCAL/issues
http://127.0.0.1:8080/
https://staging.example.com/
https://example.net/
```

## Caveats 🚩

* Be careful when using this feature because checking every link against a large set of regular expressions has a performance impact even though the Rust regex engine is very fast.
* There are no constraints on the URI mapping, so the rules might contradict each other. It's the user's responsibility to make sure this does not happen.
* File remappings might be a bit surprising. Files are handled as URIs internally and get prefixed with a `file://` scheme. As a consequence, using `^../../issues` as a remap pattern would never match. Instead `../../issues` (without the `^`) would work.


## Open Questions 🤔  (please provide feedback)

* Shall we first remap a URI and then check if it is excluded or vice versa? 🤔 







Fixes #547
