### PR TITLE
Listing InnerSourceCommons/InnerSourcePatterns as user

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ We collect a list of common workarounds for various websites in our [troubleshoo
 
 ## Users
 
+- https://github.com/InnerSourceCommons/InnerSourcePatterns
 - https://github.com/opensearch-project/OpenSearch
 - https://github.com/ramitsurana/awesome-kubernetes
 - https://github.com/papers-we-love/papers-we-love


### PR DESCRIPTION
The repo [InnerSourceCommons/InnerSourcePatterns](https://github.com/InnerSourceCommons/InnerSourcePatterns) is using lychee as a link checker since a couple of days.
(we found the recommendation for it in the liche repo)

I wasn't clear if we should add the new user/repo at top or bottom of the list.
Went for the top :)

Thank you for this great tool!