### PR TITLE
Update to gracefully handle nonexistent relative paths

### DIFF
--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -827,4 +827,43 @@ mod cli {
 
         Ok(())
     }
+
+    #[test]
+    fn test_handle_relative_paths_as_input() -> Result<()> {
+        let test_path = fixtures_path();
+        let mut cmd = main_command();
+
+        cmd.current_dir(&test_path)
+            .arg("--verbose")
+            .arg("--exclude")
+            .arg("example.*")
+            .arg("--")
+            .arg("./TEST_DUMP_EXCLUDE.txt")
+            .assert()
+            .success()
+            .stdout(contains("3 Total"))
+            .stdout(contains("3 Excluded"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_handle_nonexistent_relative_paths_as_input() -> Result<()> {
+        let test_path = fixtures_path();
+        let mut cmd = main_command();
+
+        cmd.current_dir(&test_path)
+            .arg("--verbose")
+            .arg("--exclude")
+            .arg("example.*")
+            .arg("--")
+            .arg("./NOT-A-REAL-TEST-FIXTURE.md")
+            .assert()
+            .failure()
+            .stderr(contains(
+                "Cannot find local file ./NOT-A-REAL-TEST-FIXTURE.md",
+            ));
+
+        Ok(())
+    }
 }

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -148,7 +148,7 @@ impl Input {
                 if path.exists() {
                     InputSource::FsPath(path)
                 } else if path.is_relative() {
-                    // If the file does not exist and it is a relative path exit immediately
+                    // If the file does not exist and it is a relative path, exit immediately
                     return Err(ErrorKind::FileNotFound(path));
                 } else {
                     // Invalid path; check if a valid URL can be constructed from the input

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -147,6 +147,8 @@ impl Input {
                 let path = PathBuf::from(value);
                 if path.exists() {
                     InputSource::FsPath(path)
+                } else if path.is_relative() {
+                    return Err(ErrorKind::FileNotFound(path));
                 } else {
                     // Invalid path; check if a valid URL can be constructed from the input
                     // by prefixing it with a `http://` scheme.
@@ -373,6 +375,13 @@ fn is_excluded_path(excluded_paths: &[PathBuf], path: &PathBuf) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_input_gracefully_handles_nonexistent_relative_paths() {
+        let input = Input::new("./relative/path", None, false, None);
+        assert!(input.is_err());
+        assert!(matches!(input, Err(ErrorKind::FileNotFound(..))));
+    }
 
     #[test]
     fn test_valid_extension() {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -399,7 +399,13 @@ mod tests {
 
     #[test]
     fn test_input_handles_nonexistent_relative_paths() {
-        let input = Input::new("./nonexistent/relative/path", None, false, None);
+        let test_file = "./nonexistent/relative/path";
+        let path = Path::new(test_file);
+
+        assert!(!path.exists());
+        assert!(path.is_relative());
+
+        let input = Input::new(test_file, None, false, None);
         assert!(input.is_err());
         assert!(matches!(
             input,


### PR DESCRIPTION
# Fix #666

Update `Input::new` to immediately exit when the input is a relative path that does not exist. The early return helps guarantee the input is not coerced into a URL that will take 30 seconds to resolve.

Also adds a small test to validate the new behavior.

I tried to follow the guidance from this comment when resolving the issue: https://github.com/lycheeverse/lychee/issues/666#issuecomment-1172172797