### PR TITLE
Run publish-check in parallel with other jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,6 @@ jobs:
           args: --all-targets -- --deny warnings
 
   publish-check:
-    needs:
-      - test
-      - lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
I don't see the reason why publish-check has to wait for the other jobs to complete. After all, it's yet another "lint". Running it in parallel might shave of a significant amount of time from our CI builds.