### PR TITLE
test(client): make exponential_backoff better

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -835,7 +835,6 @@ mod tests {
             .unwrap();
         let _res = warm_up_client.check(mock_server.uri()).await.unwrap();
 
-        let start = Instant::now();
         let client = ClientBuilder::builder()
             .timeout(checker_timeout)
             .max_retries(3_u64)
@@ -853,6 +852,7 @@ mod tests {
         // 6. Retry after 200ms (total 360ms)
         // Total: 360ms
 
+        let start = Instant::now();
         let res = client.check(mock_server.uri()).await.unwrap();
         let end = start.elapsed();
 


### PR DESCRIPTION
This test is still flaky on riscv64 boards after #1049.

It turns out that building the client might take 59ms, which should not be counted.