### PR TITLE
Recursively skip verbatim elements

### DIFF
--- a/lychee-lib/src/extract/html5ever.rs
+++ b/lychee-lib/src/extract/html5ever.rs
@@ -214,6 +214,27 @@ mod tests {
     }
 
     #[test]
+    fn test_include_verbatim_recursive() {
+        const HTML_INPUT: &str = r#"
+        <a href="https://example.com/">valid link</a>
+        <code>
+            <pre>
+                <span>https://example.org</span>
+            </pre>
+        </code>
+        "#;
+
+        let expected = vec![RawUri {
+            text: "https://example.com/".to_string(),
+            element: Some("a".to_string()),
+            attribute: Some("href".to_string()),
+        }];
+
+        let uris = extract_html(HTML_INPUT, false);
+        assert_eq!(uris, expected);
+    }
+
+    #[test]
     fn test_include_nofollow() {
         let input = r#"
         <a rel="nofollow" href="https://foo.com">do not follow me</a> 

--- a/lychee-lib/src/extract/html5gum.rs
+++ b/lychee-lib/src/extract/html5gum.rs
@@ -16,6 +16,7 @@ struct LinkExtractor {
     current_attribute_value: Vec<u8>,
     last_start_element: Vec<u8>,
     include_verbatim: bool,
+    current_verbatim_element_name: Option<Vec<u8>>,
 }
 
 /// this is the same as `std::str::from_utf8_unchecked`, but with extra debug assertions for ease
@@ -37,6 +38,7 @@ impl LinkExtractor {
             current_attribute_value: Vec::new(),
             last_start_element: Vec::new(),
             include_verbatim,
+            current_verbatim_element_name: None,
         }
     }
 
@@ -92,7 +94,8 @@ impl LinkExtractor {
     fn flush_current_characters(&mut self) {
         // safety: since we feed html5gum tokenizer with a &str, this must be a &str as well.
         let name = unsafe { from_utf8_unchecked(&self.current_element_name) };
-        if !self.include_verbatim && is_verbatim_elem(name) {
+        if !self.include_verbatim && (is_verbatim_elem(name) || self.inside_verbatim_block()) {
+            self.update_verbatim_element_name();
             // Early return if we don't want to extract links from preformatted text
             self.current_string.clear();
             return;
@@ -103,14 +106,47 @@ impl LinkExtractor {
         self.current_string.clear();
     }
 
+    /// Check if we are currently inside a verbatim element.
+    const fn inside_verbatim_block(&self) -> bool {
+        self.current_verbatim_element_name.is_some()
+    }
+
+    /// Update the current verbatim element name.
+    ///
+    /// Keeps track of the last verbatim element name, so that we can
+    /// properly handle nested verbatim blocks.
+    fn update_verbatim_element_name(&mut self) {
+        if self.current_element_is_closing {
+            if self.inside_verbatim_block() {
+                // If we are closing a verbatim element, we need to check if it is the
+                // top-level verbatim element. If it is, we need to reset the verbatim block.
+                if Some(&self.current_element_name) == self.current_verbatim_element_name.as_ref() {
+                    self.current_verbatim_element_name = None;
+                }
+            }
+        } else if !self.include_verbatim
+            && is_verbatim_elem(unsafe { from_utf8_unchecked(&self.current_element_name) })
+        {
+            // If we are opening a verbatim element, we need to check if we are already
+            // inside a verbatim element. If so, we need to ignore this element.
+            if !self.inside_verbatim_block() {
+                self.current_verbatim_element_name = Some(self.current_element_name.clone());
+            }
+        }
+    }
+
     fn flush_old_attribute(&mut self) {
         {
             // safety: since we feed html5gum tokenizer with a &str, this must be a &str as well.
             let name = unsafe { from_utf8_unchecked(&self.current_element_name) };
-            if !self.include_verbatim && is_verbatim_elem(name) {
-                // Early return if we don't want to extract links from preformatted text
+
+            // Early return if we don't want to extract links from verbatim
+            // blocks (e.g. preformatted text)
+            if !self.include_verbatim && (is_verbatim_elem(name) || self.inside_verbatim_block()) {
+                self.update_verbatim_element_name();
                 return;
             }
+
             let attr = unsafe { from_utf8_unchecked(&self.current_attribute_name) };
             let value = unsafe { from_utf8_unchecked(&self.current_attribute_value) };
 
@@ -298,6 +334,27 @@ mod tests {
         ];
 
         let uris = extract_html(HTML_INPUT, true);
+        assert_eq!(uris, expected);
+    }
+
+    #[test]
+    fn test_include_verbatim_recursive() {
+        const HTML_INPUT: &str = r#"
+        <a href="https://example.com/">valid link</a>
+        <code>
+            <pre>
+                <span>https://example.org</span>
+            </pre>
+        </code>
+        "#;
+
+        let expected = vec![RawUri {
+            text: "https://example.com/".to_string(),
+            element: Some("a".to_string()),
+            attribute: Some("href".to_string()),
+        }];
+
+        let uris = extract_html(HTML_INPUT, false);
         assert_eq!(uris, expected);
     }
 

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -101,6 +101,24 @@ mod tests {
     }
 
     #[test]
+    fn test_verbatim_matching() {
+        assert!(is_verbatim_elem("pre"));
+        assert!(is_verbatim_elem("code"));
+        assert!(is_verbatim_elem("listing"));
+    }
+
+    #[test]
+    fn verbatim_elem() {
+        let input = r#"
+        <pre>
+        https://example.com
+        </pre>
+        "#;
+        let uris = extract_uris(input, FileType::Html);
+        assert!(uris.is_empty());
+    }
+
+    #[test]
     fn test_file_type() {
         assert_eq!(FileType::from(Path::new("/")), FileType::Plaintext);
         assert_eq!(FileType::from("test.md"), FileType::Markdown);


### PR DESCRIPTION
This handles cases like

```html
<code>
    <pre>
        <span>https://example.org</span>
    </pre>
</code>
```

where a link was embedded in a verbatim block, but embedded in a non-verbatim element (`<span>`).
This was correctly handled in html5ever, but not html5gum (which is our default HTML parser in lychee)

Fixes https://github.com/lycheeverse/lychee/issues/259#issuecomment-1328292006.

@untitaker, is there a better way to handle nested tags in html5gum or would you have resolved the issue in a similar way?
