### PR TITLE
Exclude example domains as per RFC 2606 from checking

### DIFF
--- a/fixtures/TEST_EXAMPLE_DOMAINS.md
+++ b/fixtures/TEST_EXAMPLE_DOMAINS.md
@@ -1,0 +1,7 @@
+http://example.com
+https://github.com/rust-lang/rust
+https://example.com
+http://example.org
+https://www.rust-lang.org/
+http://foo.example.org
+http://example.net/foo/bar

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -68,3 +68,13 @@ tracing-subscriber = { version = "0.3.11", default-features = false, features = 
 [features]
 #tokio-console = ["console-subscriber", "tracing-subscriber/registry"]
 vendored-openssl = ["openssl-sys/vendored"]
+check_example_domains = ["lychee-lib/check_example_domains"]
+
+# Unfortunately, it's not possible to automatically enable features
+# for cargo test. See rust-lang/cargo#2911.
+# As a workaround we introduce a new feature to allow example domains
+# in integration tests.
+[[test]]
+name = "cli"
+path = "tests/cli.rs"
+required-features = ["check_example_domains"]

--- a/lychee-bin/tests/example_domains.rs
+++ b/lychee-bin/tests/example_domains.rs
@@ -1,3 +1,6 @@
+//! The rest of the integration tests make heavy use of example domains, so
+//! we use a separate module for testing that the exclusion of these domains
+//! works as expected for normal users.
 #[cfg(test)]
 mod cli {
     use std::{

--- a/lychee-bin/tests/example_domains.rs
+++ b/lychee-bin/tests/example_domains.rs
@@ -1,0 +1,44 @@
+#[cfg(test)]
+mod cli {
+    use std::{
+        error::Error,
+        path::{Path, PathBuf},
+    };
+
+    use assert_cmd::Command;
+    use predicates::str::contains;
+
+    type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+    fn fixtures_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("fixtures")
+    }
+
+    fn main_command() -> Command {
+        // this gets the "main" binary name (e.g. `lychee`)
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name")
+    }
+
+    #[test]
+    fn test_exclude_example_domains() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("TEST_EXAMPLE_DOMAINS.md");
+
+        let cmd = cmd
+            .arg(input)
+            .arg("--dump")
+            .assert()
+            .success()
+            .stdout(contains("https://github.com/rust-lang/rust"))
+            .stdout(contains("https://www.rust-lang.org/"));
+
+        let output = cmd.get_output();
+        let output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(output.lines().count(), 2);
+
+        Ok(())
+    }
+}

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -64,4 +64,12 @@ tempfile = "3.3.0"
 wiremock = "0.5.13"
 
 [features]
+# Vendor OpenSSL instead of dynamically linking it at runtime.
 vendored-openssl = ["openssl-sys/vendored"]
+# Feature flag to include checking reserved example domains 
+# as per RFC 2606, section 3.
+# This flag is off by default and only exists to allow example domains in
+# integration tests, which don't respect `#[cfg(test)]`.
+# See https://users.rust-lang.org/t/36630
+check_example_domains = []
+default = []

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -18,6 +18,7 @@ lazy_static! {
         HashSet::from_iter(["example.com", "example.org", "example.net", "example.edu"]);
 }
 
+// Allow usage of example domains in tests
 #[cfg(any(test, feature = "check_example_domains"))]
 lazy_static! {
     static ref EXAMPLE_DOMAINS: HashSet<&'static str> = HashSet::new();
@@ -48,8 +49,8 @@ pub fn is_false_positive(input: &str) -> bool {
 pub fn is_example_domain(uri: &Uri) -> bool {
     let res = match uri.domain() {
         Some(domain) => {
-            // It is not enough to check if `EXAMPLE_DOMAINS.contains(domain)`
-            // as this would not include checks for subdomains such as
+            // It is not enough to use `EXAMPLE_DOMAINS.contains(domain)` here
+            // as this would not include checks for subdomains, such as
             // `foo.example.com`
             EXAMPLE_DOMAINS.iter().any(|tld| domain.ends_with(tld))
         }

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -1,12 +1,27 @@
 mod excludes;
 mod includes;
 
+use lazy_static::lazy_static;
 use std::collections::HashSet;
 
 pub use excludes::Excludes;
 pub use includes::Includes;
 
 use crate::Uri;
+
+#[cfg(all(not(test), not(feature = "check_example_domains")))]
+lazy_static! {
+    /// These domains are explicitly defined by RFC 2606, section 3 Reserved Example
+    /// Second Level Domain Names for describing example cases and should not be
+    /// dereferenced as they should not have content.
+    static ref EXAMPLE_DOMAINS: HashSet<&'static str> =
+        HashSet::from_iter(["example.com", "example.org", "example.net", "example.edu"]);
+}
+
+#[cfg(any(test, feature = "check_example_domains"))]
+lazy_static! {
+    static ref EXAMPLE_DOMAINS: HashSet<&'static str> = HashSet::new();
+}
 
 /// Pre-defined exclusions for known false-positives
 const FALSE_POSITIVE_PAT: &[&str] = &[
@@ -24,6 +39,23 @@ const FALSE_POSITIVE_PAT: &[&str] = &[
 /// `Include` pattern, which will match on a false positive
 pub fn is_false_positive(input: &str) -> bool {
     FALSE_POSITIVE_PAT.iter().any(|pat| input.starts_with(pat))
+}
+
+#[inline]
+#[must_use]
+/// Check if the host belongs to a known example domain as defined in
+/// [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606)
+pub fn is_example_domain(uri: &Uri) -> bool {
+    let res = match uri.domain() {
+        Some(domain) => {
+            // It is not enough to check if `EXAMPLE_DOMAINS.contains(domain)`
+            // as this would not include checks for subdomains such as
+            // `foo.example.com`
+            EXAMPLE_DOMAINS.iter().any(|tld| domain.ends_with(tld))
+        }
+        None => false,
+    };
+    res
 }
 
 /// A generic URI filter
@@ -134,6 +166,7 @@ impl Filter {
             || self.is_ip_excluded(uri)
             || self.is_host_excluded(uri)
             || self.is_scheme_excluded(uri)
+            || is_example_domain(uri)
         {
             return true;
         }
@@ -151,14 +184,14 @@ impl Filter {
             return false;
         }
 
-        if is_false_positive(input)
         // Exclude well-known false-positives
         // Performed after checking includes to allow user-overwrites
-                || self.is_excludes_empty()
+        if is_false_positive(input)
                 // Previous checks imply input is not explicitly included.
                 // If exclude rules are empty, then *presumably excluded*
-            || self.is_excludes_match(input)
-        // If exclude rules match input, then *explicitly excluded*
+                || self.is_excludes_empty()
+                // If exclude rules match input, then *explicitly excluded*
+                || self.is_excludes_match(input)
         {
             return true;
         }


### PR DESCRIPTION
This skips example domains from checking.
I decided to not make this configurable by the user and instead always
skip example domains except while running tests.

Unfortunately, it's not possible to automatically enable features
for `cargo test`. See https://github.com/rust-lang/cargo/issues/2911.

As a workaround to allow for using example domains for unit- and integration
tests,  we introduce a new feature, `check_example_domains`, which is
disabled by default for normal users. The feature gets activated for the
integration test which checks that the example domain exclusion works as
expected.

Closes https://github.com/lycheeverse/lychee/issues/551.
