### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ token with no extra permissions is enough to be able to check public repos links
 There is an extensive list of commandline parameters to customize the behavior.
 See below for a full list.
 
-```ignore
+```text
 USAGE:
     lychee [OPTIONS] <inputs>...
 

--- a/lychee-bin/tests/usage.rs
+++ b/lychee-bin/tests/usage.rs
@@ -44,13 +44,13 @@ mod readme {
             .expect("Invalid utf8 output for `--help`");
         let readme = load_readme_text();
 
-        const BACKTICKS_OFFSET: usize = 9; // marker: ```ignore
+        const BACKTICKS_OFFSET: usize = 7; // marker: ```text
         const NEWLINE_OFFSET: usize = 1;
 
         let usage_start = BACKTICKS_OFFSET
             + NEWLINE_OFFSET
             + readme
-                .find("```ignore\nUSAGE:\n")
+                .find("```text\nUSAGE:\n")
                 .expect("Couldn't find USAGE section in README.md");
 
         let usage_end = readme[usage_start..]


### PR DESCRIPTION
The help message was highlighted as if it was a gitignore file.
Let's disable this spurious syntax highlighting.