### PR TITLE
Don't check Twitter URLs

### DIFF
--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -241,8 +241,10 @@ mod cli {
     }
 
     #[test]
-    #[ignore = "Twitter quirk works locally but is flaky on Github (timeout)"]
-    fn test_twitter_quirk() {
+    // Exclude Twitter links because they require login to view tweets.
+    // https://techcrunch.com/2023/06/30/twitter-now-requires-an-account-to-view-tweets/
+    // https://github.com/zedeus/nitter/issues/919
+    fn test_ignored_hosts() {
         let url = "https://twitter.com/zarfeblong/status/1339742840142872577";
 
         main_command()
@@ -253,7 +255,7 @@ mod cli {
             .assert()
             .success()
             .stdout(contains("1 Total"))
-            .stdout(contains("1 OK"));
+            .stdout(contains("1 Excluded"));
     }
 
     #[tokio::test]

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -5,8 +5,6 @@ use regex::Regex;
 use reqwest::{Request, Url};
 use std::collections::HashMap;
 
-static TWITTER_PATTERN: Lazy<Regex> =
-    Lazy::new(|| Regex::new(r"^(https?://)?(www\.)?twitter.com").unwrap());
 static CRATES_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^(https?://)?(www\.)?crates.io").unwrap());
 static YOUTUBE_PATTERN: Lazy<Regex> =
@@ -33,13 +31,6 @@ pub(crate) struct Quirks {
 impl Default for Quirks {
     fn default() -> Self {
         let quirks = vec![
-            Quirk {
-                pattern: &TWITTER_PATTERN,
-                rewrite: |mut request| {
-                    request.url_mut().set_host(Some("nitter.net")).unwrap();
-                    request
-                },
-            },
             Quirk {
                 pattern: &CRATES_PATTERN,
                 rewrite: |mut request| {
@@ -115,34 +106,6 @@ mod tests {
     impl PartialEq for MockRequest {
         fn eq(&self, other: &Self) -> bool {
             self.0.url() == other.0.url() && self.0.method() == other.0.method()
-        }
-    }
-
-    #[test]
-    fn test_twitter_request() {
-        let cases = vec![
-            (
-                "https://twitter.com/search?q=rustlang",
-                "https://nitter.net/search?q=rustlang",
-            ),
-            ("http://twitter.com/jack", "http://nitter.net/jack"),
-            (
-                "https://twitter.com/notifications",
-                "https://nitter.net/notifications",
-            ),
-        ];
-
-        for (input, output) in cases {
-            let url = Url::parse(input).unwrap();
-            let expected = Url::parse(output).unwrap();
-
-            let request = Request::new(Method::GET, url.clone());
-            let modified = Quirks::default().apply(request);
-
-            assert_eq!(
-                MockRequest(modified),
-                MockRequest::new(Method::GET, expected)
-            );
         }
     }
 


### PR DESCRIPTION
Twitter completely locked down and requires
a login to read tweets. (Temporarily) disable all
Twitter URLs to avoid false-positives.

For context:
https://github.com/zedeus/nitter/issues/919
https://news.ycombinator.com/item?id=36540957
https://techcrunch.com/2023/06/30/twitter-now-requires-an-account-to-view-tweets/

Fixes https://github.com/lycheeverse/lychee/issues/1108