### PR TITLE
Don't check example mail addresses by default

### DIFF
--- a/fixtures/TEST_EXAMPLE_DOMAINS.md
+++ b/fixtures/TEST_EXAMPLE_DOMAINS.md
@@ -1,7 +1,13 @@
 http://example.com
 https://github.com/rust-lang/rust
 https://example.com
+hi@example.edu
 http://example.org
 https://www.rust-lang.org/
+test@foo.example.org
 http://foo.example.org
+mailto:foo@bar.dev
+mailto:hello@example.com?subject=hello
 http://example.net/foo/bar
+mail@example.com
+mail@somedomain.com

--- a/lychee-bin/tests/example_domains.rs
+++ b/lychee-bin/tests/example_domains.rs
@@ -35,12 +35,14 @@ mod cli {
             .arg("--dump")
             .assert()
             .success()
+            .stdout(contains("mail@somedomain.com"))
+            .stdout(contains("foo@bar.dev"))
             .stdout(contains("https://github.com/rust-lang/rust"))
             .stdout(contains("https://www.rust-lang.org/"));
 
         let output = cmd.get_output();
         let output = std::str::from_utf8(&output.stdout).unwrap();
-        assert_eq!(output.lines().count(), 2);
+        assert_eq!(output.lines().count(), 4);
 
         Ok(())
     }

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -55,7 +55,16 @@ pub fn is_example_domain(uri: &Uri) -> bool {
             // `foo.example.com`
             EXAMPLE_DOMAINS.iter().any(|tld| domain.ends_with(tld))
         }
-        None => false,
+        None => {
+            // Check if the URI is an email address.
+            // e.g. `mailto:mail@example.com`
+            // In this case, the domain is part of the path
+            if uri.is_mail() {
+                EXAMPLE_DOMAINS.iter().any(|tld| uri.path().ends_with(tld))
+            } else {
+                false
+            }
+        }
     };
     res
 }

--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -53,6 +53,13 @@ impl Uri {
 
     #[inline]
     #[must_use]
+    /// Returns the path of the URI (e.g. `/path/to/resource`)
+    pub fn path(&self) -> &str {
+        self.url.path()
+    }
+
+    #[inline]
+    #[must_use]
     /// Unless this URL is cannot-be-a-base,
     /// return an iterator of '/' slash-separated path segments,
     /// each as a percent-encoded ASCII string.


### PR DESCRIPTION
This was an oversight so far that became apparent after our
recent fix for email addreses with query params
(e.g. `test@example.com?subject=test`).
The parsing of email addresses has improved and so we detect
more mail addresses, but we didn't check if they belonged
to an example domain, causing false-positive checks.