### PR TITLE
Replace lazy hashset with matches!

### DIFF
--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+
 
 use crate::types::{uri::raw::RawUri, FileType, InputContent};
 

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -8,26 +8,23 @@ mod markdown;
 mod plaintext;
 
 use markdown::extract_markdown;
-use once_cell::sync::Lazy;
 use plaintext::extract_plaintext;
 
-/// HTML elements that are deemed verbatim (i.e. preformatted).
-/// These will be excluded from link checking by default.
-static VERBATIM_ELEMENTS: Lazy<HashSet<String>> = Lazy::new(|| {
-    HashSet::from_iter([
-        "pre".into(),
-        "code".into(),
-        "textarea".into(),
-        "samp".into(),
-        "xmp".into(),
-        "plaintext".into(),
-        "listing".into(),
-    ])
-});
 
 /// Check if the given element is in the list of preformatted tags
+///
+/// preformatted tags are HTML elements that are deemed verbatim (i.e. preformatted).  These will
+/// be excluded from link checking by default.
 pub(crate) fn is_verbatim_elem(name: &str) -> bool {
-    VERBATIM_ELEMENTS.contains(name)
+    matches!(name, 
+        "pre"|
+        "code"|
+        "textarea"|
+        "samp"|
+        "xmp"|
+        "plaintext"|
+        "listing"
+    )
 }
 
 /// A handler for extracting links from various input formats like Markdown and

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -1,5 +1,3 @@
-
-
 use crate::types::{uri::raw::RawUri, FileType, InputContent};
 
 mod html5ever;
@@ -10,20 +8,14 @@ mod plaintext;
 use markdown::extract_markdown;
 use plaintext::extract_plaintext;
 
-
 /// Check if the given element is in the list of preformatted tags
 ///
 /// preformatted tags are HTML elements that are deemed verbatim (i.e. preformatted).  These will
 /// be excluded from link checking by default.
 pub(crate) fn is_verbatim_elem(name: &str) -> bool {
-    matches!(name, 
-        "pre"|
-        "code"|
-        "textarea"|
-        "samp"|
-        "xmp"|
-        "plaintext"|
-        "listing"
+    matches!(
+        name,
+        "pre" | "code" | "textarea" | "samp" | "xmp" | "plaintext" | "listing"
     )
 }
 

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -8,10 +8,9 @@ mod plaintext;
 use markdown::extract_markdown;
 use plaintext::extract_plaintext;
 
-/// Check if the given element is in the list of preformatted tags
+/// Check if the given element is in the list of preformatted ("verbatim") tags.
 ///
-/// preformatted tags are HTML elements that are deemed verbatim (i.e. preformatted).  These will
-/// be excluded from link checking by default.
+/// These will be excluded from link checking by default.
 pub(crate) fn is_verbatim_elem(name: &str) -> bool {
     matches!(
         name,


### PR DESCRIPTION
llvm will typically create much faster code than accessing a hashset at
runtime

~source: trust me bro~ actually ran benchmarks now