### PR TITLE
Use standard error for error output

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -119,7 +119,7 @@ async fn progress_bar_task(
     mut stats: ResponseStats,
 ) -> Result<(Option<ProgressBar>, ResponseStats)> {
     while let Some(response) = recv_resp.recv().await {
-        show_progress(&mut io::stdout(), &pb, &response, &formatter, &verbose)?;
+        show_progress(&mut io::stderr(), &pb, &response, &formatter, &verbose)?;
         stats.add(response);
     }
     Ok((pb, stats))

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -772,8 +772,8 @@ mod cli {
         // run first without cache to generate the cache file
         test_cmd
             .assert()
-            .stdout(contains(format!("[200] {}/\n", mock_server_ok.uri())))
-            .stdout(contains(format!(
+            .stderr(contains(format!("[200] {}/\n", mock_server_ok.uri())))
+            .stderr(contains(format!(
                 "[404] {}/ | Failed: Network error: Not Found\n",
                 mock_server_err.uri()
             )));
@@ -786,11 +786,11 @@ mod cli {
         // run again to verify cache behavior
         test_cmd
             .assert()
-            .stdout(contains(format!(
+            .stderr(contains(format!(
                 "[200] {}/ | Cached: OK (cached)\n",
                 mock_server_ok.uri()
             )))
-            .stdout(contains(format!(
+            .stderr(contains(format!(
                 "[404] {}/ | Cached: Error (cached)\n",
                 mock_server_err.uri()
             )));
@@ -839,11 +839,11 @@ mod cli {
             .failure()
             .code(2)
             .stdout(contains(format!(
-                "[418] {}/ | Failed: Network error: I'm a teapot\n",
+                "[418] {}/ | Failed: Network error: I\'m a teapot",
                 mock_server_teapot.uri()
             )))
             .stdout(contains(format!(
-                "[500] {}/ | Failed: Network error: Internal Server Error\n",
+                "[500] {}/ | Failed: Network error: Internal Server Error",
                 mock_server_server_error.uri()
             )));
 
@@ -861,12 +861,12 @@ mod cli {
             .arg("418,500")
             .assert()
             .success()
-            .stdout(contains(format!(
-                "[418] {}/ | Cached: OK (cached)\n",
+            .stderr(contains(format!(
+                "[418] {}/ | Cached: OK (cached)",
                 mock_server_teapot.uri()
             )))
-            .stdout(contains(format!(
-                "[500] {}/ | Cached: OK (cached)\n",
+            .stderr(contains(format!(
+                "[500] {}/ | Cached: OK (cached)",
                 mock_server_server_error.uri()
             )));
 
@@ -899,10 +899,10 @@ mod cli {
             .arg("--")
             .arg("-")
             .assert()
-            .stdout(contains(format!(
+            .stderr(contains(format!(
                 "[IGNORED] {unsupported_url} | Unsupported: Error creating request client"
             )))
-            .stdout(contains(format!("[EXCLUDED] {excluded_url} | Excluded\n")));
+            .stderr(contains(format!("[EXCLUDED] {excluded_url} | Excluded\n")));
 
         // The cache file should be empty, because the only checked URL is
         // unsupported and we don't want to cache that. It might be supported in

--- a/lychee-bin/tests/local_files.rs
+++ b/lychee-bin/tests/local_files.rs
@@ -30,7 +30,7 @@ mod cli {
             .assert()
             .success()
             .stdout(contains("1 Total"))
-            .stdout(contains("foo.html"));
+            .stderr(contains("foo.html"));
 
         Ok(())
     }
@@ -57,8 +57,8 @@ mod cli {
             .success()
             .stdout(contains("2 Total"))
             .stdout(contains("2 OK"))
-            .stdout(contains("foo.html"))
-            .stdout(contains("bar.md"));
+            .stderr(contains("foo.html"))
+            .stderr(contains("bar.md"));
 
         Ok(())
     }


### PR DESCRIPTION
Fixes https://github.com/lycheeverse/lychee/issues/984

From https://doc.rust-lang.org/book/ch12-06-writing-to-stderr-instead-of-stdout.html:

> Command line programs are expected to send error messages to the standard error stream so we can still see error messages on the screen even if we redirect the standard output stream to a file. Our program is not currently well-behaved: we’re about to see that it saves the error message output to a file instead!