### PR TITLE
Add metadata for cargo-binstall

### DIFF
--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -87,3 +87,9 @@ check_example_domains = ["lychee-lib/check_example_domains"]
 name = "cli"
 path = "tests/cli.rs"
 required-features = ["check_example_domains"]
+
+# metadata for cargo-binstall to get the right artifacts
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"


### PR DESCRIPTION
This PR updates the `Cargo.toml` of `lychee` to add [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) metadata as mentioned in https://github.com/lycheeverse/lychee/issues/59#issuecomment-1555966155

Tested as follows:

```
$ cargo binstall lychee --manifest-path lychee-bin/Cargo.toml --dry-run

 INFO resolve: Resolving package: 'lychee'
 WARN The package lychee v0.13.0 will be downloaded from github.com
 INFO This will install the following binaries:
 INFO   - lychee (lychee -> /home/orhun/.cargo/bin/lychee)
 INFO Dry-run: Not proceeding to install fetched binaries
 INFO Done in 4.958623872s
```
