### PR TITLE
Add flag to force html mode

### DIFF
--- a/fixtures/configs/smoketest.toml
+++ b/fixtures/configs/smoketest.toml
@@ -87,6 +87,9 @@ include_verbatim = false
 # Ignore case of paths when matching glob patterns.
 glob_ignore_case = false
 
+# Treat input as HTML
+html = false
+
 # Exclude URLs from checking (supports regex).
 exclude = [ '.*\.github.com\.*' ]
 

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -86,6 +86,9 @@ include_verbatim = false
 # Ignore case of paths when matching glob patterns.
 glob_ignore_case = false
 
+# Treat the input as HTML.
+html = false
+
 # Exclude URLs from checking (supports regex).
 exclude = [ '.*\.github.com\.*' ]
 


### PR DESCRIPTION
This is an attempt to address #671 by adding a flag `--html` to parse
the input as HTML.  Otherwise, STDIN and local files without the `.html`
suffix are parsed as plain text.
