### PR TITLE
Add different verbosity levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1096,6 +1096,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1877,6 +1890,7 @@ dependencies = [
  "const_format",
  "csv",
  "dashmap",
+ "env_logger",
  "futures",
  "headers",
  "http",

--- a/README.md
+++ b/README.md
@@ -310,6 +310,9 @@ OPTIONS:
         --offline
             Only check local files and block network requests
 
+    -q, --quiet
+            Less output per occurrence (e.g. `-q` or `-qq`)
+
     -r, --retry-wait-time <RETRY_WAIT_TIME>
             Minimum wait time in seconds between retries of failed requests [default: 1]
 
@@ -335,7 +338,7 @@ OPTIONS:
             User agent [default: lychee/0.10.3]
 
     -v, --verbose
-            Verbose program output
+            Set verbosity level; more output per occurrence (e.g. `-v` or `-vv`)
 
     -X, --method <METHOD>
             Request method [default: get]

--- a/fixtures/TEST_DATA_URIS.html
+++ b/fixtures/TEST_DATA_URIS.html
@@ -1,0 +1,8 @@
+<a href="http://www.w3.org/2000/svg">False positive link</a>
+<a href="data:,Hello%2C%20World%21">Hello World</a>
+<a href="data:text/plain;base64,SGVsbG8sIFdvcmxkIQ==">Plaintext</a>
+<a
+  href="data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 147 40'"
+  >data URI</a
+>
+<a href="http://localhost/assets/img/bg-water.webp">normal link</a>

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -48,6 +48,7 @@ humantime-serde = "1.1.1"
 secrecy = { version = "0.8.0", features = ["serde"] }
 supports-color = "1.3.0"
 log = "0.4.17"
+env_logger = "0.9.3"
 
 [dependencies.clap]
 version = "3.2.23"

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -1,4 +1,5 @@
 use crate::parse::{parse_base, parse_statuscodes};
+use crate::verbosity::{Verbosity, WarnLevel};
 use anyhow::{anyhow, Context, Error, Result};
 use clap::StructOpt;
 use const_format::{concatcp, formatcp};
@@ -139,9 +140,8 @@ impl LycheeOptions {
 #[derive(Debug, Deserialize, StructOpt, Clone)]
 pub(crate) struct Config {
     /// Verbose program output
-    #[clap(short, long)]
-    #[serde(default)]
-    pub(crate) verbose: bool,
+    #[clap(flatten)]
+    pub(crate) verbose: Verbosity<WarnLevel>,
 
     /// Do not show progress bar.
     /// This is recommended for non-interactive shells (e.g. for continuous integration)
@@ -362,7 +362,7 @@ impl Config {
             self, toml;
 
             // Keys with defaults to assign
-            verbose: false;
+            verbose: Verbosity::new(0, 0);
             cache: false;
             no_progress: false;
             max_redirects: DEFAULT_MAX_REDIRECTS;

--- a/lychee-bin/src/verbosity.rs
+++ b/lychee-bin/src/verbosity.rs
@@ -1,0 +1,218 @@
+//! Control `log` level with a `--verbose` flag for your CLI
+//!
+//! The original source is from
+//! [this crate](https://github.com/clap-rs/clap-verbosity-flag).
+//! Modifications were made to add support for serializing the `Verbosity`
+//! struct and to add a convenience method to get the verbosity status.
+//!
+//! # Examples
+//!
+//! To get `--quiet` and `--verbose` flags through your entire program, just `flatten`
+//! [`Verbosity`]:
+//! ```rust,no_run
+//! # use clap::Parser;
+//! # use clap_verbosity_flag::Verbosity;
+//! #
+//! # /// Le CLI
+//! # #[derive(Debug, Parser)]
+//! # struct Cli {
+//! #[command(flatten)]
+//! verbose: Verbosity,
+//! # }
+//! ```
+//!
+//! You can then use this to configure your logger:
+//! ```rust,no_run
+//! # use clap::Parser;
+//! # use clap_verbosity_flag::Verbosity;
+//! #
+//! # /// Le CLI
+//! # #[derive(Debug, Parser)]
+//! # struct Cli {
+//! #     #[command(flatten)]
+//! #     verbose: Verbosity,
+//! # }
+//! let cli = Cli::parse();
+//! env_logger::Builder::new()
+//!     .filter_level(cli.verbose.log_level_filter())
+//!     .init();
+//! ```
+//!
+//! By default, this will only report errors.
+//! - `-q` silences output
+//! - `-v` show warnings
+//! - `-vv` show info
+//! - `-vvv` show debug
+//! - `-vvvv` show trace
+//!
+//! You can also customize the default logging level:
+//! ```rust,no_run
+//! # use clap::Parser;
+//! use clap_verbosity_flag::{Verbosity, InfoLevel};
+//!
+//! /// Le CLI
+//! #[derive(Debug, Parser)]
+//! struct Cli {
+//!     #[command(flatten)]
+//!     verbose: Verbosity<InfoLevel>,
+//! }
+//! ```
+//!
+//! Or implement [`LogLevel`] yourself for more control.
+
+#[derive(clap::Args, Eq, PartialEq, Debug, Deserialize, Clone)]
+pub(crate) struct Verbosity<L: LogLevel = ErrorLevel> {
+    #[clap(
+        long,
+        short = 'v',
+        action = clap::ArgAction::Count,
+        global = true,
+        help = L::verbose_help(),
+        long_help = L::verbose_long_help(),
+    )]
+    verbose: u8,
+
+    #[clap(
+        long,
+        short = 'q',
+        action = clap::ArgAction::Count,
+        global = true,
+        help = L::quiet_help(),
+        long_help = L::quiet_long_help(),
+        conflicts_with = "verbose",
+    )]
+    quiet: u8,
+
+    #[clap(skip)]
+    phantom: std::marker::PhantomData<L>,
+}
+
+impl<L: LogLevel> Verbosity<L> {
+    /// Create a new verbosity instance by explicitly setting the values
+    pub(crate) const fn new(verbose: u8, quiet: u8) -> Self {
+        Verbosity {
+            verbose,
+            quiet,
+            phantom: std::marker::PhantomData,
+        }
+    }
+
+    /// Get the log level.
+    ///
+    /// `None` means all output is disabled.
+    pub(crate) fn log_level(&self) -> Option<log::Level> {
+        level_enum(self.verbosity())
+    }
+
+    /// Get the log level filter.
+    pub(crate) fn log_level_filter(&self) -> log::LevelFilter {
+        level_enum(self.verbosity()).map_or(log::LevelFilter::Off, |l| l.to_level_filter())
+    }
+
+    /// Shorthand to check if the user requested "more verbose" output
+    /// (assuming the default log level is `Warn`)
+    pub(crate) fn is_verbose(&self) -> bool {
+        self.log_level() >= log::LevelFilter::Info.to_level()
+    }
+
+    fn verbosity(&self) -> i8 {
+        #![allow(clippy::cast_possible_wrap)]
+        level_value(L::default()) - (self.quiet as i8) + (self.verbose as i8)
+    }
+}
+
+const fn level_value(level: Option<log::Level>) -> i8 {
+    match level {
+        None => -1,
+        Some(log::Level::Error) => 0,
+        Some(log::Level::Warn) => 1,
+        Some(log::Level::Info) => 2,
+        Some(log::Level::Debug) => 3,
+        Some(log::Level::Trace) => 4,
+    }
+}
+
+const fn level_enum(verbosity: i8) -> Option<log::Level> {
+    match verbosity {
+        std::i8::MIN..=-1 => None,
+        0 => Some(log::Level::Error),
+        1 => Some(log::Level::Warn),
+        2 => Some(log::Level::Info),
+        3 => Some(log::Level::Debug),
+        4..=std::i8::MAX => Some(log::Level::Trace),
+    }
+}
+
+use std::fmt;
+
+use serde::Deserialize;
+
+impl<L: LogLevel> fmt::Display for Verbosity<L> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.verbosity())
+    }
+}
+
+pub(crate) trait LogLevel {
+    fn default() -> Option<log::Level>;
+
+    fn verbose_help() -> Option<&'static str> {
+        Some("Set verbosity level; more output per occurrence (e.g. `-v` or `-vv`)")
+    }
+
+    fn verbose_long_help() -> Option<&'static str> {
+        None
+    }
+
+    fn quiet_help() -> Option<&'static str> {
+        Some("Less output per occurrence (e.g. `-q` or `-qq`)")
+    }
+
+    fn quiet_long_help() -> Option<&'static str> {
+        None
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub(crate) struct ErrorLevel;
+
+impl LogLevel for ErrorLevel {
+    fn default() -> Option<log::Level> {
+        Some(log::Level::Error)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub(crate) struct WarnLevel;
+
+impl LogLevel for WarnLevel {
+    fn default() -> Option<log::Level> {
+        Some(log::Level::Warn)
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub(crate) struct InfoLevel;
+
+impl LogLevel for InfoLevel {
+    fn default() -> Option<log::Level> {
+        Some(log::Level::Info)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn verify_app() {
+        #[derive(Debug, clap::Parser)]
+        struct Cli {
+            #[clap(flatten)]
+            verbose: Verbosity,
+        }
+
+        use clap::CommandFactory;
+        Cli::command().debug_assert();
+    }
+}

--- a/lychee-bin/tests/data_uris.rs
+++ b/lychee-bin/tests/data_uris.rs
@@ -1,0 +1,72 @@
+//! The rest of the integration tests make heavy use of example domains, so
+//! we use a separate module for testing that the exclusion of these domains
+//! works as expected for normal users.
+#[cfg(test)]
+mod cli {
+    use std::{
+        error::Error,
+        path::{Path, PathBuf},
+    };
+
+    use assert_cmd::Command;
+    use predicates::str::contains;
+
+    type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+    fn fixtures_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("fixtures")
+    }
+
+    fn main_command() -> Command {
+        // this gets the "main" binary name (e.g. `lychee`)
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name")
+    }
+
+    #[test]
+    fn test_dont_dump_data_uris_by_default() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("TEST_DATA_URIS.html");
+
+        let cmd = cmd
+            .arg(input)
+            .arg("--dump")
+            .assert()
+            .success()
+            .stdout(contains("http://localhost/assets/img/bg-water.webp"));
+
+        let output = cmd.get_output();
+        let output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(output.lines().count(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_dump_data_uris_in_verbose_mode() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("TEST_DATA_URIS.html");
+
+        let cmd = cmd
+            .arg(input)
+            .arg("--dump")
+            .arg("--verbose")
+            .assert()
+            .success()
+            .stdout(contains("http://www.w3.org/2000/svg"))
+            .stdout(contains(
+                "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 147 40'",
+            ))
+            .stdout(contains("data:text/plain;base64,SGVsbG8sIFdvcmxkIQ=="))
+            .stdout(contains("http://localhost/assets/img/bg-water.webp"))
+            .stdout(contains("data:,Hello%2C%20World%21"));
+
+        let output = cmd.get_output();
+        let output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(output.lines().count(), 5);
+
+        Ok(())
+    }
+}

--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -96,6 +96,13 @@ impl Uri {
 
     #[inline]
     #[must_use]
+    /// Check if the URI is a `data` URI
+    pub fn is_data(&self) -> bool {
+        self.scheme() == "data"
+    }
+
+    #[inline]
+    #[must_use]
     /// Returns `true` if this is a loopback address.
     ///
     /// ## IPv4


### PR DESCRIPTION
More granular verbosity levels have been asked
for repeatedly.
To enable that we're moving to [env_logger] and [clap-verbosity-flag]
to provide more flexible verbosity settings.

Also tackles #661, #709.
Lays the groundwork for tackling #268 and #704.

https://github.com/rust-cli/env_logger
https://github.com/clap-rs/clap-verbosity-flag