### PR TITLE
Extend description of "--exclude" to also exclude email addresses, not only URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ OPTIONS:
             Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
 
         --exclude <EXCLUDE>
-            Exclude URLs from checking (supports regex)
+            Exclude URLs and mail addresses from checking (supports regex)
 
         --exclude-file <EXCLUDE_FILE>
             Deprecated; use `--exclude-path` instead

--- a/fixtures/configs/smoketest.toml
+++ b/fixtures/configs/smoketest.toml
@@ -87,7 +87,7 @@ include_verbatim = false
 # Ignore case of paths when matching glob patterns.
 glob_ignore_case = false
 
-# Exclude URLs from checking (supports regex).
+# Exclude URLs and mail addresses from checking (supports regex).
 exclude = [ '.*\.github.com\.*' ]
 
 # Exclude these filesystem paths from getting checked.

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -216,7 +216,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) include: Vec<String>,
 
-    /// Exclude URLs from checking (supports regex)
+    /// Exclude URLs and mail addresses from checking (supports regex)
     #[clap(long)]
     #[serde(default)]
     pub(crate) exclude: Vec<String>,

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -86,7 +86,7 @@ include_verbatim = false
 # Ignore case of paths when matching glob patterns.
 glob_ignore_case = false
 
-# Exclude URLs from checking (supports regex).
+# Exclude URLs and mail addresses from checking (supports regex).
 exclude = [ '.*\.github.com\.*' ]
 
 # Exclude these filesystem paths from getting checked.


### PR DESCRIPTION
Having this help available:
```
$ lychee --help
[...]
--exclude <exclude>...                 Exclude URLs from checking (supports regex)
[...]
--exclude-mail           Exclude all mail addresses from checking
[...]
```

makes me think "How to I exclude single email addresses?".
The answer is: `--exclude` does this as well.
For me, this was not clear from the start.

This pull requests changes the help text for the `--exclude` argument from

> Exclude URLs from checking (supports regex)

to

> Exclude URLs and mail addresses from checking (supports regex)