### PR TITLE
Harden URL detection and extend verbatim elements

### DIFF
--- a/fixtures/TEST_VERBATIM.html
+++ b/fixtures/TEST_VERBATIM.html
@@ -1,0 +1,28 @@
+<!-- Test URLs in verbatim HTML elements -->
+
+<html>
+  <head>
+    <title>Verbatim HTML</title>
+  </head>
+  <body>
+    <h1>Verbatim HTML</h1>
+    <p>Some verbatim HTML elements:</p>
+
+    <pre>http://www.example.com/pre</pre>
+
+    <code>http://www.example.com/code</code>
+
+    <samp> http://www.example.com/samp </samp>
+
+    <kbd>http://www.example.com/kbd</kbd>
+
+    <var>http://www.example.com/var</var>
+
+    <address>http://www.example.com/address</address>
+
+    <script>
+      // http://www.example.com/script
+      "http://www.example.com/script";
+    </script>
+  </body>
+</html>

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -17,7 +17,18 @@ use plaintext::extract_plaintext;
 pub(crate) fn is_verbatim_elem(name: &str) -> bool {
     matches!(
         name,
-        "code" | "listing" | "plaintext" | "samp" | "script" | "textarea" | "xmp" | "pre"
+        "address"
+            | "code"
+            | "kbd"
+            | "listing"
+            | "noscript"
+            | "plaintext"
+            | "pre"
+            | "samp"
+            | "script"
+            | "textarea"
+            | "var"
+            | "xmp"
     )
 }
 
@@ -108,6 +119,7 @@ mod tests {
         assert!(is_verbatim_elem("pre"));
         assert!(is_verbatim_elem("code"));
         assert!(is_verbatim_elem("listing"));
+        assert!(is_verbatim_elem("script"));
     }
 
     #[test]

--- a/lychee-lib/src/test_utils.rs
+++ b/lychee-lib/src/test_utils.rs
@@ -39,6 +39,7 @@ pub(crate) fn website(url: &str) -> Uri {
     Uri::from(Url::parse(url).expect("Expected valid Website URI"))
 }
 
+/// Creates a mail URI from a string
 pub(crate) fn mail(address: &str) -> Uri {
     if address.starts_with("mailto:") {
         Url::parse(address)
@@ -49,6 +50,7 @@ pub(crate) fn mail(address: &str) -> Uri {
     .into()
 }
 
+/// Loads a fixture from the `fixtures` directory
 pub(crate) fn load_fixture(filename: &str) -> String {
     let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR"))
         .parent()

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -19,18 +19,22 @@ impl Default for FileType {
 
 impl<P: AsRef<Path>> From<P> for FileType {
     /// Detect if the given path points to a Markdown, HTML, or plaintext file.
+    //
+    // Assume HTML in case of no extension.
+    //
+    // This is only reasonable for URLs, not paths on disk. For example,
+    // a file named `README` without an extension is more likely to be a
+    // plaintext file.
+    //
+    // A better solution would be to also implement `From<Url> for
+    // FileType`. Unfortunately that's not possible without refactoring, as
+    // `AsRef<Path>` could be implemented for `Url` in the future, which is
+    // why `From<Url> for FileType` is not allowed (orphan rule).
+    //
+    // As a workaround, we check if the scheme is `http` or `https` and
+    // assume HTML in that case.
     fn from(p: P) -> FileType {
         let path = p.as_ref();
-        // Assume HTML in case of no extension.
-        // Note: this is only reasonable for URLs; not paths on disk.
-        // For example, `README` without an extension is more likely to be a plaintext file.
-        // A better solution would be to also implement `From<Url> for FileType`.
-        // Unfortunately that's not possible without refactoring, as
-        // `AsRef<Path>` could be implemented for `Url` in the future, which is why
-        // `From<Url> for FileType` is not allowed.
-        // As a workaround, we check if we got a known web-protocol
-        let is_url = path.starts_with("http");
-
         match path
             .extension()
             .and_then(std::ffi::OsStr::to_str)
@@ -42,10 +46,17 @@ impl<P: AsRef<Path>> From<P> for FileType {
                 FileType::Markdown
             }
             Some("htm" | "html") => FileType::Html,
-            None if is_url => FileType::Html,
-            _ => FileType::Plaintext,
+            None if is_url(path) => FileType::Html,
+            _ => FileType::default(),
         }
     }
+}
+
+/// Helper function to check if a path is likely a URL.
+fn is_url(path: &Path) -> bool {
+    path.to_str().map_or(false, |s| {
+        s.starts_with("http://") || s.starts_with("https://")
+    })
 }
 
 #[cfg(test)]
@@ -72,5 +83,14 @@ mod tests {
             FileType::from(Path::new("http://foo.com/index.html")),
             FileType::Html
         );
+    }
+
+    #[test]
+    fn test_is_url() {
+        assert!(is_url(Path::new("http://foo.com")));
+        assert!(is_url(Path::new("https://foo.com")));
+        assert!(!is_url(Path::new("foo.com")));
+        assert!(!is_url(Path::new("foo")));
+        assert!(!is_url(Path::new("foo/bar")));
     }
 }


### PR DESCRIPTION
Previously remote URLs were incorrectly detected because the
string representation of a path is different than the path itself,
causing the `http` prefix match to be insufficient.

This resulted in unexpected side-effects, such as the
incorrect detection of verbatim mode for remote URLs.

The check now got improved and unit tests were added to avoid
future breakage. On top of that, missing verbatim elements were added.

Fixes #895.