### PR TITLE
Log redirects in verbose mode (-vv)

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -25,7 +25,7 @@ use http::{
 use log::debug;
 use octocrab::Octocrab;
 use regex::RegexSet;
-use reqwest::{header, Url};
+use reqwest::{header, redirect, Url};
 use secrecy::{ExposeSecret, SecretString};
 use typed_builder::TypedBuilder;
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -321,7 +321,7 @@ impl ClientBuilder {
             }
         });
 
-        let mut builder = reqwest::ClientBuilder::new()
+        let builder = reqwest::ClientBuilder::new()
             .gzip(true)
             .default_headers(headers)
             .danger_accept_invalid_certs(self.allow_insecure)
@@ -918,7 +918,7 @@ mod tests {
             .await;
 
         let client = ClientBuilder::builder()
-            .max_redirects(1_usize)
+            .max_redirects(0_usize)
             .build()
             .client()
             .unwrap();
@@ -927,7 +927,7 @@ mod tests {
         assert!(res.status().is_failure());
 
         let client = ClientBuilder::builder()
-            .max_redirects(2_usize)
+            .max_redirects(1_usize)
             .build()
             .client()
             .unwrap();


### PR DESCRIPTION
This adds a custom redirect policy,
which logs redirects as debug messages.
It can help with troubleshooting, e.g. in situations like https://github.com/lycheeverse/lychee/issues/1115.

@oupala fyi