### PR TITLE
Add support for excluding paths from link checking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,7 @@ dependencies = [
  "http",
  "humantime",
  "indicatif",
+ "log",
  "lychee-lib",
  "once_cell",
  "openssl-sys",

--- a/README.md
+++ b/README.md
@@ -234,9 +234,8 @@ OPTIONS:
         --basic-auth <basic-auth>              Basic authentication support. E.g. `username:password`
     -c, --config <config-file>                 Configuration file to use [default: ./lychee.toml]
         --exclude <exclude>...                 Exclude URLs from checking (supports regex)
-        --exclude-file <exclude-file>...       File or files that contain URLs to be excluded from checking. Regular
-                                               expressions supported; one pattern per line. Automatically excludes
-                                               patterns from `.lycheeignore` if file exists
+        --exclude-file <exclude-file>...       Deprecated; use `--exclude-path` instead
+        --exclude-path <exclude-path>...       Exclude file path from getting checked
     -f, --format <format>                      Output format of final status report (compact, detailed, json, markdown)
                                                [default: compact]
         --github-token <github-token>          GitHub API token to use when checking github.com links, to avoid rate

--- a/examples/collect_links/collect_links.rs
+++ b/examples/collect_links/collect_links.rs
@@ -13,10 +13,12 @@ async fn main() -> Result<()> {
                 Url::parse("https://github.com/lycheeverse/lychee").unwrap(),
             )),
             file_type_hint: None,
+            excluded_paths: None,
         },
         Input {
             source: InputSource::FsPath(PathBuf::from("fixtures/TEST.md")),
             file_type_hint: None,
+            excluded_paths: None,
         },
     ];
 

--- a/fixtures/exclude-path/dir1/TEST.md
+++ b/fixtures/exclude-path/dir1/TEST.md
@@ -1,0 +1,1 @@
+https://example.com/excluded_dir

--- a/fixtures/exclude-path/dir2/TEST.md
+++ b/fixtures/exclude-path/dir2/TEST.md
@@ -1,0 +1,1 @@
+https://example.com

--- a/fixtures/exclude-path/dir2/subdir/TEST.md
+++ b/fixtures/exclude-path/dir2/subdir/TEST.md
@@ -1,0 +1,1 @@
+https://example.com/excluded_subdir

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -47,6 +47,7 @@ csv = "1.1.6"
 humantime = "2.1.0"
 secrecy = { version = "0.8.0", features = ["serde"] }
 supports-color = "1.3.0"
+log = "0.4.17"
 
 [dev-dependencies]
 assert_cmd = "2.0.4"

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -8,7 +8,7 @@ use crate::ExitCode;
 use super::CommandParams;
 
 /// Dump all detected links to stdout without checking them
-pub(crate) async fn dump<'a, S>(params: CommandParams<S>) -> Result<ExitCode>
+pub(crate) async fn dump<S>(params: CommandParams<S>) -> Result<ExitCode>
 where
     S: futures::Stream<Item = Result<Request>>,
 {

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -58,20 +58,20 @@
 #![deny(anonymous_parameters, macro_use_extern_crate, pointer_structural_match)]
 #![deny(missing_docs)]
 
-use color::YELLOW;
-use commands::CommandParams;
-use formatters::response::ResponseFormatter;
-use lychee_lib::Collector;
-// required for apple silicon
-use ring as _;
-
-use anyhow::{Context, Error, Result};
-use openssl_sys as _; // required for vendored-openssl feature
-use ring as _;
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, ErrorKind, Write};
 use std::sync::Arc;
+
+use anyhow::{Context, Error, Result};
+use color::YELLOW;
+use commands::CommandParams;
+use formatters::response::ResponseFormatter;
+use log::warn;
+use openssl_sys as _; // required for vendored-openssl feature
+use ring as _; // required for apple silicon
 use structopt::StructOpt;
+
+use lychee_lib::Collector;
 
 mod cache;
 mod client;
@@ -140,6 +140,11 @@ fn load_config() -> Result<LycheeOptions> {
 
     if let Ok(lycheeignore) = File::open(LYCHEE_IGNORE_FILE) {
         opts.config.exclude.append(&mut read_lines(&lycheeignore)?);
+    }
+
+    // TODO: Remove this warning and the parameter in a future release
+    if !&opts.config.exclude_file.is_empty() {
+        warn!("WARNING: `--exclude-file` is deprecated and will soon be removed; use `{}` file to ignore URL patterns instead. To exclude paths of files and directories, use `--exclude-path`.", LYCHEE_IGNORE_FILE);
     }
 
     // Load excludes from file

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -695,4 +695,27 @@ mod cli {
 
         Ok(())
     }
+
+    #[test]
+    fn test_excluded_paths() -> Result<()> {
+        let test_path = fixtures_path().join("exclude-path");
+
+        let excluded_path1 = test_path.join("dir1");
+        let excluded_path2 = test_path.join("dir2").join("subdir");
+        let mut cmd = main_command();
+
+        cmd.arg("--exclude-path")
+            .arg(&excluded_path1)
+            .arg(&excluded_path2)
+            .arg("--")
+            .arg(&test_path)
+            .assert()
+            .success()
+            // Links in excluded files are not taken into account in the total
+            // number of links.
+            .stdout(contains("1 Total"))
+            .stdout(contains("1 OK"));
+
+        Ok(())
+    }
 }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -49,7 +49,7 @@ pub const DEFAULT_USER_AGENT: &str = concat!("lychee/", env!("CARGO_PKG_VERSION"
 /// A timeout for only the connect phase of a Client.
 const CONNECT_TIMEOUT: u64 = 10;
 /// TCP keepalive
-/// See `https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html` for more info
+/// See <https://tldp.org/HOWTO/TCP-Keepalive-HOWTO/overview.html> for more info
 const TCP_KEEPALIVE: u64 = 60;
 
 /// Builder for [`Client`].

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -115,7 +115,7 @@ mod test {
         // Treat as plaintext file (no extension)
         let file_path = temp_dir.path().join("README");
         let _file = File::create(&file_path).unwrap();
-        let input = Input::new(&file_path.as_path().display().to_string(), None, true)?;
+        let input = Input::new(&file_path.as_path().display().to_string(), None, true, None)?;
         let contents: Vec<_> = input.get_contents(true).await.collect::<Vec<_>>().await;
 
         assert_eq!(contents.len(), 1);
@@ -125,7 +125,7 @@ mod test {
 
     #[tokio::test]
     async fn test_url_without_extension_is_html() -> Result<()> {
-        let input = Input::new("https://example.com/", None, true)?;
+        let input = Input::new("https://example.com/", None, true, None)?;
         let contents: Vec<_> = input.get_contents(true).await.collect::<Vec<_>>().await;
 
         assert_eq!(contents.len(), 1);
@@ -156,6 +156,7 @@ mod test {
             Input {
                 source: InputSource::String(TEST_STRING.to_owned()),
                 file_type_hint: None,
+                excluded_paths: None,
             },
             Input {
                 source: InputSource::RemoteUrl(Box::new(
@@ -164,10 +165,12 @@ mod test {
                         .unwrap(),
                 )),
                 file_type_hint: None,
+                excluded_paths: None,
             },
             Input {
                 source: InputSource::FsPath(file_path),
                 file_type_hint: None,
+                excluded_paths: None,
             },
             Input {
                 source: InputSource::FsGlob {
@@ -175,6 +178,7 @@ mod test {
                     ignore_case: true,
                 },
                 file_type_hint: None,
+                excluded_paths: None,
             },
         ];
 
@@ -199,6 +203,7 @@ mod test {
         let input = Input {
             source: InputSource::String("This is [a test](https://endler.dev). This is a relative link test [Relative Link Test](relative_link)".to_string()),
             file_type_hint: Some(FileType::Markdown),
+                excluded_paths: None,
         };
         let links = collect(vec![input], Some(base)).await;
 
@@ -224,6 +229,7 @@ mod test {
                     .to_string(),
             ),
             file_type_hint: Some(FileType::Html),
+            excluded_paths: None,
         };
         let links = collect(vec![input], Some(base)).await;
 
@@ -252,6 +258,7 @@ mod test {
                 .to_string(),
             ),
             file_type_hint: Some(FileType::Html),
+            excluded_paths: None,
         };
         let links = collect(vec![input], Some(base)).await;
 
@@ -277,6 +284,7 @@ mod test {
                     .to_string(),
             ),
             file_type_hint: Some(FileType::Markdown),
+            excluded_paths: None,
         };
 
         let links = collect(vec![input], Some(base)).await;
@@ -299,6 +307,7 @@ mod test {
         let input = Input {
             source: InputSource::String(input),
             file_type_hint: Some(FileType::Html),
+            excluded_paths: None,
         };
         let links = collect(vec![input], Some(base)).await;
 
@@ -331,6 +340,7 @@ mod test {
         let input = Input {
             source: InputSource::RemoteUrl(Box::new(server_uri.clone())),
             file_type_hint: None,
+            excluded_paths: None,
         };
 
         let links = collect(vec![input], None).await;


### PR DESCRIPTION
This change deprecates `--exclude-file` as it was ambiguous.
Instead, `--exclude-path` was introduced to support excluding paths
to files and directories that should not be checked.
Furthermore, `.lycheeignore` is now the only way
to exclude URL patterns.

Fixes https://github.com/lycheeverse/lychee/issues/418.