### PR TITLE
Add optional Rustls support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2944,6 +2944,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -2959,7 +2960,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -4157,25 +4157,6 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2926,6 +2926,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2935,11 +2936,14 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-socks",
  "tokio-util",
  "tower-service",
@@ -2948,6 +2952,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
 ]
 
@@ -4144,6 +4149,25 @@ checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ apt install gcc pkg-config libc6-dev libssl-dev
 cargo install lychee
 ```
 
+#### Feature flags
+
+Lychee supports several feature flags:
+
+- `native-tls` enables the platform-native TLS crate [native-tls](https://crates.io/crates/native-tls).
+- `vendored-openssl` compiles and statically links a copy of OpenSSL. See the corresponding feature of the [openssl](https://crates.io/crates/openssl) crate.
+- `rustls-tls` enables the alternative TLS crate [rustls](https://crates.io/crates/rustls).
+- `email-check` enables checking email addresses using the [check-if-email-exists](https://crates.io/crates/check-if-email-exists) crate. This feature requires the `native-tls` feature.
+- `check_example_domains` allows checking example domains such as `example.com`. This feature is useful for testing.
+
+By default, `native-tls` and `email-check` are enabled.
+
 ## Features
 
 This comparison is made on a best-effort basis. Please create a PR to fix

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -8,11 +8,17 @@ edition = "2021"
 publish = false
 
 [dependencies]
-lychee-lib = { path = "../lychee-lib"}
+lychee-lib = { path = "../lychee-lib", default-features = false }
 # TODO: Move back to crates.io version once
 # https://github.com/bheisler/criterion.rs/pull/602
 # got released
 criterion = { git = "https://github.com/bheisler/criterion.rs"}
+
+[features]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls"]
+default = ["native-tls", "email-check"]
 
 [[bench]]
 name = "extract"

--- a/examples/builder/Cargo.toml
+++ b/examples/builder/Cargo.toml
@@ -17,5 +17,5 @@ reqwest = { version = "0.11.18", default-features = false, features = ["gzip"] }
 [features]
 email-check = ["lychee-lib/email-check"]
 native-tls = ["lychee-lib/native-tls", "reqwest/native-tls"]
-rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls"]
+rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls-native-roots"]
 default = ["native-tls", "email-check"]

--- a/examples/builder/Cargo.toml
+++ b/examples/builder/Cargo.toml
@@ -8,8 +8,14 @@ name = "builder"
 path = "builder.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.13.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.13.0", default-features = false }
 tokio = { version = "1.28.2", features = ["full"] }
 regex = "1.8.4"
 http = "0.2.9"
-reqwest = { version = "0.11.18", features = ["gzip"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["gzip"] }
+
+[features]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls", "reqwest/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls"]
+default = ["native-tls", "email-check"]

--- a/examples/client_pool/Cargo.toml
+++ b/examples/client_pool/Cargo.toml
@@ -10,5 +10,11 @@ path = "client_pool.rs"
 [dependencies]
 futures = "0.3.27"
 tokio-stream = "0.1.14"
-lychee-lib = { path = "../../lychee-lib", version = "0.13.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.13.0", default-features = false }
 tokio = { version = "1.28.2", features = ["full"] }
+
+[features]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls"]
+default = ["native-tls", "email-check"]

--- a/examples/collect_links/Cargo.toml
+++ b/examples/collect_links/Cargo.toml
@@ -18,5 +18,5 @@ reqwest = { version = "0.11.18", default-features = false, features = ["gzip"] }
 [features]
 email-check = ["lychee-lib/email-check"]
 native-tls = ["lychee-lib/native-tls", "reqwest/native-tls"]
-rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls"]
+rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls-native-roots"]
 default = ["native-tls", "email-check"]

--- a/examples/collect_links/Cargo.toml
+++ b/examples/collect_links/Cargo.toml
@@ -8,9 +8,15 @@ name = "collect_links"
 path = "collect_links.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.13.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.13.0", default-features = false }
 tokio = { version = "1.28.2", features = ["full"] }
 regex = "1.8.4"
 http = "0.2.9"
 tokio-stream = "0.1.14"
-reqwest = { version = "0.11.18", features = ["gzip"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["gzip"] }
+
+[features]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls", "reqwest/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls"]
+default = ["native-tls", "email-check"]

--- a/examples/extract/Cargo.toml
+++ b/examples/extract/Cargo.toml
@@ -8,5 +8,11 @@ name = "extract"
 path = "extract.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.13.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.13.0", default-features = false }
 tokio = { version = "1.28.2", features = ["full"] }
+
+[features]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls"]
+default = ["native-tls", "email-check"]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -8,5 +8,11 @@ name = "simple"
 path = "simple.rs"
 
 [dependencies]
-lychee-lib = { path = "../../lychee-lib", version = "0.13.0" }
+lychee-lib = { path = "../../lychee-lib", version = "0.13.0", default-features = false }
 tokio = { version = "1.28.2", features = ["full"] }
+
+[features]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls"]
+default = ["native-tls", "email-check"]

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -76,11 +76,22 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 
 [features]
 #tokio-console = ["console-subscriber", "tracing-subscriber/registry"]
+
+# Compile and statically link a copy of OpenSSL.
 vendored-openssl = ["openssl-sys/vendored"]
+
+# Allow checking example domains such as example.com.
 check_example_domains = ["lychee-lib/check_example_domains"]
+
+# Enable checking email addresses. Requires the native-tls feature.
 email-check = ["lychee-lib/email-check"]
+
+# Use platform-native TLS.
 native-tls = ["lychee-lib/native-tls", "openssl-sys", "reqwest/native-tls"]
+
+# Use Rustls TLS.
 rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls-native-roots"]
+
 default = ["native-tls", "email-check"]
 
 # Unfortunately, it's not possible to automatically enable features

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -24,10 +24,10 @@ const_format = "0.2.31"
 headers = "0.3.8"
 http = "0.2.9"
 indicatif = "0.17.5"
-openssl-sys = "0.9.88"
+openssl-sys = { version = "0.9.88", optional = true }
 pad = "0.1.6"
 regex = "1.8.4"
-reqwest = { version = "0.11.18", features = ["gzip"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["gzip", "json"] }
 # Make build work on Apple Silicon.
 # See https://github.com/briansmith/ring/issues/1163
 # This is necessary for the homebrew build
@@ -78,6 +78,10 @@ tracing-subscriber = { version = "0.3.17", default-features = false, features = 
 #tokio-console = ["console-subscriber", "tracing-subscriber/registry"]
 vendored-openssl = ["openssl-sys/vendored"]
 check_example_domains = ["lychee-lib/check_example_domains"]
+email-check = ["lychee-lib/email-check"]
+native-tls = ["lychee-lib/native-tls", "openssl-sys", "reqwest/native-tls"]
+rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls"]
+default = ["native-tls", "email-check"]
 
 # Unfortunately, it's not possible to automatically enable features
 # for cargo test. See rust-lang/cargo#2911.

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -80,7 +80,7 @@ vendored-openssl = ["openssl-sys/vendored"]
 check_example_domains = ["lychee-lib/check_example_domains"]
 email-check = ["lychee-lib/email-check"]
 native-tls = ["lychee-lib/native-tls", "openssl-sys", "reqwest/native-tls"]
-rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls"]
+rustls-tls = ["lychee-lib/rustls-tls", "reqwest/rustls-tls-native-roots"]
 default = ["native-tls", "email-check"]
 
 # Unfortunately, it's not possible to automatically enable features

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -69,9 +69,11 @@ use color::YELLOW;
 use commands::CommandParams;
 use formatters::response::ResponseFormatter;
 use log::{error, info, warn};
-use openssl_sys as _;
+
+#[cfg(feature = "native-tls")]
+use openssl_sys as _; // required for vendored-openssl feature
+
 use options::LYCHEE_CONFIG_FILE;
-// required for vendored-openssl feature
 use ring as _; // required for apple silicon
 
 use lychee_lib::Collector;

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -17,17 +17,17 @@ repository = "https://github.com/lycheeverse/lychee"
 version = "0.13.0"
 
 [dependencies]
-check-if-email-exists = "0.9.0"
+check-if-email-exists = { version = "0.9.0", optional = true }
 email_address = "0.2.4"
 glob = "0.3.1"
 http = "0.2.9"
 linkify = "0.9.0"
-openssl-sys = "0.9.88"
+openssl-sys = { version = "0.9.88", optional = true }
 pulldown-cmark = "0.9.3"
 regex = "1.8.4"
 # Use trust-dns to avoid lookup failures on high concurrency
 # https://github.com/seanmonstar/reqwest/issues/296
-reqwest = { version = "0.11.18", features = ["gzip", "trust-dns"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["gzip", "trust-dns"] }
 # Make build work on Apple Silicon.
 # See https://github.com/briansmith/ring/issues/1163
 # This is necessary for the homebrew build
@@ -66,12 +66,15 @@ wiremock = "0.5.18"
 serde_json = "1.0.96"
 
 [features]
+email-check = ["check-if-email-exists"]
+native-tls = ["openssl-sys", "reqwest/native-tls"]
+rustls-tls = ["reqwest/rustls-tls"]
 # Vendor OpenSSL instead of dynamically linking it at runtime.
 vendored-openssl = ["openssl-sys/vendored"]
-# Feature flag to include checking reserved example domains 
+# Feature flag to include checking reserved example domains
 # as per RFC 2606, section 3.
 # This flag is off by default and only exists to allow example domains in
 # integration tests, which don't respect `#[cfg(test)]`.
 # See https://users.rust-lang.org/t/36630
 check_example_domains = []
-default = []
+default = ["native-tls", "email-check"]

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -66,15 +66,24 @@ wiremock = "0.5.19"
 serde_json = "1.0.96"
 
 [features]
+
+# Enable checking email addresses. Requires the native-tls feature.
 email-check = ["check-if-email-exists"]
+
+# Use platform-native TLS.
 native-tls = ["openssl-sys", "reqwest/native-tls"]
+
+# Use Rustls TLS.
 rustls-tls = ["reqwest/rustls-tls-native-roots"]
-# Vendor OpenSSL instead of dynamically linking it at runtime.
+
+# Compile and statically link a copy of OpenSSL.
 vendored-openssl = ["openssl-sys/vendored"]
+
 # Feature flag to include checking reserved example domains
 # as per RFC 2606, section 3.
 # This flag is off by default and only exists to allow example domains in
 # integration tests, which don't respect `#[cfg(test)]`.
 # See https://users.rust-lang.org/t/36630
 check_example_domains = []
+
 default = ["native-tls", "email-check"]

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -68,7 +68,7 @@ serde_json = "1.0.96"
 [features]
 email-check = ["check-if-email-exists"]
 native-tls = ["openssl-sys", "reqwest/native-tls"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls-native-roots"]
 # Vendor OpenSSL instead of dynamically linking it at runtime.
 vendored-openssl = ["openssl-sys/vendored"]
 # Feature flag to include checking reserved example domains

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -74,8 +74,10 @@ pub mod test_utils;
 
 #[cfg(test)]
 use doc_comment as _; // required for doctest
-use openssl_sys as _; // required for vendored-openssl feature
 use ring as _; // required for apple silicon
+
+#[cfg(feature = "native-tls")]
+use openssl_sys as _; // required for vendored-openssl feature
 
 #[doc(inline)]
 pub use crate::{

--- a/lychee-lib/src/types/mail.rs
+++ b/lychee-lib/src/types/mail.rs
@@ -1,3 +1,5 @@
+#![cfg(all(feature = "email-check", feature = "native-tls"))]
+
 use check_if_email_exists::{CheckEmailOutput, Reachable};
 
 /// A crude way to extract error details from the mail output.


### PR DESCRIPTION
Hello. I would like to discuss adding optional [Rustls](https://github.com/rustls/rustls) support to Lychee. I've prepared a pull request to show that's it's mostly a question of passing feature flags down to existing dependencies. What do you think?

---

This commit adds a non-default feature flag to use Rustls instead of OpenSSL.

My personal motivation is to use Lychee on OpenBSD -current, where the `openssl` crate frequently fails to link against the unreleased system LibreSSL. Using the `vendored-openssl` feature helps with compilation, but segfaults at runtime.

The commit adds three feature flags to the library, binary, benchmark, and all examples:

- The `native-tls` feature flag toggles the `openssl` crate.
- The `rustls-tls` feature flag toggles the `rustls` crate.
- The `email-check` feature flag toggles the `check-if-email-exists` crate, which is the only existing functionality currently incompatible with Rustls.

By default, `native-tls` and `email-check` are enabled. Thus, Lychee (bin and lib) can be used as before unless default features are disabled.

To use the Rustls feature, pass `--no-default-features --features rustls` to cargo check/build/test/..., e.g.,

    $ cargo clippy --workspace --all-targets --no-default-features --features rustls-tls -- --deny warnings

Checking email addresses requires both, `native-tls` and `email-check`, to be enabled. Otherwise, email addresses are excluded.

The `email-check` feature flag is technically not necessary. I preferred it over `not(rustls-tls)` because it's clearer and it addresses the AGPL license issue #594. As far as I understand, a Lychee binary compiled without the `email-check` feature could be distributed with file-based copyleft for the MPL-licensed dependencies only. But that's out of scope here.

The benchmark shows a performance regression varying between 2% and 4.4% when using Rustls instead of OpenSSL on my machine.

PS: The `ring` crate needs to be patched on OpenBSD 7.3 and later until the new xonly patches have been upstreamed, see the `rust-ring` port.