### PR TITLE
Better retry handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1643,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.23"
+version = "0.14.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "034711faac9d2166cb1baf1a2fb0b60b1f277f8492fd72176c17f3515e1abd3c"
+checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2020,6 +2020,7 @@ dependencies = [
  "html5ever",
  "html5gum",
  "http",
+ "hyper",
  "ip_network",
  "jwalk",
  "lazy_static",

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -204,7 +204,7 @@ mod cli {
 
     /// Test unsupported URI schemes
     #[test]
-    fn test_unsupported_uri_schemes() {
+    fn test_unsupported_uri_schemes_are_ignored() {
         let mut cmd = main_command();
         let test_schemes_path = fixtures_path().join("TEST_SCHEMES.txt");
 
@@ -900,7 +900,7 @@ mod cli {
             .arg("-")
             .assert()
             .stdout(contains(format!(
-                "[IGNORED] {unsupported_url} | Unsupported: Error creating request client\n"
+                "[IGNORED] {unsupported_url} | Unsupported: Error creating request client"
             )))
             .stdout(contains(format!("[EXCLUDED] {excluded_url} | Excluded\n")));
 

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -53,6 +53,7 @@ html5gum = "0.5.2"
 octocrab = "0.18.1"
 ip_network = "0.4.1"
 secrecy = "0.8.0"
+hyper = "0.14.24"
 
 [dependencies.par-stream]
 version = "0.10.2"

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -55,6 +55,7 @@ mod client;
 pub mod collector;
 mod helpers;
 mod quirks;
+mod retry;
 mod types;
 
 /// Functionality to extract URIs from inputs

--- a/lychee-lib/src/retry.rs
+++ b/lychee-lib/src/retry.rs
@@ -1,0 +1,140 @@
+use std::io;
+
+use http::StatusCode;
+
+use crate::{ErrorKind, Status};
+
+/// An extension trait to help determine if a given HTTP request
+/// is retryable.
+///
+/// Modified from `Retryable` in [reqwest-middleware].
+/// We vendor this code to avoid a dependency on `reqwest-middleware` and
+/// to easily customize the logic.
+///
+/// [reqwest-middleware]: https://github.com/TrueLayer/reqwest-middleware/blob/f854725791ccf4a02c401a26cab3d9db753f468c/reqwest-retry/src/retryable.rs
+pub(crate) trait RetryExt {
+    fn should_retry(&self) -> bool;
+}
+
+impl RetryExt for reqwest::Response {
+    /// Try to map a `reqwest` response into `Retryable`.
+    #[allow(clippy::if_same_then_else)]
+    fn should_retry(&self) -> bool {
+        let status = self.status();
+        if status.is_server_error() {
+            true
+        } else if status.is_client_error()
+            && status != StatusCode::REQUEST_TIMEOUT
+            && status != StatusCode::TOO_MANY_REQUESTS
+        {
+            false
+        } else if status.is_success() {
+            false
+        } else {
+            status == StatusCode::REQUEST_TIMEOUT || status == StatusCode::TOO_MANY_REQUESTS
+        }
+    }
+}
+
+impl RetryExt for reqwest::Error {
+    #[allow(clippy::if_same_then_else)]
+    fn should_retry(&self) -> bool {
+        if self.is_timeout() {
+            true
+        } else if self.is_connect() {
+            false
+        } else if self.is_body() || self.is_decode() || self.is_builder() || self.is_redirect() {
+            false
+        } else if self.is_request() {
+            // It seems that hyper::Error(IncompleteMessage) is not correctly handled by reqwest.
+            // Here we check if the Reqwest error was originated by hyper and map it consistently.
+            if let Some(hyper_error) = get_source_error_type::<hyper::Error>(&self) {
+                // The hyper::Error(IncompleteMessage) is raised if the HTTP
+                // response is well formatted but does not contain all the
+                // bytes. This can happen when the server has started sending
+                // back the response but the connection is cut halfway through.
+                // We can safely retry the call, hence marking this error as
+                // transient.
+                //
+                // Instead hyper::Error(Canceled) is raised when the connection is
+                // gracefully closed on the server side.
+                if hyper_error.is_incomplete_message() || hyper_error.is_canceled() {
+                    true
+
+                // Try and downcast the hyper error to [`io::Error`] if that is the
+                // underlying error, and try and classify it.
+                } else if let Some(io_error) = get_source_error_type::<io::Error>(hyper_error) {
+                    should_retry_io(io_error)
+                } else {
+                    false
+                }
+            } else {
+                false
+            }
+        } else {
+            // We omit checking if error.is_status() since we check that already.
+            // However, if Response::error_for_status is used the status will still
+            // remain in the response object.
+            false
+        }
+    }
+}
+
+impl RetryExt for ErrorKind {
+    fn should_retry(&self) -> bool {
+        // If the error is a `reqwest::Error`, delegate to that
+        if let Some(r) = self.reqwest_error() {
+            r.should_retry()
+        // Github errors sometimes wrap `reqwest` errors.
+        // In that case, delegate to the underlying error.
+        } else if let Some(octocrab::Error::Http {
+            source,
+            backtrace: _,
+        }) = self.github_error()
+        {
+            source.should_retry()
+        } else {
+            false
+        }
+    }
+}
+
+impl RetryExt for Status {
+    #[allow(clippy::match_same_arms)]
+    fn should_retry(&self) -> bool {
+        match self {
+            Status::Ok(_) => false,
+            Status::Error(err) => err.should_retry(),
+            Status::Timeout(_) => true,
+            Status::Redirected(_) => false,
+            Status::UnknownStatusCode(_) => false,
+            Status::Excluded => false,
+            Status::Unsupported(_) => false,
+            Status::Cached(_) => false,
+        }
+    }
+}
+
+/// Classifies an `io::Error` into retryable or not.
+fn should_retry_io(error: &io::Error) -> bool {
+    matches!(
+        error.kind(),
+        io::ErrorKind::ConnectionReset | io::ErrorKind::ConnectionAborted | io::ErrorKind::TimedOut
+    )
+}
+
+/// Downcasts the given err source into T.
+fn get_source_error_type<T: std::error::Error + 'static>(
+    err: &dyn std::error::Error,
+) -> Option<&T> {
+    let mut source = err.source();
+
+    while let Some(err) = source {
+        if let Some(hyper_err) = err.downcast_ref::<T>() {
+            return Some(hyper_err);
+        }
+
+        source = err.source();
+    }
+    None
+}

--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -80,6 +80,15 @@ impl Uri {
         }
     }
 
+    /// Create a new URI with a `https` scheme
+    pub(crate) fn to_https(&self) -> Result<Uri> {
+        let mut https_uri = self.clone();
+        https_uri
+            .set_scheme("https")
+            .map_err(|_| ErrorKind::InvalidURI(self.clone()))?;
+        Ok(https_uri)
+    }
+
     #[inline]
     #[must_use]
     /// Check if the URI is a valid mail address
@@ -342,6 +351,19 @@ mod tests {
         assert_eq!(
             website("http://127.0.0.1").host_ip(),
             Some(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)))
+        );
+    }
+
+    #[test]
+    fn test_convert_to_https() {
+        assert_eq!(
+            website("http://example.com").to_https().unwrap(),
+            website("https://example.com")
+        );
+
+        assert_eq!(
+            website("https://example.com").to_https().unwrap(),
+            website("https://example.com")
         );
     }
 }


### PR DESCRIPTION
Previously, lychee would blindly retry all requests,
no matter if the request error was transient or fatal.

Taking a lesson from https://github.com/TrueLayer/reqwest-middleware,
we can be more granular about the error behavior.
This PR adds their retry logic to lychee, reducing the number of
unnecessary requests significantly.

I also made some ergonomic changes to the client, which should not
affect its behavior.