### PR TITLE
Add support for dumping inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ OPTIONS:
             Don't perform any link checking. Instead, dump all the links extracted from inputs that
             would be checked
 
+        --dump-inputs
+            Don't perform any link checking. Instead, dump all the inputs that would be checked
+
     -E, --exclude-all-private
             Exclude all private IPs from checking.
             Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`

--- a/fixtures/dump-inputs/file.html
+++ b/fixtures/dump-inputs/file.html
@@ -1,0 +1,1 @@
+<a href="https://example.org">Link</a>

--- a/fixtures/dump-inputs/file.md
+++ b/fixtures/dump-inputs/file.md
@@ -1,0 +1,1 @@
+[Example](https://example.com)

--- a/fixtures/dump-inputs/folder/file.html
+++ b/fixtures/dump-inputs/folder/file.html
@@ -1,0 +1,1 @@
+<a href="https://example.org">Link</a>

--- a/fixtures/dump-inputs/folder/file.md
+++ b/fixtures/dump-inputs/folder/file.md
@@ -1,0 +1,1 @@
+[Example](https://example.com)

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -2,30 +2,12 @@ use lychee_lib::Request;
 use lychee_lib::Result;
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
 use tokio_stream::StreamExt;
 
+use crate::commands::helpers::create_writer;
 use crate::ExitCode;
 
 use super::CommandParams;
-
-// Helper function to create an output writer.
-//
-// If the output file is not specified, it will use `stdout`.
-//
-// # Errors
-//
-// If the output file cannot be opened, an error is returned.
-fn create_writer(output: Option<PathBuf>) -> Result<Box<dyn Write>> {
-    let out = if let Some(output) = output {
-        let out = fs::OpenOptions::new().append(true).open(output)?;
-        Box::new(out) as Box<dyn Write>
-    } else {
-        let out = io::stdout();
-        Box::new(out.lock()) as Box<dyn Write>
-    };
-    Ok(out)
-}
 
 /// Dump all detected links to stdout without checking them
 pub(crate) async fn dump<S>(params: CommandParams<S>) -> Result<ExitCode>

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -1,0 +1,62 @@
+use crate::commands::helpers::create_writer;
+use lychee_lib::InputSource;
+use lychee_lib::Request;
+use lychee_lib::Result;
+use std::collections::HashSet;
+use std::fs;
+use std::io::{self, Write};
+use tokio_stream::StreamExt;
+
+use crate::ExitCode;
+
+use super::CommandParams;
+
+/// Dumps all detected inputs to stdout without checking them
+/// This is useful for debugging purposes.
+///
+/// The implementation is suboptimal at the moment.
+/// - The collected inputs get read from disk before being written to stdout.
+/// - If inputs don't contain any links, they are ignored.
+///
+/// It would be better to just stream the inputs and not load them into memory.
+/// This would require some refactoring in the `lychee-lib` crate,
+/// so it is left as a TODO for now.
+pub(crate) async fn dump_inputs<S>(params: CommandParams<S>) -> Result<ExitCode>
+where
+    S: futures::Stream<Item = Result<Request>>,
+{
+    let requests = params.requests;
+
+    if let Some(outfile) = &params.cfg.output {
+        fs::File::create(outfile)?;
+    }
+    let mut writer = create_writer(params.cfg.output)?;
+
+    // A cache to avoid printing duplicate inputs
+    let mut cache = HashSet::new();
+
+    tokio::pin!(requests);
+    while let Some(request) = requests.next().await {
+        let request = request?;
+        let source = request.source;
+
+        if cache.contains(&source) {
+            continue;
+        }
+        cache.insert(source.clone());
+
+        if let Err(e) = write(&mut writer, &source) {
+            if e.kind() != io::ErrorKind::BrokenPipe {
+                eprintln!("{e}");
+                return Ok(ExitCode::UnexpectedFailure);
+            }
+        }
+    }
+
+    Ok(ExitCode::Success)
+}
+
+/// Dump request to stdout
+fn write(writer: &mut Box<dyn Write>, source: &InputSource) -> io::Result<()> {
+    writeln!(writer, "{}", source)
+}

--- a/lychee-bin/src/commands/helpers.rs
+++ b/lychee-bin/src/commands/helpers.rs
@@ -1,0 +1,22 @@
+use lychee_lib::Result;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+// Helper function to create an output writer.
+//
+// If the output file is not specified, it will use `stdout`.
+//
+// # Errors
+//
+// If the output file cannot be opened, an error is returned.
+pub(crate) fn create_writer(output: Option<PathBuf>) -> Result<Box<dyn Write>> {
+    let out = if let Some(output) = output {
+        let out = fs::OpenOptions::new().append(true).open(output)?;
+        Box::new(out) as Box<dyn Write>
+    } else {
+        let out = io::stdout();
+        Box::new(out.lock()) as Box<dyn Write>
+    };
+    Ok(out)
+}

--- a/lychee-bin/src/commands/mod.rs
+++ b/lychee-bin/src/commands/mod.rs
@@ -1,8 +1,11 @@
 pub(crate) mod check;
 pub(crate) mod dump;
+pub(crate) mod dump_inputs;
+pub(crate) mod helpers;
 
 pub(crate) use check::check;
 pub(crate) use dump::dump;
+pub(crate) use dump_inputs::dump_inputs;
 
 use std::sync::Arc;
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -238,6 +238,7 @@ fn underlying_io_error_kind(error: &Error) -> Option<io::ErrorKind> {
 /// Run lychee on the given inputs
 async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs()?;
+
     let requests = Collector::new(opts.config.base.clone())
         .skip_missing_inputs(opts.config.skip_missing)
         .include_verbatim(opts.config.include_verbatim)
@@ -262,6 +263,8 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
 
     let exit_code = if opts.config.dump {
         commands::dump(params).await?
+    } else if opts.config.dump_inputs {
+        commands::dump_inputs(params).await?
     } else {
         let (stats, cache, exit_code) = commands::check(params).await?;
 

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -170,6 +170,12 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) dump: bool,
 
+    /// Don't perform any link checking.
+    /// Instead, dump all the inputs that would be checked
+    #[clap(long)]
+    #[serde(default)]
+    pub(crate) dump_inputs: bool,
+
     /// Maximum number of allowed redirects
     #[clap(short, long, default_value = &MAX_REDIRECTS_STR)]
     #[serde(default = "max_redirects")]

--- a/lychee-bin/tests/dump_inputs.rs
+++ b/lychee-bin/tests/dump_inputs.rs
@@ -1,0 +1,46 @@
+#[cfg(test)]
+mod cli {
+    use std::{
+        error::Error,
+        path::{Path, PathBuf},
+    };
+
+    use assert_cmd::Command;
+    use predicates::str::contains;
+
+    type Result<T> = std::result::Result<T, Box<dyn Error>>;
+
+    fn fixtures_path() -> PathBuf {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .unwrap()
+            .join("fixtures")
+    }
+
+    fn main_command() -> Command {
+        // this gets the "main" binary name (e.g. `lychee`)
+        Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name")
+    }
+
+    #[test]
+    fn test_dump_inputs() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("dump-inputs");
+
+        let cmd = cmd
+            .arg(input)
+            .arg("--dump-inputs")
+            .assert()
+            .success()
+            .stdout(contains("fixtures/dump-inputs/folder/file.html"))
+            .stdout(contains("fixtures/dump-inputs/folder/file.md"))
+            .stdout(contains("fixtures/dump-inputs/file.html"))
+            .stdout(contains("fixtures/dump-inputs/file.md"));
+
+        let output = cmd.get_output();
+        let output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(output.lines().count(), 4);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
Dumps all detected inputs to stdout without checking them
This is useful for debugging purposes.

The implementation is suboptimal at the moment.
- The collected inputs get read from disk before being written to stdout.
- If inputs don't contain any links, they are ignored.

It would be better to just stream the inputs and not load them into memory.
This would require some refactoring in the `lychee-lib` crate,
so it is left as a TODO for now.