### PR TITLE
Reorder md output

### DIFF
--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -73,11 +73,11 @@ impl Display for MarkdownResponseStats {
                 for response in responses {
                     writeln!(
                         f,
-                        "* [{}]({}): {} (status code: {})",
+                        "* [{}] [{}]({}) | {}",
+                        response.status.code(),
                         response.uri,
                         response.uri,
-                        response.status,
-                        response.status.code()
+                        response.status
                     )?;
                 }
                 writeln!(f)?;
@@ -153,7 +153,7 @@ mod tests {
 
 ## Errors per input
 ### Errors in stdin
-* [http://127.0.0.1/](http://127.0.0.1/): Cached: Error (cached) (status code: 404)
+* [404] [http://127.0.0.1/](http://127.0.0.1/) | Cached: Error (cached)
 
 "#;
         assert_eq!(summary.to_string(), expected.to_string());


### PR DESCRIPTION
As mentioned in #694, this is a first simple and quick improvement to the md output that brings it more in line with what is shown in the console and helps with spotting the error type.
Until there is agreement on a new, better and uniform style and somebody has time to implement that, this should be a little improvement in the meantime.

old:
- [mre/idiomatic-rust-doesnt-exist-man](https://github.com/mre/idiomatic-rust-doesnt-exist-man): Failed: Network error (status code: 404)

new:
- [404] [mre/idiomatic-rust-doesnt-exist-man](https://github.com/mre/idiomatic-rust-doesnt-exist-man) | Failed: Network error

<br>

I hope I got it right. :)