### PR TITLE
Make checking email addresses optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,10 @@ Options:
           Exclude loopback IP address range and localhost from checking
 
       --exclude-mail
-          Exclude all mail addresses from checking
+          Exclude all mail addresses from checking (deprecated; excluded by default)
+
+      --include-mail
+          Also check email addresses
 
       --remap <REMAP>
           Remap URI matching pattern to different URI

--- a/fixtures/TEST_EMAIL.md
+++ b/fixtures/TEST_EMAIL.md
@@ -1,6 +1,5 @@
 https://endler.dev
 test@example.com
-foo@bar.dev
 https://example.com
 octocat+github@github.com
 mailto:test2@example.com

--- a/fixtures/TEST_EXCLUDE_1.txt
+++ b/fixtures/TEST_EXCLUDE_1.txt
@@ -1,3 +1,0 @@
-https://en.wikipedia.org/*
-https://ldra.com
-https://url-does-not-exist

--- a/fixtures/TEST_EXCLUDE_2.txt
+++ b/fixtures/TEST_EXCLUDE_2.txt
@@ -1,1 +1,0 @@
-https://i.creativecommons.org/p/zero/1.0/88x31.png

--- a/lychee-bin/src/client.rs
+++ b/lychee-bin/src/client.rs
@@ -37,6 +37,25 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
         None => None,
     };
 
+    // `exclude_mail` will be removed in 1.0. Until then, we need to support it.
+    // Therefore, we need to check if both `include_mail` and `exclude_mail` are set to `true`
+    // and return an error if that's the case.
+    if cfg.include_mail && cfg.exclude_mail {
+        return Err(anyhow::anyhow!(
+            "Cannot set both `include-mail` and `exclude-mail` to true"
+        ));
+    }
+
+    // By default, clap sets `exclude_mail` to `false`.
+    // Therefore, we need to check if `exclude_mail` is explicitly set to
+    // `true`. If so, we need to set `include_mail` to `false`.
+    // Otherwise, we use the value of `include_mail`.
+    let include_mail = if cfg.exclude_mail {
+        false
+    } else {
+        cfg.include_mail
+    };
+
     ClientBuilder::builder()
         .remaps(remaps)
         .includes(includes)
@@ -45,7 +64,7 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
         .exclude_private_ips(cfg.exclude_private)
         .exclude_link_local_ips(cfg.exclude_link_local)
         .exclude_loopback_ips(cfg.exclude_loopback)
-        .exclude_mail(cfg.exclude_mail)
+        .include_mail(include_mail)
         .max_redirects(cfg.max_redirects)
         .user_agent(cfg.user_agent.clone())
         .allow_insecure(cfg.insecure)

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -177,9 +177,14 @@ fn load_config() -> Result<LycheeOptions> {
         opts.config.exclude.append(&mut read_lines(&lycheeignore)?);
     }
 
-    // TODO: Remove this warning and the parameter in a future release
+    // TODO: Remove this warning and the parameter with 1.0
     if !&opts.config.exclude_file.is_empty() {
-        warn!("WARNING: `--exclude-file` is deprecated and will soon be removed; use `{}` file to ignore URL patterns instead. To exclude paths of files and directories, use `--exclude-path`.", LYCHEE_IGNORE_FILE);
+        warn!("WARNING: `--exclude-file` is deprecated and will soon be removed; use the `{}` file to ignore URL patterns instead. To exclude paths of files and directories, use `--exclude-path`.", LYCHEE_IGNORE_FILE);
+    }
+
+    // TODO: Remove this warning and the parameter with 1.0
+    if opts.config.exclude_mail {
+        warn!("WARNING: `--exclude-mail` is deprecated and will soon be removed; E-Mail is no longer checked by default. Use `--include-mail` to enable E-Mail checking.");
     }
 
     // Load excludes from file

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -282,9 +282,15 @@ pub(crate) struct Config {
     pub(crate) exclude_loopback: bool,
 
     /// Exclude all mail addresses from checking
+    /// (deprecated; excluded by default)
     #[arg(long)]
     #[serde(default)]
     pub(crate) exclude_mail: bool,
+
+    /// Also check email addresses
+    #[arg(long)]
+    #[serde(default)]
+    pub(crate) include_mail: bool,
 
     /// Remap URI matching pattern to different URI
     #[serde(default)]

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -121,16 +121,29 @@ mod cli {
     }
 
     #[test]
-    fn test_exclude_email() -> Result<()> {
+    fn test_email() -> Result<()> {
         test_json_output!(
             "TEST_EMAIL.md",
             MockResponseStats {
-                total: 6,
-                excludes: 4,
-                successful: 2,
+                total: 5,
+                excludes: 0,
+                successful: 5,
                 ..MockResponseStats::default()
             },
-            "--exclude-mail"
+            "--include-mail"
+        )
+    }
+
+    #[test]
+    fn test_exclude_email_by_default() -> Result<()> {
+        test_json_output!(
+            "TEST_EMAIL.md",
+            MockResponseStats {
+                total: 5,
+                excludes: 3,
+                successful: 2,
+                ..MockResponseStats::default()
+            }
         )
     }
 
@@ -141,6 +154,7 @@ mod cli {
 
         cmd.arg("--dump")
             .arg(input)
+            .arg("--include-mail")
             .assert()
             .success()
             .stdout(contains("hello@example.org?subject=%5BHello%5D"));
@@ -155,6 +169,7 @@ mod cli {
 
         cmd.arg("--dump")
             .arg(input)
+            .arg("--include-mail")
             .assert()
             .success()
             .stdout(contains("hello@example.org?subject=%5BHello%5D"));
@@ -475,7 +490,8 @@ mod cli {
             "TEST.md",
             MockResponseStats {
                 total: 11,
-                successful: 11,
+                successful: 9,
+                excludes: 2,
                 ..MockResponseStats::default()
             }
         )
@@ -491,6 +507,7 @@ mod cli {
         cmd.arg("--output")
             .arg(&outfile)
             .arg("--dump")
+            .arg("--include-mail")
             .arg(test_path)
             .assert()
             .success();
@@ -533,42 +550,7 @@ mod cli {
             .arg("https://ldra.com/")
             .assert()
             .success()
-            .stdout(contains("2 Excluded"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_exclude_file() -> Result<()> {
-        let mut cmd = main_command();
-        let test_path = fixtures_path().join("TEST.md");
-        let excludes_path = fixtures_path().join("TEST_EXCLUDE_1.txt");
-
-        cmd.arg(test_path)
-            .arg("--exclude-file")
-            .arg(excludes_path)
-            .assert()
-            .success()
-            .stdout(contains("2 Excluded"));
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_multiple_exclude_files() -> Result<()> {
-        let mut cmd = main_command();
-        let test_path = fixtures_path().join("TEST.md");
-        let excludes_path1 = fixtures_path().join("TEST_EXCLUDE_1.txt");
-        let excludes_path2 = fixtures_path().join("TEST_EXCLUDE_2.txt");
-
-        cmd.arg(test_path)
-            .arg("--exclude-file")
-            .arg(excludes_path1)
-            .arg("--exclude-file")
-            .arg(excludes_path2)
-            .assert()
-            .success()
-            .stdout(contains("3 Excluded"));
+            .stdout(contains("4 Excluded"));
 
         Ok(())
     }

--- a/lychee-bin/tests/example_domains.rs
+++ b/lychee-bin/tests/example_domains.rs
@@ -32,6 +32,7 @@ mod cli {
 
         let cmd = cmd
             .arg(input)
+            .arg("--include-mail")
             .arg("--dump")
             .assert()
             .success()

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -110,5 +110,5 @@ exclude_link_local = false
 # Exclude loopback IP address range and localhost from checking.
 exclude_loopback = false
 
-# Exclude all mail addresses from checking.
-exclude_mail = false
+# Check mail addresses
+include_mail = true


### PR DESCRIPTION
E-Mail checks cause too many false-postives,
so we put them behind a flag.

* `--exclude-mail` is deprecated (to be removed in 1.0)
* `--include-mail` is the new flag

This PR also removes the obsolete tests for `--exclude-file`, which was superseded by `.lycheeignore`.

Fixes #1089