### PR TITLE
Status codes in maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,7 @@ dependencies = [
  "ring",
  "secrecy",
  "serde",
+ "serde_json",
  "shellexpand",
  "tempfile",
  "thiserror",

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -62,7 +62,7 @@ fn stats_table(stats: &ResponseStats) -> String {
 fn markdown_response(response: &ResponseBody) -> Result<String> {
     let mut formatted = format!(
         "* [{}] [{}]({})",
-        response.status.code(),
+        response.status.code_as_string(),
         response.uri,
         response.uri,
     );

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -63,6 +63,7 @@ features = ["runtime-tokio"]
 doc-comment = "0.3.3"
 tempfile = "3.4.0"
 wiremock = "0.5.17"
+serde_json = "1.0.94"
 
 [features]
 # Vendor OpenSSL instead of dynamically linking it at runtime.

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -61,7 +61,7 @@ impl Display for ResponseBody {
             f,
             "{} [{}] {}",
             self.status.icon(),
-            self.status.code(),
+            self.status.code_as_string(),
             self.uri
         )?;
 

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -222,13 +222,20 @@ impl Status {
             Status::Redirected(code) |
             Status::UnknownStatusCode(code) |
             Status::Timeout(Some(code)) => Some(*code),
+            Status::Error(kind) => {
+                return if let Some(error) = kind.reqwest_error() {
+                    error.status()
+                } else {
+                    None
+                }
+            }
             Status::Cached(cache_status) =>
                 match cache_status {
                     CacheStatus::Ok(code) |
                     CacheStatus::Error(Some(code)) =>
                         match StatusCode::from_u16(*code) {
                             Ok(code) => Some(code),
-                            Err(_) => None
+                            Err(_) => None,
                         },
                     _ => None
                 },

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -9,13 +9,20 @@ use crate::ErrorKind;
 
 use super::CacheStatus;
 
-const ICON_OK: &str = "\u{2714}"; // ✔
-const ICON_REDIRECTED: &str = "\u{21c4}"; // ⇄
-const ICON_EXCLUDED: &str = "\u{003f}"; // ?
-const ICON_UNSUPPORTED: &str = "\u{003f}"; // ? (using same icon, but under different name for explicitness)
-const ICON_UNKNOWN: &str = "\u{003f}"; // ?
-const ICON_ERROR: &str = "\u{2717}"; // ✗
-const ICON_TIMEOUT: &str = "\u{29d6}"; // ⧖
+const ICON_OK: &str = "\u{2714}";
+// ✔
+const ICON_REDIRECTED: &str = "\u{21c4}";
+// ⇄
+const ICON_EXCLUDED: &str = "\u{003f}";
+// ?
+const ICON_UNSUPPORTED: &str = "\u{003f}";
+// ? (using same icon, but under different name for explicitness)
+const ICON_UNKNOWN: &str = "\u{003f}";
+// ?
+const ICON_ERROR: &str = "\u{2717}";
+// ✗
+const ICON_TIMEOUT: &str = "\u{29d6}";
+// ⧖
 const ICON_CACHED: &str = "\u{21bb}"; // ↻
 
 /// Response status of the request.
@@ -63,10 +70,14 @@ impl Serialize for Status {
         where
             S: Serializer,
     {
-        let mut s = serializer.serialize_struct("Status", 2)?;
-        s.serialize_field("text", &self.to_string())?;
+        let mut s;
         if let Some(code) = self.code() {
+            s = serializer.serialize_struct("Status", 2)?;
+            s.serialize_field("text", &self.to_string())?;
             s.serialize_field("code", &code.as_u16())?;
+        } else {
+            s = serializer.serialize_struct("Status", 1)?;
+            s.serialize_field("text", &self.to_string())?;
         }
         s.end()
     }

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -9,20 +9,13 @@ use crate::ErrorKind;
 
 use super::CacheStatus;
 
-const ICON_OK: &str = "\u{2714}";
-// ✔
-const ICON_REDIRECTED: &str = "\u{21c4}";
-// ⇄
-const ICON_EXCLUDED: &str = "\u{003f}";
-// ?
-const ICON_UNSUPPORTED: &str = "\u{003f}";
-// ? (using same icon, but under different name for explicitness)
-const ICON_UNKNOWN: &str = "\u{003f}";
-// ?
-const ICON_ERROR: &str = "\u{2717}";
-// ✗
-const ICON_TIMEOUT: &str = "\u{29d6}";
-// ⧖
+const ICON_OK: &str = "\u{2714}"; // ✔
+const ICON_REDIRECTED: &str = "\u{21c4}"; // ⇄
+const ICON_EXCLUDED: &str = "\u{003f}"; // ?
+const ICON_UNSUPPORTED: &str = "\u{003f}"; // ? (using same icon, but under different name for explicitness)
+const ICON_UNKNOWN: &str = "\u{003f}"; // ?
+const ICON_ERROR: &str = "\u{2717}"; // ✗
+const ICON_TIMEOUT: &str = "\u{29d6}"; // ⧖
 const ICON_CACHED: &str = "\u{21bb}"; // ↻
 
 /// Response status of the request.

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -308,7 +308,7 @@ mod tests {
 
         let status_timeout = Status::Timeout(None);
         let serialized_without_code = serde_json::to_string(&status_timeout).unwrap();
-        assert_eq!("{\"text\":\"Timeout\"}", serialized_without_code)
+        assert_eq!("{\"text\":\"Timeout\"}", serialized_without_code);
     }
 
     #[test]

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -222,13 +222,13 @@ impl Status {
             Status::Redirected(code) |
             Status::UnknownStatusCode(code) |
             Status::Timeout(Some(code)) => Some(*code),
-            Status::Error(kind) => {
-                return if let Some(error) = kind.reqwest_error() {
+            Status::Error(kind) |
+            Status::Unsupported(kind) =>
+                if let Some(error) = kind.reqwest_error() {
                     error.status()
                 } else {
                     None
                 }
-            }
             Status::Cached(cache_status) =>
                 match cache_status {
                     CacheStatus::Ok(code) |


### PR DESCRIPTION
This is the PR regarding to the previous discussion about the status code in the fail_map and success_map (https://github.com/lycheeverse/lychee/discussions/1013).

`cargo run -- www.example.com --format json -v` now prints a success_map, containing a status object with a text and a code field. 
The code field is not included, when the status doesn't contain a code.
```
..., 
 "success_map": {
    "http://www.example.com/": [
      {
        "url": "https://www.iana.org/domains/example",
        "status": {
          "text": "OK (200 OK)",
          "code": 200
        }
      }
    ]
  },
...
```