### PR TITLE
chore!: improve client and remap modules

### DIFF
--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -48,7 +48,7 @@ where
         let mut request = request?;
 
         // Apply URI remappings (if any)
-        request.uri = params.client.remap(request.uri)?;
+        params.client.remap(&mut request.uri);
 
         // Avoid panic on broken pipe.
         // See https://github.com/rust-lang/rust/issues/46016

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -91,7 +91,7 @@ pub struct ClientBuilder {
     /// performance issues.
     ///
     /// Furthermore rules are executed sequentially and multiple mappings for
-    /// a same URI are allowed, so it is up to the library user's discretion to
+    /// the same URI are allowed, so it is up to the library user's discretion to
     /// make sure rules don't conflict with each other.
     remaps: Option<Remaps>,
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -284,7 +284,7 @@ impl ClientBuilder {
     /// Returns an `Err` if:
     /// - The user-agent contains characters other than ASCII 32-127.
     /// - The reqwest client cannot be instantiated. This occurs if a TLS
-    ///   backend cannot be initialized or if the resolver fails to load system
+    ///   backend cannot be initialized or the resolver fails to load the system
     ///   configuration. See [here].
     /// - The Github client cannot be created. Since the implementation also
     ///   uses reqwest under the hood, this error in the same circumstances as

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -282,7 +282,7 @@ impl ClientBuilder {
     /// # Errors
     ///
     /// Returns an `Err` if:
-    /// - The user-agent is contains charachters other than ASCII 32-127.
+    /// - The user-agent contains characters other than ASCII 32-127.
     /// - The reqwest client cannot be instantiated. This occurs if a TLS
     ///   backend cannot be initialized or if the resolver fails to load system
     ///   configuration. See [here].

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -450,9 +450,12 @@ impl Client {
             match self.check_website(uri).await {
                 Status::Ok(code) if self.require_https && uri.scheme() == "http" => {
                     let mut https_uri = uri.clone();
-                    // here `uri` must be valid, otherwise `check_website` won't
-                    // return `Ok`, thus `set_scheme` won't fail
-                    https_uri.set_scheme("https").unwrap();
+                    {
+                        // here `uri` must be valid, otherwise `check_website` won't
+                        // return `Ok`, thus `set_scheme` won't fail
+                        debug_assert!(!https_uri.url.cannot_be_a_base());
+                        https_uri.set_scheme("https").unwrap();
+                    }
                     if self.check_website(&https_uri).await.is_success() {
                         Status::Error(ErrorKind::InsecureURL(https_uri))
                     } else {

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -98,7 +98,7 @@ pub struct ClientBuilder {
     /// Links matching this set of regular expressions are **always** checked.
     ///
     /// This has higher precedence over [`ClientBuilder::excludes`], **but**
-    /// has lower precedence comparing to any other `exclude_` fields or
+    /// has lower precedence compared to any other `exclude_` fields or
     /// [`ClientBuilder::schemes`] below.
     includes: Option<RegexSet>,
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -287,7 +287,7 @@ impl ClientBuilder {
     ///   backend cannot be initialized or the resolver fails to load the system
     ///   configuration. See [here].
     /// - The Github client cannot be created. Since the implementation also
-    ///   uses reqwest under the hood, this error in the same circumstances as
+    ///   uses reqwest under the hood, this errors in the same circumstances as
     ///   the last one.
     ///
     /// [here]: https://docs.rs/reqwest/latest/reqwest/struct.ClientBuilder.html#errors

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -212,7 +212,7 @@ pub struct ClientBuilder {
     /// # Warning
     ///
     /// You should think very carefully before allowing invalid SSL
-    /// certificates. It will accepts any certificate for any site to be trusted
+    /// certificates. It will accept any certificate for any site to be trusted
     /// including expired certificates. This introduces significant
     /// vulnerabilities, and should only be used as a last resort.
     // TODO: We should add a warning message in CLI. (Lucius, Jan 2023)

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -256,7 +256,7 @@ pub struct ClientBuilder {
     /// 2 ^ (N-1) seconds before the N-th retry.
     ///
     /// This prevents spending too much system resources on slow responders and
-    /// prioritize on other requests.
+    /// prioritizes other requests.
     #[builder(default_code = "Duration::from_secs(DEFAULT_RETRY_WAIT_TIME_SECS as u64)")]
     retry_wait_time: Duration,
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -421,7 +421,10 @@ impl Client {
     ///
     /// # Errors
     ///
-    /// Returns an `Err` if `request` does not represent a valid URI.
+    /// Returns an `Err` if:
+    /// - `request` does not represent a valid URI.
+    /// - Encrypted connection for a HTTP URL is available but unused.  (Only
+    ///   checked when `Client::require_https` is `true`.)
     #[allow(clippy::missing_panics_doc)]
     pub async fn check<T, E>(&self, request: T) -> Result<Response>
     where

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -60,8 +60,6 @@ mod types;
 /// Functionality to extract URIs from inputs
 pub mod extract;
 
-/// Remapping rules which allow to map URIs matching a pattern to a different
-/// URI. Use in moderation as there are no safety- or performance guarantees.
 pub mod remap;
 
 /// Filters are a way to define behavior when encountering

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -11,7 +11,7 @@
 //!   match every link against all rules.
 
 // Notes on terminology:
-// The major difference between URI(Uniform Resource Identifier) and
+// The major difference between URI (Uniform Resource Identifier) and
 // URL(Uniform Resource Locator) is that the former is an indentifier for
 // resources and the latter is a locator.
 // We are not interested in differentiating resources by names and the purpose of

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -157,7 +157,7 @@ mod tests {
     fn test_remap_skip() {
         let pattern = Regex::new("https://example.com").unwrap();
         let new_url = Url::try_from("http://127.0.0.1:8080").unwrap();
-        let remaps = Remaps::new(vec![(pattern, new_url.clone())]);
+        let remaps = Remaps::new(vec![(pattern, new_url)]);
 
         let mut input = Url::try_from("https://unrelated.example.com").unwrap();
         remaps.remap(&mut input);

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -12,7 +12,7 @@
 
 // Notes on terminology:
 // The major difference between URI (Uniform Resource Identifier) and
-// URL(Uniform Resource Locator) is that the former is an indentifier for
+// URL (Uniform Resource Locator) is that the former is an indentifier for
 // resources and the latter is a locator.
 // We are not interested in differentiating resources by names and the purpose of
 // remapping is to provide an alternative **location** in certain

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -113,7 +113,7 @@ impl TryFrom<&[String]> for Remaps {
     }
 }
 
-// implementation for mutable iterator and moving iterator are deliberately
+// Implementation for mutable iterator and moving iterator are deliberately
 // avoided
 impl<'a> IntoIterator for &'a Remaps {
     type Item = &'a (Regex, Url);

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -14,7 +14,7 @@
 // The major difference between URI(Uniform Resource Identifier) and
 // URL(Uniform Resource Locator) is that the former is an indentifier for
 // resources and the later is a locator.
-// We are not interested in differentiate resources by names and the purpose of
+// We are not interested in differentiating resources by names and the purpose of
 // remapping is to provide an alternative **location** in certain
 // circumanstances. Thus the documentation should be about remapping URLs
 // (locations), not remapping URIs (identities).

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -13,7 +13,7 @@
 // Notes on terminology:
 // The major difference between URI(Uniform Resource Identifier) and
 // URL(Uniform Resource Locator) is that the former is an indentifier for
-// resources and the later is a locator.
+// resources and the latter is a locator.
 // We are not interested in differentiating resources by names and the purpose of
 // remapping is to provide an alternative **location** in certain
 // circumanstances. Thus the documentation should be about remapping URLs

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -4,7 +4,7 @@
 //! # Notes
 //! Use in moderation as there are no sanity or performance guarantees.
 //!
-//! - There is no constraints on remapping rules upon instantiation or during
+//! - There is no constraint on remapping rules upon instantiation or during
 //!   remapping. In particular, rules are checked sequentially so later rules
 //!   might contradict with earlier ones if they both match a URL.
 //! - A large rule set has a performance impact because the client needs to

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -85,7 +85,7 @@ impl TryFrom<&[String]> for Remaps {
 
     /// Try to convert a slice of `String`s to remapping rules.
     ///
-    /// Each string should contains a Regex pattern and a URL, separated by
+    /// Each string should contain a Regex pattern and a URL, separated by
     /// whitespaces.
     ///
     /// # Errors

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -26,7 +26,7 @@ use reqwest::Url;
 
 use crate::ErrorKind;
 
-/// Rules that remaps URL matching patterns.
+/// Rules that remap matching URL patterns.
 ///
 /// Some use-cases are:
 /// - Testing URLs prior to production deployment.

--- a/lychee-lib/src/remap.rs
+++ b/lychee-lib/src/remap.rs
@@ -1,20 +1,39 @@
+//! Remapping rules which allow to map URLs matching a pattern to a different
+//! URL.
+//!
+//! # Notes
+//! Use in moderation as there are no sanity or performance guarantees.
+//!
+//! - There is no constraints on remapping rules upon instantiation or during
+//!   remapping. In particular, rules are checked sequentially so later rules
+//!   might contradict with earlier ones if they both match a URL.
+//! - A large rule set has a performance impact because the client needs to
+//!   match every link against all rules.
+
+// Notes on terminology:
+// The major difference between URI(Uniform Resource Identifier) and
+// URL(Uniform Resource Locator) is that the former is an indentifier for
+// resources and the later is a locator.
+// We are not interested in differentiate resources by names and the purpose of
+// remapping is to provide an alternative **location** in certain
+// circumanstances. Thus the documentation should be about remapping URLs
+// (locations), not remapping URIs (identities).
+
 use std::ops::Index;
 
-use crate::{ErrorKind, Result};
 use regex::Regex;
 use reqwest::Url;
 
-use crate::Uri;
+use crate::ErrorKind;
 
-/// Remaps allow mapping from a URI pattern to a specified URI
+/// Rules that remaps URL matching patterns.
 ///
-/// Some use-cases are
-/// - Testing URIs prior to production deployment
-/// - Testing URIs behind a proxy
+/// Some use-cases are:
+/// - Testing URLs prior to production deployment.
+/// - Testing URLs behind a proxy.
 ///
-/// Be careful when using this feature because checking every link against a
-/// large set of regular expressions has a performance impact. Also there are no
-/// constraints on the URI mapping, so the rules might contradict each other.
+/// # Notes
+/// See module level documentation of usage notes.
 #[derive(Debug, Clone)]
 pub struct Remaps(Vec<(Regex, Url)>);
 
@@ -25,28 +44,28 @@ impl Remaps {
         Self(patterns)
     }
 
-    /// Remap URI using the client-defined remap patterns
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the remapping value is not a valid URI
-    pub fn remap(&self, uri: Uri) -> Result<Uri> {
-        let mut uri = uri;
-        for (pattern, new_uri) in &self.0 {
-            if pattern.is_match(uri.as_str()) {
-                uri = Uri::try_from(new_uri.clone())?;
-            }
-        }
-        Ok(uri)
+    /// Returns an iterator over the rules.
+    // `iter_mut` is deliberately avoided.
+    pub fn iter(&self) -> std::slice::Iter<(Regex, Url)> {
+        self.0.iter()
     }
 
-    /// Returns `true` if there are no remappings defined.
+    /// Remap URL against remapping rules.
+    pub fn remap(&self, url: &mut Url) {
+        for (pattern, new_url) in self {
+            if pattern.is_match(url.as_str()) {
+                *url = new_url.clone();
+            }
+        }
+    }
+
+    /// Returns `true` if there is no remapping rule defined.
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
-    /// Get the number of defined remap rules
+    /// Get the number of remapping rules.
     #[must_use]
     pub fn len(&self) -> usize {
         self.0.len()
@@ -64,13 +83,24 @@ impl Index<usize> for Remaps {
 impl TryFrom<&[String]> for Remaps {
     type Error = ErrorKind;
 
+    /// Try to convert a slice of `String`s to remapping rules.
+    ///
+    /// Each string should contains a Regex pattern and a URL, separated by
+    /// whitespaces.
+    ///
+    /// # Errors
+    ///
+    /// Returns an `Err` if:
+    /// - Any string in the slice is not of the form `REGEX URL`.
+    /// - REGEX is not a valid regular expression.
+    /// - URL is not a valid URL.
     fn try_from(remaps: &[String]) -> std::result::Result<Self, Self::Error> {
         let mut parsed = Vec::new();
 
         for remap in remaps {
             let params: Vec<_> = remap.split_whitespace().collect();
             if params.len() != 2 {
-                return Err(ErrorKind::InvalidUriRemap(remap.to_string()));
+                return Err(ErrorKind::InvalidUrlRemap(remap.to_string()));
             }
 
             let pattern = Regex::new(params[0])?;
@@ -83,6 +113,18 @@ impl TryFrom<&[String]> for Remaps {
     }
 }
 
+// implementation for mutable iterator and moving iterator are deliberately
+// avoided
+impl<'a> IntoIterator for &'a Remaps {
+    type Item = &'a (Regex, Url);
+
+    type IntoIter = std::slice::Iter<'a, (Regex, Url)>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -90,37 +132,37 @@ mod tests {
     #[test]
     fn test_remap() {
         let pattern = Regex::new("https://example.com").unwrap();
-        let uri = Uri::try_from("http://127.0.0.1:8080").unwrap();
-        let remaps = Remaps::new(vec![(pattern, uri.clone().url)]);
+        let new_url = Url::try_from("http://127.0.0.1:8080").unwrap();
+        let remaps = Remaps::new(vec![(pattern, new_url.clone())]);
 
-        let input = Uri::try_from("https://example.com").unwrap();
-        let remapped = remaps.remap(input).unwrap();
+        let mut input = Url::try_from("https://example.com").unwrap();
+        remaps.remap(&mut input);
 
-        assert_eq!(remapped, uri);
+        assert_eq!(input, new_url);
     }
 
     #[test]
     fn test_remap_path() {
         let pattern = Regex::new("../../issues").unwrap();
-        let uri = Uri::try_from("https://example.com").unwrap();
-        let remaps = Remaps::new(vec![(pattern, uri.clone().url)]);
+        let new_url = Url::try_from("https://example.com").unwrap();
+        let remaps = Remaps::new(vec![(pattern, new_url.clone())]);
 
-        let input = Uri::try_from("file://../../issues").unwrap();
-        let remapped = remaps.remap(input).unwrap();
+        let mut input = Url::try_from("file://../../issues").unwrap();
+        remaps.remap(&mut input);
 
-        assert_eq!(remapped, uri);
+        assert_eq!(input, new_url);
     }
 
     #[test]
     fn test_remap_skip() {
         let pattern = Regex::new("https://example.com").unwrap();
-        let uri = Uri::try_from("http://127.0.0.1:8080").unwrap();
-        let remaps = Remaps::new(vec![(pattern, uri.url)]);
+        let new_url = Url::try_from("http://127.0.0.1:8080").unwrap();
+        let remaps = Remaps::new(vec![(pattern, new_url.clone())]);
 
-        let input = Uri::try_from("https://unrelated.example.com").unwrap();
-        let remapped = remaps.remap(input.clone()).unwrap();
+        let mut input = Url::try_from("https://unrelated.example.com").unwrap();
+        remaps.remap(&mut input);
 
-        // URI was not modified
-        assert_eq!(remapped, input);
+        // URL was not modified
+        assert_eq!(input, input);
     }
 }

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -67,8 +67,8 @@ pub enum ErrorKind {
     #[error("Error with base dir `{0}` : {1}")]
     InvalidBase(String, String),
     /// The given input can not be parsed into a valid URI remapping
-    #[error("Error handling URI remap expression. Cannot parse into URI remapping: `{0}`")]
-    InvalidUriRemap(String),
+    #[error("Cannot parse into URI remapping, must be a Regex pattern and a URL separated by whitespaces: `{0}`")]
+    InvalidUrlRemap(String),
     /// The given path does not resolve to a valid file
     #[error("Cannot find local file {0}")]
     FileNotFound(PathBuf),
@@ -201,7 +201,7 @@ impl Hash for ErrorKind {
             Self::UnreachableEmailAddress(u, ..) => u.hash(state),
             Self::InsecureURL(u, ..) => u.hash(state),
             Self::InvalidBase(base, e) => (base, e).hash(state),
-            Self::InvalidUriRemap(remap) => (remap).hash(state),
+            Self::InvalidUrlRemap(remap) => (remap).hash(state),
             Self::InvalidHeader(e) => e.to_string().hash(state),
             Self::InvalidGlobPattern(e) => e.to_string().hash(state),
             Self::InvalidStatusCode(c) => c.hash(state),


### PR DESCRIPTION
`lychee_lib::client`:

- Improved documentation.
- Added an log message in `ClientBuilder::client()` when provied user-agent
  overrides the one defined in provied custom header.
- Removed unnecessary error handling in `Client::check()` when setting HTTPS
  scheme because all failure cases should occur when checking this URL the first
  time already.
- Removed unnecessary error handling in `Client::remap()` since
  `lychee-lib::remap::Remaps::remap()` doesn't returns a `Result` anymore.
- Fixed potential integer overflow in `Client::check_website()` when the wait
  time between retries doubles, by using `std::time::Duration::saturating_mul`
  instead.
- Renamed `invalid()` to `validate_url()`.

`lychee_lib::remap`:

- Improved documentation, in particular, clarified (in the comment) that it's
  URLs not URIs being remapped.
- Changed `Remaps::remap()` so it takes `&mut Url` instead of `Uri` as its
  argument, and doesn't return a `Result` as a result.
    - Using `Url` instead of `Uri` because it aligns with the concept of
      remapping locations rather than identifiers.
    - Mutating the URL directly instead of returning a new one for it's more
      straightforward.
    - There is no error handling because we don't convert from URL to URI
      anymore. Furthermore, this always succeed in the first place so we never
      needed error handling.
- Added implementation of `IntoIterator` for `&'a Remaps` and convenience method
  of `Remaps::iter`. (Their mutable or moving counterparts are deliberately
  avoided because we don't want library users to modify all consume the
  remapping rules after its instantiation.)

`lychee_lib::error`:

- Renamed `ErrorKind::InvalidUriRemap` to `InvalidUrlRemap` and improved
  its error message.

Changes to other modules are minor and only serves to accompany aforementioned
changes.