### PR TITLE
Don't build Docker image for pushes to arbitrary branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,6 @@ on:
     types:
       - completed
   push:
-    branches:
-      - "**"
     tags:
       - "v*.*.*"
   pull_request:


### PR DESCRIPTION
Avoids building Docker image twice on pull requests