### PR TITLE
Add check duration (in seconds) to report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2013,6 +2013,7 @@ name = "lychee"
 version = "0.12.0"
 dependencies = [
  "anyhow",
+ "assert-json-diff",
  "assert_cmd",
  "clap 4.1.11",
  "console",

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -50,6 +50,7 @@ supports-color = "2.0.0"
 log = "0.4.17"
 env_logger = "0.10.0"
 strum = {version = "0.24.1" , features = ["derive"] }
+assert-json-diff = "2.0.2"
 
 [dependencies.clap]
 version = "4.1.11"

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -31,6 +31,10 @@ where
     let (send_req, recv_req) = mpsc::channel(params.cfg.max_concurrency);
     let (send_resp, recv_resp) = mpsc::channel(params.cfg.max_concurrency);
     let max_concurrency = params.cfg.max_concurrency;
+
+    // Measure check time
+    let start = std::time::Instant::now();
+
     let stats = if params.cfg.verbose.log_level() >= log::Level::Info {
         ResponseStats::extended()
     } else {
@@ -72,6 +76,9 @@ where
     // Wait until all responses are received
     let result = show_results_task.await?;
     let (pb, mut stats) = result?;
+
+    // Store elapsed time in stats
+    stats.duration_secs = start.elapsed().as_secs();
 
     // Note that print statements may interfere with the progress bar, so this
     // must go before printing the stats

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -6,7 +6,6 @@ use serde::Serialize;
 
 #[derive(Default, Serialize, Debug)]
 pub(crate) struct ResponseStats {
-    pub(crate) detailed_stats: bool,
     pub(crate) total: usize,
     pub(crate) successful: usize,
     pub(crate) unknown: usize,
@@ -20,6 +19,8 @@ pub(crate) struct ResponseStats {
     pub(crate) fail_map: HashMap<InputSource, HashSet<ResponseBody>>,
     pub(crate) suggestion_map: HashMap<InputSource, HashSet<Suggestion>>,
     pub(crate) excluded_map: HashMap<InputSource, HashSet<ResponseBody>>,
+    pub(crate) duration_secs: u64,
+    pub(crate) detailed_stats: bool,
 }
 
 impl ResponseStats {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -5,7 +5,7 @@ use futures::stream::Stream;
 use glob::glob_with;
 use jwalk::WalkDir;
 use reqwest::Url;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use shellexpand::tilde;
 use std::fmt::Display;
 use std::fs;
@@ -59,7 +59,7 @@ impl TryFrom<&PathBuf> for InputContent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 #[non_exhaustive]
 /// Input types which lychee supports
 pub enum InputSource {


### PR DESCRIPTION
This adds a new field, `duration_secs` to the JSON report:

```json
{
  "total": 55,
  "successful": 55,
  "unknown": 0,
  "unsupported": 0,
  "timeouts": 0,
  "redirects": 0,
  "excludes": 0,
  "errors": 0,
  "cached": 0,
  "success_map": {},
  "fail_map": {},
  "suggestion_map": {},
  "excluded_map": {},
  "duration_secs": 1,
  "detailed_stats": false
}
```

It's helpful for troubleshooting slow runs and for measuring the performance over time.