### PR TITLE
alpine for docker image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,9 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,21 +19,44 @@ env:
   IMAGE_NAME: lycheeverse/lychee
   DOCKER_PLATFORMS: linux/amd64,linux/arm64/v8
   DOCKERFILE: Dockerfile-CI.Dockerfile
+  DOCKERFILE_ALPINE: Dockerfile-CI.alpine.Dockerfile
 
 jobs:
   build:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'lycheeverse' &&
-        github.actor != 'dependabot[bot]' && 
+        github.actor != 'dependabot[bot]' &&
         ( github.event_name != 'pull_request' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login )
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Docker meta
+      - name: Docker meta (debian)
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ${{ env.IMAGE_NAME }}
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            # set latest tag for default branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Docker meta (alpine)
+        id: meta-alpine
+        uses: docker/metadata-action@v4
+        with:
+          # A global suffix for each generated tag
+          flavor: |
+            suffix=-alpine
           # list of Docker images to use as base name for tags
           images: |
             ${{ env.IMAGE_NAME }}
@@ -61,8 +84,8 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Push Image
-        uses: docker/build-push-action@v3
+      - name: Push Image (debian)
+        uses: docker/build-push-action@v4
         with:
           context: .
           file: ${{ env.DOCKERFILE }}
@@ -70,6 +93,16 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Push Image (alpine)
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ env.DOCKERFILE_ALPINE }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+          tags: ${{ steps.meta-alpine.outputs.tags }}
+          labels: ${{ steps.meta-alpine.outputs.labels }}
 
       - name: Update DockerHub description
         uses: peter-evans/dockerhub-description@v3

--- a/Dockerfile-CI.Dockerfile
+++ b/Dockerfile-CI.Dockerfile
@@ -1,41 +1,28 @@
-FROM debian:bullseye-slim as builder
+FROM alpine:latest as builder
 WORKDIR /builder
 
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    --no-install-recommends \
-    ca-certificates \
-    jq \
-    wget \
-    && case $(dpkg --print-architecture) in \
-      "amd64") \
-        wget -q -O - "$(wget -q -O- https://api.github.com/repos/lycheeverse/lychee/releases/latest \
+RUN apk update \
+    && apk add --no-cache ca-certificates jq wget \
+    && case $(arch) in \
+      "x86_64") \
+        wget -4 -q -O - "$(wget -4 -q -O- https://api.github.com/repos/lycheeverse/lychee/releases/latest \
         | jq -r '.assets[].browser_download_url' \
-        | grep x86_64-unknown-linux-gnu)" | tar -xz lychee \
+        | grep x86_64-unknown-linux-musl)" | tar -xz lychee \
       ;; \
-      "arm64") \
-        wget -q -O - "$(wget -q -O- https://api.github.com/repos/lycheeverse/lychee/releases/latest \
+      "aarch64") \
+        wget -4 -q -O - "$(wget -4 -q -O- https://api.github.com/repos/lycheeverse/lychee/releases/latest \
         | jq -r '.assets[].browser_download_url' \
-        | grep  aarch64-unknown-linux-gnu)" | tar -xz lychee \
+        | grep arm-unknown-linux-musleabihf)" | tar -xz lychee \
       ;; \
     esac \
     && chmod +x lychee
 
-FROM debian:bullseye-slim
-
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-    --no-install-recommends \
-    ca-certificates \
-    tzdata \
-    && rm -rf /var/cache/debconf/* \
-    # Clean and keep the image small. This should not
-    # be necessary as the debian-slim images have an
-    # auto clean mechanism but we may rely on other
-    # images in the future (see:
-    # https://github.com/debuerreotype/debuerreotype/blob/master/scripts/debuerreotype-minimizing-config).
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates tzdata \
+    && addgroup -S lychee \
+    && adduser -D -G lychee -S lychee
 
 COPY --from=builder /builder/lychee /usr/local/bin/lychee
+# Run as non-root user
+USER lychee
 ENTRYPOINT [ "/usr/local/bin/lychee" ]

--- a/Dockerfile-CI.Dockerfile
+++ b/Dockerfile-CI.Dockerfile
@@ -38,5 +38,4 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /builder/lychee /usr/local/bin/lychee
-
 ENTRYPOINT [ "/usr/local/bin/lychee" ]

--- a/Dockerfile-CI.Dockerfile
+++ b/Dockerfile-CI.Dockerfile
@@ -35,10 +35,8 @@ RUN apt-get update \
     # images in the future (see:
     # https://github.com/debuerreotype/debuerreotype/blob/master/scripts/debuerreotype-minimizing-config).
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && adduser --group --disabled-password --disabled-login --system lychee
+    && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /builder/lychee /usr/local/bin/lychee
-# Run as non-root user
-USER lychee
+
 ENTRYPOINT [ "/usr/local/bin/lychee" ]

--- a/Dockerfile-CI.Dockerfile
+++ b/Dockerfile-CI.Dockerfile
@@ -36,8 +36,7 @@ RUN apt-get update \
     # https://github.com/debuerreotype/debuerreotype/blob/master/scripts/debuerreotype-minimizing-config).
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
-    && addgroup -S lychee \
-    && adduser -D -G lychee -S lychee
+    && adduser --group --disabled-password --disabled-login --system lychee
 
 COPY --from=builder /builder/lychee /usr/local/bin/lychee
 # Run as non-root user

--- a/Dockerfile-CI.alpine.Dockerfile
+++ b/Dockerfile-CI.alpine.Dockerfile
@@ -1,0 +1,28 @@
+FROM alpine:latest as builder
+WORKDIR /builder
+
+RUN apk update \
+    && apk add --no-cache ca-certificates jq wget \
+    && case $(arch) in \
+      "x86_64") \
+        wget -4 -q -O - "$(wget -4 -q -O- https://api.github.com/repos/lycheeverse/lychee/releases/latest \
+        | jq -r '.assets[].browser_download_url' \
+        | grep x86_64-unknown-linux-musl)" | tar -xz lychee \
+      ;; \
+      "aarch64") \
+        wget -4 -q -O - "$(wget -4 -q -O- https://api.github.com/repos/lycheeverse/lychee/releases/latest \
+        | jq -r '.assets[].browser_download_url' \
+        | grep arm-unknown-linux-musleabihf)" | tar -xz lychee \
+      ;; \
+    esac \
+    && chmod +x lychee
+
+FROM alpine:latest
+RUN apk add --no-cache ca-certificates tzdata \
+    && addgroup -S lychee \
+    && adduser -D -G lychee -S lychee
+
+COPY --from=builder /builder/lychee /usr/local/bin/lychee
+# Run as non-root user
+USER lychee
+ENTRYPOINT [ "/usr/local/bin/lychee" ]

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ or use the `--github-token` CLI option. It can also be set in the config file.
 [Here is an example config file][config file].
 
 The token can be generated on your [GitHub account settings page](https://github.com/settings/tokens).
-A personal access token with no extra permissions is enough to be able to check public repos links.
+A personal access token with no extra permissions is enough to be able to check public repo links.
 
 For more scalable organization-wide scenarios you can consider a [GitHub App][github-app-overview].
 It has a higher rate limit than personal access tokens but requires additional configuration steps on your GitHub workflow.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This comparison is made on a best-effort basis. Please create a PR to fix
 outdated information.
 
 |                      | lychee  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| -------------------- | ------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+|----------------------|---------|---------------|----------|-----------------------|--------------|----------------------|-----------------------|--------|
 | Language             | Rust    | Ruby          | Go       | JS                    | TypeScript   | Python               | JS                    | PHP    |
 | Async/Parallel       | ![yes]  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | JSON output          | ![yes]  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
@@ -190,10 +190,19 @@ but in case you need dedicated support for a new file format, please consider cr
 Here's how to mount a local directory into the container and check some input
 with lychee. The `--init` parameter is passed so that lychee can be stopped
 from the terminal. We also pass `-it` to start an interactive terminal, which
-is required to show the progress bar.
+is required to show the progress bar. The `--rm` removes not used anymore
+container from the host after the run.
+
+#### Linux/macOS shell command
 
 ```sh
-docker run --init -it -v `pwd`:/input lycheeverse/lychee /input/README.md
+docker run --init -it --rm -w /input -v $(pwd):/input lycheeverse/lychee README.md
+```
+
+#### Windows PowerShell command
+
+```powershell
+docker run --init -it --rm -w /input -v ${PWD}:/input lycheeverse/lychee README.md
 ```
 
 ### GitHub Token
@@ -226,7 +235,7 @@ Arguments:
 Options:
   -c, --config <CONFIG_FILE>
           Configuration file to use
-          
+
           [default: lychee.toml]
 
   -v, --verbose...
@@ -244,7 +253,7 @@ Options:
 
       --max-cache-age <MAX_CACHE_AGE>
           Discard all cached requests older than this duration
-          
+
           [default: 1d]
 
       --dump
@@ -252,7 +261,7 @@ Options:
 
       --archive <ARCHIVE>
           Specify the use of a specific web archive. Can be used in combination with `--suggest`
-          
+
           [possible values: wayback]
 
       --suggest
@@ -260,17 +269,17 @@ Options:
 
   -m, --max-redirects <MAX_REDIRECTS>
           Maximum number of allowed redirects
-          
+
           [default: 5]
 
       --max-retries <MAX_RETRIES>
           Maximum number of retries per request
-          
+
           [default: 3]
 
       --max-concurrency <MAX_CONCURRENCY>
           Maximum number of concurrent network requests
-          
+
           [default: 128]
 
   -T, --threads <THREADS>
@@ -278,7 +287,7 @@ Options:
 
   -u, --user-agent <USER_AGENT>
           User agent
-          
+
           [default: lychee/0.13.0]
 
   -i, --insecure
@@ -329,17 +338,17 @@ Options:
 
   -t, --timeout <TIMEOUT>
           Website timeout in seconds from connect to response finished
-          
+
           [default: 20]
 
   -r, --retry-wait-time <RETRY_WAIT_TIME>
           Minimum wait time in seconds between retries of failed requests
-          
+
           [default: 1]
 
   -X, --method <METHOD>
           Request method
-          
+
           [default: get]
 
   -b, --base <BASE>
@@ -350,7 +359,7 @@ Options:
 
       --github-token <GITHUB_TOKEN>
           GitHub API token to use when checking github.com links, to avoid rate limiting
-          
+
           [env: GITHUB_TOKEN]
 
       --skip-missing
@@ -367,7 +376,7 @@ Options:
 
   -f, --format <FORMAT>
           Output format of final status report (compact, detailed, json, markdown)
-          
+
           [default: compact]
 
       --require-https

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ with lychee.
 - The `--init` parameter is passed so that lychee can be stopped from the terminal.
 - We also pass `-it` to start an interactive terminal, which is required to show the progress bar.
 - The `--rm` removes not used anymore container from the host after the run (self-cleanup).
-- The `-w /input` points to /input as the default workspace
+- The `-w /input` points to `/input` as the default workspace
 - The `-v $(pwd):/input` does local volume mounting to the container for lychee access.
 
 > By default debian-based docker image is used. If you want to run alpine-based image, use the `latest-alpine` tag.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ with lychee.
 - The `-w /input` points to `/input` as the default workspace
 - The `-v $(pwd):/input` does local volume mounting to the container for lychee access.
 
-> By default debian-based docker image is used. If you want to run alpine-based image, use the `latest-alpine` tag.
+> By default a Debian-based docker image is used. If you want to run an Alpine-based image, use the `latest-alpine` tag.
 > For example, `lycheeverse/lychee:latest-alpine`
 
 #### Linux/macOS shell command

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Arguments:
 Options:
   -c, --config <CONFIG_FILE>
           Configuration file to use
-
+          
           [default: lychee.toml]
 
   -v, --verbose...
@@ -253,7 +253,7 @@ Options:
 
       --max-cache-age <MAX_CACHE_AGE>
           Discard all cached requests older than this duration
-
+          
           [default: 1d]
 
       --dump
@@ -261,7 +261,7 @@ Options:
 
       --archive <ARCHIVE>
           Specify the use of a specific web archive. Can be used in combination with `--suggest`
-
+          
           [possible values: wayback]
 
       --suggest
@@ -269,17 +269,17 @@ Options:
 
   -m, --max-redirects <MAX_REDIRECTS>
           Maximum number of allowed redirects
-
+          
           [default: 5]
 
       --max-retries <MAX_RETRIES>
           Maximum number of retries per request
-
+          
           [default: 3]
 
       --max-concurrency <MAX_CONCURRENCY>
           Maximum number of concurrent network requests
-
+          
           [default: 128]
 
   -T, --threads <THREADS>
@@ -287,7 +287,7 @@ Options:
 
   -u, --user-agent <USER_AGENT>
           User agent
-
+          
           [default: lychee/0.13.0]
 
   -i, --insecure
@@ -338,17 +338,17 @@ Options:
 
   -t, --timeout <TIMEOUT>
           Website timeout in seconds from connect to response finished
-
+          
           [default: 20]
 
   -r, --retry-wait-time <RETRY_WAIT_TIME>
           Minimum wait time in seconds between retries of failed requests
-
+          
           [default: 1]
 
   -X, --method <METHOD>
           Request method
-
+          
           [default: get]
 
   -b, --base <BASE>
@@ -359,7 +359,7 @@ Options:
 
       --github-token <GITHUB_TOKEN>
           GitHub API token to use when checking github.com links, to avoid rate limiting
-
+          
           [env: GITHUB_TOKEN]
 
       --skip-missing
@@ -376,7 +376,7 @@ Options:
 
   -f, --format <FORMAT>
           Output format of final status report (compact, detailed, json, markdown)
-
+          
           [default: compact]
 
       --require-https

--- a/README.md
+++ b/README.md
@@ -508,7 +508,7 @@ Lychee makes heavy use of async code to be resource-friendly while still being
 performant. Async code can be difficult to troubleshoot with most tools,
 however. Therefore we provide experimental support for
 [tokio-console](https://github.com/tokio-rs/console). It provides a top(1)-like
-an overview for async tasks!
+overview for async tasks!
 
 If you want to give it a spin, download and start the console:
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ set an environment variable with your GitHub token like so `GITHUB_TOKEN=xxxx`,
 or use the `--github-token` CLI option. It can also be set in the config file.
 [Here is an example config file][config file].
 
-The token can be generated on your
-[GitHub account settings page](https://github.com/settings/tokens). A personal
-access token with no extra permissions is enough to be able to check public repos links.
+The token can be generated on your [GitHub account settings page](https://github.com/settings/tokens).
+A personal access token with no extra permissions is enough to be able to check public repos links.
 
-For more scalable organization-wide scenarios you can consider a [GitHub App][github-app-overview]. It has a higher rate limit than personal access tokens but requires additional configuration steps on your GitHub workflow, please follow the [GitHub App Setup example][github-app-setup].
+For more scalable organization-wide scenarios you can consider a [GitHub App][github-app-overview].
+It has a higher rate limit than personal access tokens but requires additional configuration steps on your GitHub workflow.
+Please follow the [GitHub App Setup][github-app-setup] example.
 
 [github-app-overview]: https://docs.github.com/en/apps/overview
 [github-app-setup]: https://github.com/github/combine-prs/blob/main/docs/github-app-setup.md#github-app-setup

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ with lychee.
 - The `-w /input` points to /input as the default workspace
 - The `-v $(pwd):/input` does local volume mounting to the container for lychee access.
 
-> By default debian-based docker image is used. If you want to run alpine-based image, use the `:latest-alpine` tag.
+> By default debian-based docker image is used. If you want to run alpine-based image, use the `latest-alpine` tag.
 > For example, `lycheeverse/lychee:latest-alpine`
 
 #### Linux/macOS shell command
@@ -214,17 +214,22 @@ docker run --init -it --rm -w /input -v ${PWD}:/input lycheeverse/lychee README.
 ### GitHub Token
 
 To avoid getting rate-limited while checking GitHub links, you can optionally
-set an environment variable with your Github token like so `GITHUB_TOKEN=xxxx`,
+set an environment variable with your GitHub token like so `GITHUB_TOKEN=xxxx`,
 or use the `--github-token` CLI option. It can also be set in the config file.
 [Here is an example config file][config file].
 
-The token can be generated in your
+The token can be generated on your
 [GitHub account settings page](https://github.com/settings/tokens). A personal
-token with no extra permissions is enough to be able to check public repos links.
+access token with no extra permissions is enough to be able to check public repos links.
+
+For more scalable organization-wide scenarios you can consider a [GitHub App][github-app-overview]. It has a higher rate limit than personal access tokens but requires additional configuration steps on your GitHub workflow, please follow the [GitHub App Setup example][github-app-setup].
+
+[github-app-overview]: https://docs.github.com/en/apps/overview
+[github-app-setup]: https://github.com/github/combine-prs/blob/main/docs/github-app-setup.md#github-app-setup
 
 ### Commandline Parameters
 
-There is an extensive list of commandline parameters to customize the behavior.
+There is an extensive list of command line parameters to customize the behavior.
 See below for a full list.
 
 ```text
@@ -487,7 +492,7 @@ which includes usage instructions.
 ## Contributing to lychee
 
 We'd be thankful for any contribution. \
-We try to keep the issue-tracker up-to-date so you can quickly find a task to work on.
+We try to keep the issue tracker up-to-date so you can quickly find a task to work on.
 
 Try one of these links to get started:
 
@@ -502,7 +507,7 @@ Lychee makes heavy use of async code to be resource-friendly while still being
 performant. Async code can be difficult to troubleshoot with most tools,
 however. Therefore we provide experimental support for
 [tokio-console](https://github.com/tokio-rs/console). It provides a top(1)-like
-overview for async tasks!
+an overview for async tasks!
 
 If you want to give it a spin, download and start the console:
 
@@ -547,7 +552,7 @@ If you are using lychee for your project, **please add it here**.
 ## Credits
 
 The first prototype of lychee was built in [episode 10 of Hello
-Rust](https://hello-rust.show/10/). Thanks to all Github- and Patreon sponsors
+Rust](https://hello-rust.show/10/). Thanks to all GitHub and Patreon sponsors
 for supporting the development since the beginning. Also, thanks to all the
 great contributors who have since made this project more mature.
 

--- a/README.md
+++ b/README.md
@@ -188,10 +188,16 @@ but in case you need dedicated support for a new file format, please consider cr
 ### Docker Usage
 
 Here's how to mount a local directory into the container and check some input
-with lychee. The `--init` parameter is passed so that lychee can be stopped
-from the terminal. We also pass `-it` to start an interactive terminal, which
-is required to show the progress bar. The `--rm` removes not used anymore
-container from the host after the run.
+with lychee.
+
+- The `--init` parameter is passed so that lychee can be stopped from the terminal.
+- We also pass `-it` to start an interactive terminal, which is required to show the progress bar.
+- The `--rm` removes not used anymore container from the host after the run (self-cleanup).
+- The `-w /input` points to /input as the default workspace
+- The `-v $(pwd):/input` does local volume mounting to the container for lychee access.
+
+> By default debian-based docker image is used. If you want to run alpine-based image, use the `:latest-alpine` tag.
+> For example, `lycheeverse/lychee:latest-alpine`
 
 #### Linux/macOS shell command
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ with lychee.
 - The `-w /input` points to `/input` as the default workspace
 - The `-v $(pwd):/input` does local volume mounting to the container for lychee access.
 
-> By default a Debian-based docker image is used. If you want to run an Alpine-based image, use the `latest-alpine` tag.
+> By default a Debian-based Docker image is used. If you want to run an Alpine-based image, use the `latest-alpine` tag.
 > For example, `lycheeverse/lychee:latest-alpine`
 
 #### Linux/macOS shell command


### PR DESCRIPTION
Do not see any issue for this, but somehow it may be related to https://github.com/lycheeverse/lychee/issues/59 :)

- docker: add alpine flavor for CI docker image
  - reduces image from ~37 MB (debian) to ~12 MB on the registry side (compressed)
  - reduces image from ~104 MB (debian) to ~30 MB on the local disk (uncompressed)
- security: run lychee as non-root user for alpine
- docs: add example about running lychee on Windows PowerShell
- docs: add `--rm` flag to docker run command to remove container after the run (self-cleanup)
- docs: add `-w /input` flag to docker run command to set working directory to /input
  - better UX when running lychee from docker locally (feeling like cli)
- ci: tag/build/push for alpine

bonus:
- docker related github-actions: bump (because of https://github.com/lycheeverse/lychee/actions/runs/5034258304/jobs/9028968846#step:3:54)
- dependabot: auto-bump gh actions
- GitHub App usage for GITHUB_TOKEN
- minor typos fix