### PR TITLE
fix exclude pattern in example

### DIFF
--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -88,7 +88,7 @@ include_verbatim = false
 glob_ignore_case = false
 
 # Exclude URLs and mail addresses from checking (supports regex).
-exclude = [ '.*\.github.com\.*' ]
+exclude = [ '.*github\.com.*' ]
 
 # Exclude these filesystem paths from getting checked.
 exclude_path = ["file/path/to/Ignore", "./other/file/path/to/Ignore"]


### PR DESCRIPTION
I think the regex was wrong and it should be like that. it is also used in `include = [ 'gist\.github\.com.*' ]` some lines below.