### PR TITLE
Don't cache unknown status codes

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -263,9 +263,11 @@ async fn handle(
     //   future run.
     // - Skip caching excluded links; they might not be excluded in the next run
     let status = response.status();
-    if !uri.is_file() && !status.is_excluded() && !status.is_unsupported() {
-        cache.insert(uri, status.into());
+    if uri.is_file() || status.is_excluded() || status.is_unsupported() || status.is_unknown() {
+        return response;
     }
+
+    cache.insert(uri, status.into());
     response
 }
 

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -268,6 +268,16 @@ impl Status {
             },
         }
     }
+
+    /// Returns true if the status code is unknown
+    /// (i.e. not a valid HTTP status code)
+    ///
+    /// For example, `200` is a valid HTTP status code,
+    /// while `999` is not.
+    #[must_use]
+    pub const fn is_unknown(&self) -> bool {
+        matches!(self, Status::UnknownStatusCode(_))
+    }
 }
 
 impl From<ErrorKind> for Status {
@@ -351,5 +361,11 @@ mod tests {
             Status::Unsupported(ErrorKind::InvalidStatusCode(999)).code(),
             None
         );
+    }
+
+    #[test]
+    fn test_status_unknown() {
+        assert!(Status::UnknownStatusCode(StatusCode::from_u16(999).unwrap()).is_unknown());
+        assert!(!Status::Ok(StatusCode::from_u16(200).unwrap()).is_unknown());
     }
 }


### PR DESCRIPTION
Unknown status codes should be skipped and not cached by default. The reason is that we don't know if they are valid or not and even if they are invalid, we don't know if they will be valid in the future.

The only error case I know of is currently LinkedIn, which returns a `999` status code.