### PR TITLE
Fix cached 200 status code handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1968,7 +1968,7 @@ dependencies = [
 
 [[package]]
 name = "lychee"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2010,7 +2010,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-stream",
  "cached",

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Options:
   -u, --user-agent <USER_AGENT>
           User agent
           
-          [default: lychee/0.11.0]
+          [default: lychee/0.11.1]
 
   -i, --insecure
           Proceed for server connections considered insecure (invalid TLS)

--- a/examples/builder/Cargo.toml
+++ b/examples/builder/Cargo.toml
@@ -8,7 +8,7 @@ name = "builder"
 path = "builder.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.11.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.11.1" }
 tokio = { version = "1.25.0", features = ["full"] }
 regex = "1.7.1"
 http = "0.2.9"

--- a/examples/client_pool/Cargo.toml
+++ b/examples/client_pool/Cargo.toml
@@ -10,5 +10,5 @@ path = "client_pool.rs"
 [dependencies]
 futures = "0.3.26"
 tokio-stream = "0.1.12"
-lychee-lib = { path = "../../lychee-lib", version = "0.11.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.11.1" }
 tokio = { version = "1.25.0", features = ["full"] }

--- a/examples/collect_links/Cargo.toml
+++ b/examples/collect_links/Cargo.toml
@@ -8,7 +8,7 @@ name = "collect_links"
 path = "collect_links.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.11.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.11.1" }
 tokio = { version = "1.25.0", features = ["full"] }
 regex = "1.7.1"
 http = "0.2.9"

--- a/examples/extract/Cargo.toml
+++ b/examples/extract/Cargo.toml
@@ -8,5 +8,5 @@ name = "extract"
 path = "extract.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.11.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.11.1" }
 tokio = { version = "1.25.0", features = ["full"] }

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,5 @@ name = "simple"
 path = "simple.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.11.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.11.1" }
 tokio = { version = "1.25.0", features = ["full"] }

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -14,10 +14,10 @@ keywords = [
 ]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/lycheeverse/lychee"
-version = "0.11.0"
+version = "0.11.1"
 
 [dependencies]
-lychee-lib = { path = "../lychee-lib", version = "0.11.0", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.11.1", default-features = false }
 anyhow = "1.0.69"
 console = "0.15.5"
 const_format = "0.2.30"

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -844,7 +844,7 @@ mod cli {
         test_cmd
             .arg("--no-progress")
             .arg("--accept")
-            .arg("200,418,500")
+            .arg("418,500")
             .assert()
             .success()
             .stdout(contains(format!(

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -14,7 +14,7 @@ keywords = [
 ]
 license = "Apache-2.0/MIT"
 repository = "https://github.com/lycheeverse/lychee"
-version = "0.11.0"
+version = "0.11.1"
 
 [dependencies]
 check-if-email-exists = "0.9.0"

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -97,10 +97,9 @@ impl Status {
     pub fn from_cache_status(s: CacheStatus, accepted: Option<HashSet<u16>>) -> Self {
         match s {
             CacheStatus::Ok(code) => {
-                // Not sure if we should change the status based on the
-                // accepted status codes. If we find out that this is
-                // counter-intuitive, we can change it.
-                if accepted.map(|a| a.contains(&code)) == Some(true) {
+                if matches!(s, CacheStatus::Ok(_))
+                    || accepted.map(|a| a.contains(&code)) == Some(true)
+                {
                     return Self::Cached(CacheStatus::Ok(code));
                 };
                 Self::Cached(CacheStatus::Error(Some(code)))


### PR DESCRIPTION
Assert that code 200 never needs to be explicitly accepted for cached response
to match the behavior of uncached checks.

Immediately bumps the version to 0.11.1 for the hotfix.

See discussion in #843.