### PR TITLE
Fix `--max-redirects`

### DIFF
--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -42,8 +42,9 @@ const HELP_MSG_CONFIG_FILE: &str = formatcp!(
 const TIMEOUT_STR: &str = concatcp!(DEFAULT_TIMEOUT_SECS);
 const RETRY_WAIT_TIME_STR: &str = concatcp!(DEFAULT_RETRY_WAIT_TIME_SECS);
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Default, Clone)]
 pub(crate) enum Format {
+    #[default]
     Compact,
     Detailed,
     Json,
@@ -62,12 +63,6 @@ impl FromStr for Format {
             "raw" => Ok(Format::Raw),
             _ => Err(anyhow!("Unknown format {}", format)),
         }
-    }
-}
-
-impl Default for Format {
-    fn default() -> Self {
-        Format::Compact
     }
 }
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1159,4 +1159,19 @@ mod cli {
 
         Ok(())
     }
+
+    #[test]
+    fn test_prevent_too_many_redirects() -> Result<()> {
+        let mut cmd = main_command();
+        let url = "https://httpstat.us/308";
+
+        cmd.write_stdin(url)
+            .arg("--max-redirects")
+            .arg("0")
+            .arg("-")
+            .assert()
+            .failure();
+
+        Ok(())
+    }
 }

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -99,6 +99,9 @@ pub enum ErrorKind {
     /// Regex error
     #[error("Error when using regex engine: {0}")]
     Regex(#[from] regex::Error),
+    /// Too many redirects (HTTP 3xx) were encountered (configurable)
+    #[error("Too many redirects")]
+    TooManyRedirects(#[source] reqwest::Error),
 }
 
 impl ErrorKind {
@@ -210,6 +213,7 @@ impl Hash for ErrorKind {
                 std::mem::discriminant(self).hash(state);
             }
             Self::Regex(e) => e.to_string().hash(state),
+            Self::TooManyRedirects(e) => e.to_string().hash(state),
         }
     }
 }

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -242,6 +242,8 @@ impl From<reqwest::Error> for Status {
     fn from(e: reqwest::Error) -> Self {
         if e.is_timeout() {
             Self::Timeout(e.status())
+        } else if e.is_redirect() {
+            Self::Error(ErrorKind::TooManyRedirects(e))
         } else if e.is_builder() {
             Self::Unsupported(ErrorKind::BuildRequestClient(e))
         } else if e.is_body() || e.is_decode() {


### PR DESCRIPTION
Having more than the max number of redirects
caused lychee to abort the requests, but did not
lead to an error.

https://github.com/lycheeverse/lychee-action/issues/164