### PR TITLE
chore(ci)!: update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           override: true
 
       - name: Run cargo check
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: check
 
@@ -48,7 +48,7 @@ jobs:
           override: true
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: test
 
@@ -67,7 +67,7 @@ jobs:
           override: true
 
       - name: Run cargo fmt in check mode
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
@@ -87,7 +87,7 @@ jobs:
           override: true
 
       - name: Run cargo clippy (deny warnings)
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: clippy
           # --all-targets makes it lint tests too
@@ -105,12 +105,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Fetch cargo dependencies
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: fetch
 
       - name: Publish checks for lychee-lib
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
@@ -144,12 +144,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Fetch cargo dependencies
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: fetch
 
       - name: Publish lychee-lib
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
@@ -161,7 +161,7 @@ jobs:
         shell: bash
 
       - name: Publish lychee-bin
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Install minimal rust toolchain
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           profile: minimal
           override: true
 
@@ -44,6 +45,7 @@ jobs:
       - name: Install minimal rust toolchain
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           profile: minimal
           override: true
 
@@ -62,6 +64,7 @@ jobs:
       - name: Install minimal rust toolchain with rustfmt
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           profile: minimal
           components: rustfmt
           override: true
@@ -82,6 +85,7 @@ jobs:
       - name: Install minimal rust toolchain with clippy
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           profile: minimal
           components: clippy
           override: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,33 +16,78 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Install minimal rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Run cargo check
+        uses: actions-rs/cargo@v2
+        with:
+          command: check
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Install minimal rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          override: true
+
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: test
 
-  lint:
+  fmt:
+    name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Install minimal rust toolchain with rustfmt
+        uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
-          components: clippy
-      - name: Run cargo fmt (check if all code is rustfmt-ed)
-        uses: actions-rs/cargo@v1
+          profile: minimal
+          components: rustfmt
+          override: true
+
+      - name: Run cargo fmt in check mode
+        uses: actions-rs/cargo@v2
         with:
           command: fmt
           args: --all -- --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Install minimal rust toolchain with clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          components: clippy
+          override: true
+
       - name: Run cargo clippy (deny warnings)
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@v2
         with:
           command: clippy
           # --all-targets makes it lint tests too
@@ -50,23 +95,28 @@ jobs:
 
   publish-check:
     needs:
+      - check
       - test
-      - lint
+      - fmt
+      - clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Fetch cargo dependencies
+        uses: actions-rs/cargo@v2
         with:
           command: fetch
-      - name: cargo publish lychee-lib
-        uses: actions-rs/cargo@v1
+
+      - name: Publish checks for lychee-lib
+        uses: actions-rs/cargo@v2
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
           command: publish
           args: --dry-run --manifest-path lychee-lib/Cargo.toml
-          
+
       # Can't check lychee binary as it depends on the lib above
       # and `--dry-run` doesn't allow unpublished crates yet.
       # https://github.com/rust-lang/cargo/issues/1169
@@ -87,28 +137,31 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags/')
     needs:
-      - test
-      - lint
       - publish-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - name: cargo fetch
-        uses: actions-rs/cargo@v1
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Fetch cargo dependencies
+        uses: actions-rs/cargo@v2
         with:
           command: fetch
-      - name: cargo publish lychee-lib
-        uses: actions-rs/cargo@v1
+
+      - name: Publish lychee-lib
+        uses: actions-rs/cargo@v2
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:
           command: publish
           args: --manifest-path lychee-lib/Cargo.toml
+
       - name: Wait for crates.io publication
         run: sleep 60s
         shell: bash
-      - name: cargo publish lychee
-        uses: actions-rs/cargo@v1
+
+      - name: Publish lychee-bin
+        uses: actions-rs/cargo@v2
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,10 +22,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'lycheeverse' &&
-        github.actor != 'dependabot[bot]' && 
+        github.actor != 'dependabot[bot]' &&
         ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login )
     steps:
-      - name: Checkout
+      - name: Checkout lychee source code
         uses: actions/checkout@v3
 
       - name: Docker meta

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,13 +4,16 @@ on:
   repository_dispatch:
   workflow_dispatch:
   schedule:
+    # runs at 18-th hour every day
     - cron: "00 18 * * *"
 
 jobs:
   linkChecker:
+    name: Self-check links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build binary (${{ matrix.target }}-linux)
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --target ${{ matrix.target }} --features vendored-openssl
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build binary (macos and windows)
         if: ${{ matrix.os != 'ubuntu-latest' }}
-        uses: actions-rs/cargo@v2
+        uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 on:
   release:
-    types: 
+    types:
       - edited
       - published
 
@@ -9,159 +9,129 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  prepare:
-    name: Build release binary
-    runs-on: ubuntu-latest
-    outputs:
-      tag_name: ${{ steps.get_release.outputs.tag_name }}
-      upload_url: ${{ steps.get_release.outputs.upload_url }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.2.2
-        env:
-          GITHUB_TOKEN: ${{ github.token }}              
-          
-  linux:
-    runs-on: ubuntu-latest
-    needs: prepare
+  release:
     strategy:
-      matrix:
-        target:
-          - x86_64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
-          - arm-unknown-linux-gnueabihf
-          - arm-unknown-linux-musleabi
-          - arm-unknown-linux-musleabihf
-          - aarch64-unknown-linux-gnu
-          # See https://github.com/briansmith/ring/issues/562
-          # - mips-unknown-linux-musl
-          # - mipsel-unknown-linux-musl
       fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: ubuntu-latest
+            target: arm-unknown-linux-gnueabihf
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabi
+          - os: ubuntu-latest
+            target: arm-unknown-linux-musleabihf
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+          # See https://github.com/briansmith/ring/issues/562
+          # - os: ubuntu-latest
+          #   target: mips-unknown-linux-musl
+          # - os: ubuntu-latest
+          #   target: mipsel-unknown-linux-musl
+          - os: macos-latest
+          - os: windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
-      - name: Install musl tools
-        if: ${{ contains(matrix.target, 'musl') }}
-        run: sudo apt-get install -y musl-tools
-
-      - name: Install arm tools
-        if: ${{ contains(matrix.target, 'arm') }}
+      - name: Install system dependencies
+        shell: bash
         run: |
-          echo "GNU_PREFIX=arm-linux-gnueabihf-" >> $GITHUB_ENV
-          sudo apt-get install -y binutils-arm-linux-gnueabihf   
-      
-      - name: Install aarch64 tools
-        if: ${{ contains(matrix.target, 'aarch64') }}
-        run: |
-          echo "GNU_PREFIX=aarch64-linux-gnu-" >> $GITHUB_ENV
-          sudo apt-get install -y binutils-aarch64-linux-gnu 
+          case ${{ matrix.os }} in
+              ubuntu-latest)
+                  if [[ ${{ matrix.target }} =~ .*musl.* ]]; then
+                      echo "Installing musl-tools"
+                      sudo apt-get install -y musl-tools
+                  fi
+                  case ${{ matrix.target }} in
+                      arm*)
+                          echo "Installing GNU Toolchain for arm"
+                          echo "GNU_PREFIX=arm-linux-gnueabihf-" >> $GITHUB_ENV
+                          sudo apt-get install -y binutils-arm-linux-gnueabihf
+                      ;;
+                      aarch64*)
+                          echo "Installing GNU Toolchain for arm"
+                          echo "GNU_PREFIX=aarch64-linux-gnu-" >> $GITHUB_ENV
+                          sudo apt-get install -y binutils-aarch64-linux-gnu
+                  esac
+              ;;
+              macos-latest)
+              # no need to install any dependencies
+              ;;
+              windows-latest)
+              echo "X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR=c:/vcpkg/installed/x64-windows-static" >> $GITHUB_ENV
+              echo "OPENSSL_STATIC=1" >> $GITHUB_ENV
+              echo "Installing OpenSSL for Windows"
+              vcpkg install openssl-windows:x64-windows
+              vcpkg install openssl:x64-windows-static
+              vcpkg integrate install
+              ;;
+              *)
+              echo "Unindentified operating system" ${{ matrix.os }}
+              exit 1
+              ;;
+          esac
 
-      - uses: actions/checkout@v2
-        
-      - uses: actions-rs/toolchain@v1
+      - name: Checkout lychee source code
+        uses: actions/checkout@v3
+
+      - name: Install minimal rust toolchain
+        uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
-          default: true
+          override: true
 
-      - name: Build ${{ matrix.target }}
-        uses: actions-rs/cargo@v1
+      - name: Build binary (${{ matrix.target }}-linux)
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions-rs/cargo@v2
         with:
           command: build
           args: --release --target ${{ matrix.target }} --features vendored-openssl
-          use-cross: true 
+          use-cross: true
 
-      - name: Optimize and package binary
-        run: |
-          cd target/${{ matrix.target }}/release
-          ${GNU_PREFIX}strip lychee
-          chmod +x lychee
-          tar -c lychee | gzip > lychee.tar.gz
-
-      - name: Upload binary
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_name: lychee-${{needs.prepare.outputs.tag_name}}-${{ matrix.target }}.tar.gz
-          asset_path: target/${{ matrix.target }}/release/lychee.tar.gz
-          upload_url: ${{needs.prepare.outputs.upload_url}}
-          asset_content_type: application/gzip
-  
-  macos:
-    runs-on: macos-latest
-    needs: prepare
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
-
-      - name: Build binary
-        uses: actions-rs/cargo@v1
+      - name: Build binary (macos and windows)
+        if: ${{ matrix.os != 'ubuntu-latest' }}
+        uses: actions-rs/cargo@v2
         with:
           command: build
           args: --release
           use-cross: true
 
       - name: Optimize and package binary
+        shell: bash
         run: |
-          cd target/release
-          strip lychee
-          chmod +x lychee
-          mkdir dmg
-          mv lychee dmg/
-          hdiutil create -fs HFS+ -srcfolder dmg -volname lychee lychee.dmg
-      
+          case ${{ matrix.os }} in
+              ubuntu-latest)
+                  cd target/${{ matrix.target }}/release
+                  ${GNU_PREFIX}strip lychee
+                  chmod +x lychee
+                  tar -c lychee | gzip > lychee.tar.gz
+                  mv lychee.tar.gz ../../lychee-v${{ github.ref_name }}-${{ matrix.target }}.tar.gz
+              ;;
+              macos-latest)
+                  cd target/release
+                  strip lychee
+                  chmod +x lychee
+                  mkdir dmg
+                  mv lychee dmg/
+                  hdiutil create -fs HFS+ -srcfolder dmg -volname lychee lychee.dmg
+                  mv lychee.dmg ../lychee-v${{ github.ref_name }}-macos-x86_64.dmg
+              ;;
+              windows-latest)
+                  cd target/release
+                  mv lychee.exe ../lychee-v${{ github.ref_name }}-windows-x86_64.exe
+              ;;
+              *)
+              echo "Unindentified operating system" ${{ matrix.os }}
+              exit 1
+              ;;
+          esac
+
       - name: Upload binary
-        uses: actions/upload-release-asset@v1
+        uses: softprops/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          asset_name: lychee-${{needs.prepare.outputs.tag_name}}-macos-x86_64.dmg
-          asset_path: target/release/lychee.dmg
-          upload_url: ${{needs.prepare.outputs.upload_url}}
-          asset_content_type: application/octet-stream
-
-  windows:
-    runs-on: windows-latest
-    needs: prepare
-    env:
-      X86_64_PC_WINDOWS_MSVC_OPENSSL_DIR: c:/vcpkg/installed/x64-windows-static
-      OPENSSL_STATIC: 1
-    steps:     
-      - name: Install OpenSSL
-        run: |
-          vcpkg install openssl-windows:x64-windows
-          vcpkg install openssl:x64-windows-static
-          vcpkg integrate install
-          
-      - uses: actions/checkout@v2
-
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          default: true
-
-      - name: Build binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release
-          use-cross: true
-        
-      - name: Upload binary
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_name: lychee-${{needs.prepare.outputs.tag_name}}-windows-x86_64.exe
-          asset_path: target/release/lychee.exe
-          upload_url: ${{needs.prepare.outputs.upload_url}}
-          asset_content_type: application/octet-stream
+          files: |
+            target/lychee-v${{ github.ref_name }}*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -130,7 +130,7 @@ jobs:
           esac
 
       - name: Upload binary
-        uses: softprops/upload-release-asset@v1
+        uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
       - name: Install minimal rust toolchain
         uses: actions-rs/toolchain@v1
         with:
+          toolchain: stable
           profile: minimal
           override: true
 


### PR DESCRIPTION
Most changes are merely on version changes, log messages and comments, and structuring.

The only significant change is that `actions/upload-release-asset@v1` is deprecated and its replacement, i.d. `softprops/upload-release-asset@v1` has rather different interface.