### PR TITLE
Add status code in Markdown output

### DIFF
--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -105,6 +105,8 @@ impl StatsFormatter for Markdown {
 
 #[cfg(test)]
 mod tests {
+    use lychee_lib::{CacheStatus, InputSource, Response, ResponseBody, Status, Uri};
+
     use super::*;
 
     #[test]
@@ -122,5 +124,38 @@ mod tests {
 | 🚫 Errors     | 0     |
 "#;
         assert_eq!(table, expected.to_string());
+    }
+
+    #[test]
+    fn test_render_summary() {
+        let mut stats = ResponseStats::new();
+        let response = Response(
+            InputSource::Stdin,
+            ResponseBody {
+                uri: Uri::try_from("http://127.0.0.1").unwrap(),
+                status: Status::Cached(CacheStatus::Error(Some(404))),
+            },
+        );
+        stats.add(response);
+        let summary = MarkdownResponseStats(stats);
+        let expected = r#"## Summary
+
+| Status        | Count |
+|---------------|-------|
+| 🔍 Total      | 1     |
+| ✅ Successful | 0     |
+| ⏳ Timeouts   | 0     |
+| 🔀 Redirected | 0     |
+| 👻 Excluded   | 0     |
+| ❓ Unknown    | 0     |
+| 🚫 Errors     | 1     |
+
+
+## Errors per input
+### Errors in stdin
+* [http://127.0.0.1/](http://127.0.0.1/): Cached: Error (cached) (status code: 404)
+
+"#;
+        assert_eq!(summary.to_string(), expected.to_string());
     }
 }

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -73,8 +73,11 @@ impl Display for MarkdownResponseStats {
                 for response in responses {
                     writeln!(
                         f,
-                        "* [{}]({}): {}",
-                        response.uri, response.uri, response.status
+                        "* [{}]({}): {} (status code: {})",
+                        response.uri,
+                        response.uri,
+                        response.status,
+                        response.status.code()
                     )?;
                 }
                 writeln!(f)?;


### PR DESCRIPTION
# Fix #672 

Small change to the `MarkdownResponseStats::fmt` method to ensure the final summary includes the status code for any error. This should hopefully make it easier to track down the root problem for any troublesome link.

Also adds a new tests for `MarkdownResponseStat` that verifies the "Summary" format and checks that the status code is included in error message output (to prevent any future regressions)

Manual run showing the new output for a 404 link:
```shell
cargo run -- --verbose --format markdown fixtures/TEST_GITHUB_404.md
✗ [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man | Network error: Not Found

## Summary

| Status        | Count |
|---------------|-------|
| 🔍 Total      | 1     |
| ✅ Successful | 0     |
| ⏳ Timeouts   | 0     |
| 🔀 Redirected | 0     |
| 👻 Excluded   | 0     |
| ❓ Unknown    | 0     |
| 🚫 Errors     | 1     |


## Errors per input
### Errors in fixtures/TEST_GITHUB_404.md
* [https://github.com/mre/idiomatic-rust-doesnt-exist-man](https://github.com/mre/idiomatic-rust-doesnt-exist-man): Failed: Network error (status code: 404) 
```

Let me know what you think!