### PR TITLE
Skip caching unsupported and excluded URLs

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -449,8 +449,9 @@ impl Client {
                 return Status::Error(ErrorKind::InvalidURI(uri.clone()));
             }
             // This is merely a URI with a scheme that is not supported by
-            // reqwest yet. It would be safe to pass that to reqwest and it wouldn't
-            // panic, but it's also unnecessary, because it would simply return an error.
+            // reqwest yet. It would be safe to pass that to reqwest and it
+            // wouldn't panic, but it's also unnecessary, because it would
+            // simply return an error.
             return Status::Unsupported(ErrorKind::InvalidURI(uri.clone()));
         }
 

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -16,6 +16,11 @@ pub enum CacheStatus {
     /// The request was excluded (skipped)
     Excluded,
     /// The protocol is not yet supported
+    // We no longer cache unsupported files as they might be supported in future
+    // versions.
+    // Nevertheless, keep for compatibility when deserializing older cache
+    // files, even though this no longer gets serialized. Can be removed at a
+    // later point in time.
     Unsupported,
 }
 
@@ -27,6 +32,9 @@ impl<'de> Deserialize<'de> for CacheStatus {
         let status = <&str as Deserialize<'de>>::deserialize(deserializer)?;
         match status {
             "Excluded" => Ok(CacheStatus::Excluded),
+            // Keep for compatibility with older cache files, even though this
+            // no longer gets serialized. Can be removed at a later point in
+            // time.
             "Unsupported" => Ok(CacheStatus::Unsupported),
             other => match other.parse::<u16>() {
                 Ok(code) => match code {

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -34,7 +34,7 @@ pub enum Status {
     /// Resource was excluded from checking
     Excluded,
     /// The request type is currently not supported,
-    /// for example when the URL scheme is `slack://` or `file://`
+    /// for example when the URL scheme is `slack://`.
     /// See https://github.com/lycheeverse/lychee/issues/199
     Unsupported(ErrorKind),
     /// Cached request status from previous run


### PR DESCRIPTION
As discussed in https://github.com/lycheeverse/lychee/issues/647#issuecomment-1170773449, it does not make much sense to cache unsupported
and excluded URLs.
Unsupported URLs might be supported in the future and caching them
would mean they won't get checked then. Excluded URLs were
excluded for a reason and should not appear in the cache.
Furthermore they might not be excluded
in a consecutive run, leading to a false-positive.