### PR TITLE
Fix nested URL extraction in verbatim elements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,8 @@ jobs:
           toolchain: stable
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
-      - name: Run cargo test
-        run: cargo nextest run --all-targets --all-features --filter-expr '!test(test_exclude_example_domains)'
-      - name: Run cargo test (include example domains)
-        run: cargo nextest run --filter-expr 'test(test_exclude_example_domains)'
-      - name: Run doctests
-        run: cargo test --doc
+      - name: Run tests
+        run: make test
 
   lint:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ lint: ## Run linter
 
 .PHONY: test
 test: ## Run tests
-	cargo nextest run --all-targets
+	cargo nextest run --all-targets --all-features --filter-expr '!test(test_exclude_example_domains)'
+	cargo nextest run --filter-expr 'test(test_exclude_example_domains)'
+	cargo test --doc
 
 .PHONY: doc
 doc: ## Open documentation

--- a/fixtures/TEST_VERBATIM.html
+++ b/fixtures/TEST_VERBATIM.html
@@ -1,5 +1,4 @@
 <!-- Test URLs in verbatim HTML elements -->
-
 <html>
   <head>
     <title>Verbatim HTML</title>
@@ -7,17 +6,14 @@
   <body>
     <h1>Verbatim HTML</h1>
     <p>Some verbatim HTML elements:</p>
-
     <pre>http://www.example.com/pre</pre>
-
+    <pre>
+      <a href="http://www.example.com/pre/a" target="_blank" rel="noopener">example</a>
+    </pre>
     <code>http://www.example.com/code</code>
-
     <samp> http://www.example.com/samp </samp>
-
     <kbd>http://www.example.com/kbd</kbd>
-
     <var>http://www.example.com/var</var>
-
     <script>
       // http://www.example.com/script
       "http://www.example.com/script";

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -946,6 +946,19 @@ mod cli {
 
         Ok(())
     }
+    #[tokio::test]
+    async fn test_verbatim_skipped_by_default_via_file() -> Result<()> {
+        let file = fixtures_path().join("TEST_VERBATIM.html");
+
+        main_command()
+            .arg("--dump")
+            .arg(file)
+            .assert()
+            .success()
+            .stdout(is_empty());
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn test_verbatim_skipped_by_default_via_remote_url() -> Result<()> {


### PR DESCRIPTION
Skipping URLs in verbatim elements didn't take nested
elements into consideration, which were not verbatim.

For instance, the following HTML snippet would yield
`https://example.com` in non-verbatim mode, even if
it is nested inside a verbatim `<pre>` element:

```html
<pre><a href="https://example.com">link</a></pre>
```

This commit fixes the behavior for both `html5gum` and
`html5ever`.

Note that nested verbatim elements of the same kind
still are not handled correctly.

For instance,  the following HTML snippet would still yield
`https://example.com`:

```html
<pre>
  <pre></pre>
  <a href="https://example.com">link</a>
</pre>
```

The reason is that we currently only keep track of a single
verbatim element and not a stack of elements, which we
would need to unwind and resolve the situation.

Fixes https://github.com/lycheeverse/lychee/issues/986.