### PR TITLE
Extend response stats in verbose mode

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -28,7 +28,11 @@ where
     let (send_req, recv_req) = mpsc::channel(params.cfg.max_concurrency);
     let (send_resp, recv_resp) = mpsc::channel(params.cfg.max_concurrency);
     let max_concurrency = params.cfg.max_concurrency;
-    let stats = ResponseStats::new();
+    let stats = if params.cfg.verbose.is_verbose() {
+        ResponseStats::extended()
+    } else {
+        ResponseStats::default()
+    };
     let cache_ref = params.cache.clone();
 
     let client = params.client;

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -18,7 +18,10 @@ struct CompactResponseStats(ResponseStats);
 // Helper function, which prints the detailed list of errors
 pub(crate) fn print_errors(stats: &ResponseStats) -> String {
     let mut errors = HashMap::new();
-    errors.insert("HTTP", stats.failures);
+    errors.insert(
+        "HTTP",
+        stats.errors - stats.redirects - stats.timeouts - stats.unknown,
+    );
     errors.insert("Redirects", stats.redirects);
     errors.insert("Timeouts", stats.timeouts);
     errors.insert("Unknown", stats.unknown);
@@ -62,7 +65,7 @@ impl Display for CompactResponseStats {
         color!(f, NORMAL, "\u{1F50D} {} Total", stats.total)?;
         color!(f, BOLD_GREEN, " \u{2705} {} OK", stats.successful)?;
 
-        let total_errors = stats.errors + stats.failures;
+        let total_errors = stats.errors;
 
         let err_str = if total_errors == 1 { "Error" } else { "Errors" };
         color!(f, BOLD_PINK, " \u{1f6ab} {} {}", total_errors, err_str)?;

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -37,7 +37,7 @@ impl Display for DetailedResponseStats {
         write_stat(f, "\u{1f500} Redirected", stats.redirects, true)?; // 🔀
         write_stat(f, "\u{1f47b} Excluded", stats.excludes, true)?; // 👻
         write_stat(f, "\u{2753} Unknown", stats.unknown, true)?; //❓
-        write_stat(f, "\u{1f6ab} Errors", stats.errors + stats.failures, false)?; // 🚫
+        write_stat(f, "\u{1f6ab} Errors", stats.errors, false)?; // 🚫
 
         for (source, responses) in &stats.fail_map {
             // Using leading newlines over trailing ones (e.g. `writeln!`)

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -45,7 +45,7 @@ fn stats_table(stats: &ResponseStats) -> String {
         },
         StatsTableEntry {
             status: "\u{1f6ab} Errors",
-            count: stats.errors + stats.failures,
+            count: stats.errors,
         },
     ];
     let style = tabled::Style::markdown();

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -180,7 +180,7 @@ mod tests {
 
     #[test]
     fn test_render_stats() {
-        let stats = ResponseStats::new();
+        let stats = ResponseStats::default();
         let table = stats_table(&stats);
         let expected = r#"| Status        | Count |
 |---------------|-------|
@@ -196,7 +196,7 @@ mod tests {
 
     #[test]
     fn test_render_summary() {
-        let mut stats = ResponseStats::new();
+        let mut stats = ResponseStats::default();
         let response = Response(
             InputSource::Stdin,
             ResponseBody {

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -8,8 +8,8 @@ pub(crate) struct ResponseStats {
     pub(crate) detailed_stats: bool,
     pub(crate) total: usize,
     pub(crate) successful: usize,
-    pub(crate) failures: usize,
     pub(crate) unknown: usize,
+    pub(crate) unsupported: usize,
     pub(crate) timeouts: usize,
     pub(crate) redirects: usize,
     pub(crate) excludes: usize,
@@ -32,18 +32,19 @@ impl ResponseStats {
     pub(crate) fn increment_status_counters(&mut self, status: &Status) {
         match status {
             Status::Ok(_) => self.successful += 1,
-            Status::Error(_) => self.failures += 1,
+            Status::Error(_) => self.errors += 1,
             Status::UnknownStatusCode(_) => self.unknown += 1,
             Status::Timeout(_) => self.timeouts += 1,
             Status::Redirected(_) => self.redirects += 1,
             Status::Excluded => self.excludes += 1,
-            Status::Unsupported(_) => (), // Just skip unsupported URI
+            Status::Unsupported(_) => self.unsupported += 1,
             Status::Cached(cache_status) => {
                 self.cached += 1;
                 match cache_status {
                     CacheStatus::Ok(_) => self.successful += 1,
-                    CacheStatus::Error(_) => self.failures += 1,
-                    CacheStatus::Excluded | CacheStatus::Unsupported => self.excludes += 1,
+                    CacheStatus::Error(_) => self.errors += 1,
+                    CacheStatus::Excluded => self.excludes += 1,
+                    CacheStatus::Unsupported => self.unsupported += 1,
                 }
             }
         }

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -3,8 +3,9 @@ use std::collections::{HashMap, HashSet};
 use lychee_lib::{CacheStatus, InputSource, Response, ResponseBody, Status};
 use serde::Serialize;
 
-#[derive(Default, Serialize)]
+#[derive(Default, Serialize, Debug)]
 pub(crate) struct ResponseStats {
+    pub(crate) detailed_stats: bool,
     pub(crate) total: usize,
     pub(crate) successful: usize,
     pub(crate) failures: usize,
@@ -14,25 +15,21 @@ pub(crate) struct ResponseStats {
     pub(crate) excludes: usize,
     pub(crate) errors: usize,
     pub(crate) cached: usize,
+    pub(crate) success_map: HashMap<InputSource, HashSet<ResponseBody>>,
     pub(crate) fail_map: HashMap<InputSource, HashSet<ResponseBody>>,
+    pub(crate) excluded_map: HashMap<InputSource, HashSet<ResponseBody>>,
 }
 
 impl ResponseStats {
     #[inline]
-    pub(crate) fn new() -> Self {
-        Self::default()
+    pub(crate) fn extended() -> Self {
+        Self {
+            detailed_stats: true,
+            ..Default::default()
+        }
     }
 
-    pub(crate) fn add(&mut self, response: Response) {
-        let Response(source, ResponseBody { ref status, .. }) = response;
-
-        // Silently skip unsupported URIs
-        if status.is_unsupported() {
-            return;
-        }
-
-        self.total += 1;
-
+    pub(crate) fn increment_status_counters(&mut self, status: &Status) {
         match status {
             Status::Ok(_) => self.successful += 1,
             Status::Error(_) => self.failures += 1,
@@ -41,27 +38,38 @@ impl ResponseStats {
             Status::Redirected(_) => self.redirects += 1,
             Status::Excluded => self.excludes += 1,
             Status::Unsupported(_) => (), // Just skip unsupported URI
-            Status::Cached(_) => self.cached += 1,
-        }
-
-        if let Status::Cached(cache_status) = status {
-            match cache_status {
-                CacheStatus::Ok(_) => self.successful += 1,
-                CacheStatus::Error(_) => self.failures += 1,
-                CacheStatus::Excluded | CacheStatus::Unsupported => self.excludes += 1,
+            Status::Cached(cache_status) => {
+                self.cached += 1;
+                match cache_status {
+                    CacheStatus::Ok(_) => self.successful += 1,
+                    CacheStatus::Error(_) => self.failures += 1,
+                    CacheStatus::Excluded | CacheStatus::Unsupported => self.excludes += 1,
+                }
             }
         }
+    }
 
-        if matches!(
-            status,
-            Status::Error(_)
-                | Status::Timeout(_)
-                | Status::Redirected(_)
-                | Status::Cached(CacheStatus::Error(_))
-        ) {
-            let fail = self.fail_map.entry(source).or_default();
-            fail.insert(response.1);
-        };
+    pub(crate) fn add(&mut self, response: Response) {
+        self.total += 1;
+
+        let Response(source, ResponseBody { ref status, .. }) = response;
+        self.increment_status_counters(status);
+
+        match status {
+            _ if status.is_failure() => {
+                let fail = self.fail_map.entry(source).or_default();
+                fail.insert(response.1);
+            }
+            Status::Ok(_) if self.detailed_stats => {
+                let success = self.success_map.entry(source).or_default();
+                success.insert(response.1);
+            }
+            Status::Excluded if self.detailed_stats => {
+                let excluded = self.excluded_map.entry(source).or_default();
+                excluded.insert(response.1);
+            }
+            _ => (),
+        }
     }
 
     #[inline]
@@ -80,9 +88,8 @@ mod tests {
     use std::collections::{HashMap, HashSet};
 
     use http::StatusCode;
-    use lychee_lib::{ClientBuilder, InputSource, Response, ResponseBody, Status, Uri};
+    use lychee_lib::{ErrorKind, InputSource, Response, ResponseBody, Status, Uri};
     use reqwest::Url;
-    use wiremock::{matchers::path, Mock, MockServer, ResponseTemplate};
 
     use super::ResponseStats;
 
@@ -90,64 +97,87 @@ mod tests {
         Uri::from(Url::parse(url).expect("Expected valid Website URI"))
     }
 
-    async fn get_mock_status_response<S>(status_code: S) -> Response
-    where
-        S: Into<StatusCode>,
-    {
-        let mock_server = MockServer::start().await;
-        let template = ResponseTemplate::new(status_code.into());
-
-        Mock::given(path("/"))
-            .respond_with(template)
-            .mount(&mock_server)
-            .await;
-
-        ClientBuilder::default()
-            .client()
-            .unwrap()
-            .check(mock_server.uri())
-            .await
-            .unwrap()
+    // Generate a fake response with a given status code
+    // Don't use a mock server for this, as it's not necessary
+    // and it's a lot faster to just generate a fake response
+    fn mock_response(status: Status) -> Response {
+        let uri = website("https://some-url.com/ok");
+        let response_body = ResponseBody { uri, status };
+        Response(InputSource::Stdin, response_body)
     }
 
-    #[test]
-    fn test_stats_is_empty() {
-        let mut stats = ResponseStats::new();
+    fn dummy_ok() -> Response {
+        mock_response(Status::Ok(StatusCode::OK))
+    }
+
+    fn dummy_error() -> Response {
+        mock_response(Status::Error(ErrorKind::InvalidStatusCode(1000)))
+    }
+
+    fn dummy_excluded() -> Response {
+        mock_response(Status::Excluded)
+    }
+
+    #[tokio::test]
+    async fn test_stats_is_empty() {
+        let mut stats = ResponseStats::default();
         assert!(stats.is_empty());
 
-        stats.add(Response(
-            InputSource::Stdin,
-            ResponseBody {
-                uri: website("https://example.com/ok"),
-                status: Status::Ok(StatusCode::OK),
-            },
-        ));
+        stats.add(dummy_error());
 
         assert!(!stats.is_empty());
     }
 
     #[tokio::test]
     async fn test_stats() {
-        let status_codes = [
-            StatusCode::OK,
-            StatusCode::PERMANENT_REDIRECT,
-            StatusCode::BAD_GATEWAY,
-        ];
+        let mut stats = ResponseStats::default();
+        assert!(stats.success_map.is_empty());
+        assert!(stats.excluded_map.is_empty());
 
-        let mut stats = ResponseStats::new();
-        for status in &status_codes {
-            stats.add(get_mock_status_response(status).await);
-        }
+        stats.add(dummy_error());
+        stats.add(dummy_ok());
 
-        let mut expected_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
-        for status in &status_codes {
-            if status.is_server_error() || status.is_client_error() || status.is_redirection() {
-                let Response(source, response_body) = get_mock_status_response(status).await;
-                let entry = expected_map.entry(source).or_default();
-                entry.insert(response_body);
-            }
-        }
+        // let mut expected_fail_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        // let Response(source, response_body) = dummy_error();
+        // let entry = expected_fail_map.entry(source).or_default();
+        // entry.insert(response_body);
+        // assert_eq!(stats.fail_map, expected_fail_map);
 
-        assert_eq!(stats.fail_map, expected_map);
+        let Response(source, body) = dummy_error();
+        let expected_fail_map: HashMap<InputSource, HashSet<ResponseBody>> =
+            HashMap::from_iter([(source, HashSet::from_iter([body]))]);
+        assert_eq!(stats.fail_map, expected_fail_map);
+
+        assert!(stats.success_map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_detailed_stats() {
+        let mut stats = ResponseStats::default();
+        assert!(stats.success_map.is_empty());
+        assert!(stats.fail_map.is_empty());
+        assert!(stats.excluded_map.is_empty());
+
+        stats.add(dummy_error());
+        stats.add(dummy_excluded());
+        stats.add(dummy_ok());
+
+        let mut expected_fail_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let Response(source, response_body) = dummy_error();
+        let entry = expected_fail_map.entry(source).or_default();
+        entry.insert(response_body);
+        assert_eq!(stats.fail_map, expected_fail_map);
+
+        let mut expected_success_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let Response(source, response_body) = dummy_ok();
+        let entry = expected_success_map.entry(source).or_default();
+        entry.insert(response_body);
+        assert_eq!(stats.success_map, expected_success_map);
+
+        let mut expected_excluded_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
+        let Response(source, response_body) = dummy_excluded();
+        let entry = expected_excluded_map.entry(source).or_default();
+        entry.insert(response_body);
+        assert_eq!(stats.excluded_map, expected_excluded_map);
     }
 }

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -85,6 +85,7 @@ impl ResponseStats {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
     use std::collections::{HashMap, HashSet};
 
     use http::StatusCode;
@@ -137,12 +138,6 @@ mod tests {
         stats.add(dummy_error());
         stats.add(dummy_ok());
 
-        // let mut expected_fail_map: HashMap<InputSource, HashSet<ResponseBody>> = HashMap::new();
-        // let Response(source, response_body) = dummy_error();
-        // let entry = expected_fail_map.entry(source).or_default();
-        // entry.insert(response_body);
-        // assert_eq!(stats.fail_map, expected_fail_map);
-
         let Response(source, body) = dummy_error();
         let expected_fail_map: HashMap<InputSource, HashSet<ResponseBody>> =
             HashMap::from_iter([(source, HashSet::from_iter([body]))]);
@@ -153,7 +148,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_detailed_stats() {
-        let mut stats = ResponseStats::default();
+        let mut stats = ResponseStats::extended();
         assert!(stats.success_map.is_empty());
         assert!(stats.fail_map.is_empty());
         assert!(stats.excluded_map.is_empty());

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -161,6 +161,12 @@ impl PartialEq for ErrorKind {
             }
             (Self::InvalidHeader(_), Self::InvalidHeader(_))
             | (Self::MissingGitHubToken, Self::MissingGitHubToken) => true,
+            (Self::InvalidStatusCode(c1), Self::InvalidStatusCode(c2)) => c1 == c2,
+            (Self::InvalidUrlHost, Self::InvalidUrlHost) => true,
+            (Self::InvalidURI(u1), Self::InvalidURI(u2)) => u1 == u2,
+            (Self::Regex(e1), Self::Regex(e2)) => e1.to_string() == e2.to_string(),
+            (Self::DirTraversal(e1), Self::DirTraversal(e2)) => e1.to_string() == e2.to_string(),
+            (Self::Channel(_), Self::Channel(_)) => true,
             _ => false,
         }
     }

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -152,7 +152,7 @@ impl Status {
     pub const fn is_failure(&self) -> bool {
         matches!(
             self,
-            Status::Error(_) | Status::Cached(CacheStatus::Error(_))
+            Status::Error(_) | Status::Cached(CacheStatus::Error(_)) | Status::Timeout(_)
         )
     }
 


### PR DESCRIPTION
Fixes #268.

Adds support for successful and excluded URLs.

Also,

* added missing `PartialEq` impls for `ErrorKind` variants
* fixed counters
* removed `failure`, as it was redundant; merged with `errors`