### PR TITLE
Don't check preconnect links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,6 +2564,7 @@ dependencies = [
  "par-stream",
  "path-clean",
  "percent-encoding",
+ "pretty_assertions",
  "pulldown-cmark",
  "regex",
  "reqwest 0.12.7",

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -69,6 +69,7 @@ wiremock = "0.6.2"
 serde_json = "1.0.128"
 rstest = "0.22.0"
 toml = "0.8.19"
+pretty_assertions = "1.4.0"
 
 [features]
 

--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -148,7 +148,6 @@ impl LinkExtractor {
         // and https://html.spec.whatwg.org/multipage/indices.html#attributes-1
 
         match (elem_name, attr_name) {
-            // TODO: Skip <link rel="preconnect">
 
             // Common element/attribute combinations for links
             (_, "href" | "src" | "cite" | "usemap")

--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -400,4 +400,14 @@ mod tests {
         let uris = extract_html(input, false);
         assert!(uris.is_empty());
     }
+
+    #[test]
+    fn test_skip_preconnect_reverse_order() {
+        let input = r#"
+            <link href="https://example.com" rel="preconnect">
+        "#;
+
+        let uris = extract_html(input, false);
+        assert!(uris.is_empty());
+    }
 }

--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -6,7 +6,9 @@ use html5ever::{
     tokenizer::{Tag, TagKind, Token, TokenSink, TokenSinkResult, Tokenizer, TokenizerOpts},
 };
 
-use super::{super::plaintext::extract_raw_uri_from_plaintext, is_email_link, is_verbatim_elem, srcset};
+use super::{
+    super::plaintext::extract_raw_uri_from_plaintext, is_email_link, is_verbatim_elem, srcset,
+};
 use crate::types::uri::raw::RawUri;
 
 #[derive(Clone, Default)]
@@ -26,7 +28,9 @@ impl TokenSink for LinkExtractor {
                 if self.current_verbatim_element_name.borrow().is_some() {
                     return TokenSinkResult::Continue;
                 }
-                self.links.borrow_mut().extend(extract_raw_uri_from_plaintext(&raw));
+                self.links
+                    .borrow_mut()
+                    .extend(extract_raw_uri_from_plaintext(&raw));
             }
             Token::TagToken(tag) => {
                 let Tag {

--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -6,7 +6,7 @@ use html5ever::{
     tokenizer::{Tag, TagKind, Token, TokenSink, TokenSinkResult, Tokenizer, TokenizerOpts},
 };
 
-use super::{super::plaintext::extract_plaintext, is_email_link, is_verbatim_elem, srcset};
+use super::{super::plaintext::extract_raw_uri_from_plaintext, is_email_link, is_verbatim_elem, srcset};
 use crate::types::uri::raw::RawUri;
 
 #[derive(Clone, Default)]
@@ -26,7 +26,7 @@ impl TokenSink for LinkExtractor {
                 if self.current_verbatim_element_name.borrow().is_some() {
                     return TokenSinkResult::Continue;
                 }
-                self.links.borrow_mut().extend(extract_plaintext(&raw));
+                self.links.borrow_mut().extend(extract_raw_uri_from_plaintext(&raw));
             }
             Token::TagToken(tag) => {
                 let Tag {
@@ -88,7 +88,7 @@ impl TokenSink for LinkExtractor {
                     );
 
                     let new_urls = match urls {
-                        None => extract_plaintext(&attr.value),
+                        None => extract_raw_uri_from_plaintext(&attr.value),
                         Some(urls) => urls
                             .into_iter()
                             .filter(|url| {

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -13,7 +13,7 @@ struct LinkExtractor {
     links: Vec<RawUri>,
     /// Fragments extracted from the HTML document.
     fragments: HashSet<String>,
-    /// Current string being processed.
+    /// Current raw string (a bunch of plain characters) being processed.
     current_string: Vec<u8>,
     /// Current element being processed.
     current_element_name: Vec<u8>,

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -211,12 +211,15 @@ impl LinkExtractor {
                 Some(urls) => urls
                     .into_iter()
                     .filter(|url| {
-                        // Only accept email addresses, which occur in `href` attributes
-                        // and start with `mailto:`. Technically, email addresses could
-                        // also occur in plain text, but we don't want to extract those
-                        // because of the high false positive rate.
+                        // Only accept email addresses or phone numbers, which
+                        // occur in `href` attributes and start with `mailto:`
+                        // or `tel:`, respectively
                         //
-                        // This ignores links like `<img srcset="v2@1.5x.png">`
+                        // Technically, email addresses could also occur in
+                        // plain text, but we don't want to extract those
+                        // because of the high false-positive rate.
+                        //
+                        // This skips links like `<img srcset="v2@1.5x.png">`
                         let is_email = is_email_link(url);
                         let is_mailto = url.starts_with("mailto:");
                         let is_phone = url.starts_with("tel:");

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -18,7 +18,7 @@ struct LinkExtractor {
     /// Current raw string (a bunch of plain characters) being processed.
     current_string: Vec<u8>,
     /// Current element being processed.
-    /// What html5gum calls a tag, lychee calls an element.
+    /// This is called a tag in html5gum.
     current_element_name: Vec<u8>,
     /// Whether the current element is a closing tag.
     current_element_is_closing: bool,
@@ -26,15 +26,15 @@ struct LinkExtractor {
     current_element_nofollow: bool,
     /// Whether the current element has a `rel=preconnect` attribute.
     current_element_preconnect: bool,
+    /// Element name of the current verbatim block.
+    /// Used to keep track of nested verbatim blocks.
+    current_verbatim_element_name: Option<Vec<u8>>,
     /// Current attribute name being processed.
     current_attribute_name: Vec<u8>,
     /// Current attribute value being processed.
     current_attribute_value: Vec<u8>,
     /// Last start element, i.e. the last element (tag) that was opened.
     last_start_element: Vec<u8>,
-    /// Element name of the current verbatim block.
-    /// Used to keep track of nested verbatim blocks.
-    current_verbatim_element_name: Option<Vec<u8>>,
 }
 
 /// this is the same as `std::str::from_utf8_unchecked`, but with extra debug assertions for ease
@@ -49,6 +49,7 @@ impl LinkExtractor {
         LinkExtractor {
             links: Vec::new(),
             fragments: HashSet::new(),
+            include_verbatim,
             current_string: Vec::new(),
             current_element_name: Vec::new(),
             current_element_is_closing: false,
@@ -56,9 +57,8 @@ impl LinkExtractor {
             current_element_preconnect: false,
             current_attribute_name: Vec::new(),
             current_attribute_value: Vec::new(),
-            last_start_element: Vec::new(),
-            include_verbatim,
             current_verbatim_element_name: None,
+            last_start_element: Vec::new(),
         }
     }
 

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -7,7 +7,7 @@ use crate::{extract::plaintext::extract_raw_uri_from_plaintext, types::uri::raw:
 
 /// Extract links from HTML documents.
 ///
-/// This is the main driver for the HTML5Gum tokenizer.
+/// This is the main driver for the html5gum tokenizer.
 /// It implements the `Emitter` trait, which is used by the tokenizer to
 /// communicate with the caller.
 ///
@@ -84,15 +84,15 @@ impl LinkExtractor {
     // see https://www.w3.org/TR/REC-html40/index/attributes.html
     // and https://html.spec.whatwg.org/multipage/indices.html#attributes-1
     #[allow(clippy::unnested_or_patterns)]
-    pub(crate) fn extract_urls_from_elem_attr<'a>(
+    pub(crate) fn extract_urls_from_elem_attr(
         elem_name: &str,
-        attributes: &'a [(Vec<u8>, Vec<u8>)],
+        attributes: &[(Vec<u8>, Vec<u8>)],
     ) -> Option<impl Iterator<Item = RawUri>> {
         let mut urls = Vec::new();
 
         for (attr_name, attr_value) in attributes {
-            let attr_name = unsafe { from_utf8_unchecked(&attr_name) };
-            let attr_value = unsafe { from_utf8_unchecked(&attr_value) };
+            let attr_name = unsafe { from_utf8_unchecked(attr_name) };
+            let attr_value = unsafe { from_utf8_unchecked(attr_value) };
             match (elem_name, attr_name) {
                 // Common element/attribute combinations for links
                 (_, "href" | "src" | "cite" | "usemap")
@@ -644,7 +644,6 @@ mod tests {
     fn test_email_false_positive() {
         let input = r#"<img srcset="v2@1.5x.png" alt="Wikipedia" width="200" height="183">"#;
         let uris = extract_html(input, false);
-        println!("{:?}", uris);
         assert!(uris.is_empty());
     }
 

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -238,6 +238,7 @@ impl Emitter for &mut LinkExtractor {
         self.flush_current_characters();
         self.current_element_name.clear();
         self.current_element_nofollow = false;
+        self.current_element_preconnect = false;
         self.current_element_is_closing = false;
     }
 
@@ -433,7 +434,7 @@ mod tests {
     }
 
     #[test]
-    fn test_include_nofollow() {
+    fn test_exclude_nofollow() {
         let input = r#"
         <a rel="nofollow" href="https://foo.com">do not follow me</a>
         <a rel="canonical,nofollow,dns-prefetch" href="https://example.com">do not follow me</a>
@@ -446,6 +447,15 @@ mod tests {
         }];
         let uris = extract_html(input, false);
         assert_eq!(uris, expected);
+    }
+
+    #[test]
+    fn test_exclude_nofollow_change_order() {
+        let input = r#"
+        <a href="https://foo.com" rel="nofollow">do not follow me</a>
+        "#;
+        let uris = extract_html(input, false);
+        assert!(uris.is_empty());
     }
 
     #[test]
@@ -574,6 +584,16 @@ mod tests {
     fn test_skip_preconnect() {
         let input = r#"
             <link rel="preconnect" href="https://example.com">
+        "#;
+
+        let uris = extract_html(input, false);
+        assert!(uris.is_empty());
+    }
+
+    #[test]
+    fn test_skip_preconnect_reverse_order() {
+        let input = r#"
+            <link href="https://example.com" rel="preconnect">
         "#;
 
         let uris = extract_html(input, false);

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -102,16 +102,18 @@ impl LinkExtractor {
 
     fn flush_current_characters(&mut self) {
         // safety: since we feed html5gum tokenizer with a &str, this must be a &str as well.
-        let name = unsafe { from_utf8_unchecked(&self.current_element_name) };
-        if !self.include_verbatim && (is_verbatim_elem(name) || self.inside_verbatim_block()) {
+        let current_element_name = unsafe { from_utf8_unchecked(&self.current_element_name) };
+        if !self.include_verbatim
+            && (is_verbatim_elem(current_element_name) || self.inside_verbatim_block())
+        {
             self.update_verbatim_element_name();
             // Early return if we don't want to extract links from preformatted text
             self.current_string.clear();
             return;
         }
 
-        let raw = unsafe { from_utf8_unchecked(&self.current_string) };
-        self.links.extend(extract_plaintext(raw));
+        let current_string = unsafe { from_utf8_unchecked(&self.current_string) };
+        self.links.extend(extract_plaintext(current_string));
         self.current_string.clear();
     }
 
@@ -261,16 +263,19 @@ impl Emitter for &mut LinkExtractor {
     fn emit_eof(&mut self) {
         self.flush_current_characters();
     }
+
     fn emit_error(&mut self, _: Error) {}
 
     #[inline]
     fn should_emit_errors(&mut self) -> bool {
         false
     }
+
     fn pop_token(&mut self) -> Option<()> {
         None
     }
 
+    /// Emit a bunch of plain characters as character tokens.
     fn emit_string(&mut self, c: &[u8]) {
         self.current_string.extend(c);
     }
@@ -310,9 +315,11 @@ impl Emitter for &mut LinkExtractor {
     }
 
     fn emit_current_doctype(&mut self) {}
+
     fn set_self_closing(&mut self) {
         self.current_element_is_closing = true;
     }
+
     fn set_force_quirks(&mut self) {}
 
     fn push_tag_name(&mut self, s: &[u8]) {
@@ -320,24 +327,33 @@ impl Emitter for &mut LinkExtractor {
     }
 
     fn push_comment(&mut self, _: &[u8]) {}
+
     fn push_doctype_name(&mut self, _: &[u8]) {}
+
     fn init_doctype(&mut self) {
         self.flush_current_characters();
     }
+
     fn init_attribute(&mut self) {
         self.flush_links();
     }
+
     fn push_attribute_name(&mut self, s: &[u8]) {
         self.current_attribute_name.extend(s);
     }
+
     fn push_attribute_value(&mut self, s: &[u8]) {
         self.current_attribute_value.extend(s);
     }
 
     fn set_doctype_public_identifier(&mut self, _: &[u8]) {}
+
     fn set_doctype_system_identifier(&mut self, _: &[u8]) {}
+
     fn push_doctype_public_identifier(&mut self, _: &[u8]) {}
+
     fn push_doctype_system_identifier(&mut self, _: &[u8]) {}
+
     fn current_is_appropriate_end_tag_token(&mut self) -> bool {
         self.current_element_is_closing
             && !self.current_element_name.is_empty()

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -9,13 +9,13 @@ use crate::{extract::plaintext::extract_plaintext, types::uri::raw::RawUri};
 #[allow(clippy::struct_excessive_bools)]
 struct LinkExtractor {
     /// Links extracted from the HTML document.
-    // note: what html5gum calls a tag, lychee calls an element
     links: Vec<RawUri>,
     /// Fragments extracted from the HTML document.
     fragments: HashSet<String>,
     /// Current raw string (a bunch of plain characters) being processed.
     current_string: Vec<u8>,
     /// Current element being processed.
+    /// What html5gum calls a tag, lychee calls an element.
     current_element_name: Vec<u8>,
     /// Whether the current element is a closing tag.
     current_element_is_closing: bool,

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 
 use pulldown_cmark::{CowStr, Event, LinkType, Options, Parser, Tag, TagEnd};
 
-use crate::{extract::plaintext::extract_plaintext, types::uri::raw::RawUri};
+use crate::{extract::plaintext::extract_raw_uri_from_plaintext, types::uri::raw::RawUri};
 
 use super::html::html5gum::{extract_html, extract_html_fragments};
 
@@ -59,7 +59,7 @@ pub(crate) fn extract_markdown(input: &str, include_verbatim: bool) -> Vec<RawUr
                     LinkType::Autolink |
                     // Email address in autolink like `<john@example.org>`
                     LinkType::Email =>
-                     Some(extract_plaintext(&dest_url)),
+                     Some(extract_raw_uri_from_plaintext(&dest_url)),
                 }
             }
 
@@ -91,7 +91,7 @@ pub(crate) fn extract_markdown(input: &str, include_verbatim: bool) -> Vec<RawUr
                 if inside_code_block && !include_verbatim {
                     None
                 } else {
-                    Some(extract_plaintext(&txt))
+                    Some(extract_raw_uri_from_plaintext(&txt))
                 }
             }
 
@@ -105,7 +105,7 @@ pub(crate) fn extract_markdown(input: &str, include_verbatim: bool) -> Vec<RawUr
             // An inline code node.
             Event::Code(code) => {
                 if include_verbatim {
-                    Some(extract_plaintext(&code))
+                    Some(extract_raw_uri_from_plaintext(&code))
                 } else {
                     None
                 }

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -57,6 +57,7 @@ impl Extractor {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
     use reqwest::Url;
     use std::{collections::HashSet, path::Path};
 
@@ -72,20 +73,33 @@ mod tests {
         let input_content = InputContent::from_string(input, file_type);
 
         let extractor = Extractor::new(false, false);
-        let uris_html5gum = extractor
+        let uris_html5gum: HashSet<Uri> = extractor
             .extract(&input_content)
             .into_iter()
             .filter_map(|raw_uri| Uri::try_from(raw_uri).ok())
             .collect();
+        let uris_html5gum_sorted: Vec<Uri> = {
+            let mut uris = uris_html5gum.clone().into_iter().collect::<Vec<_>>();
+            uris.sort();
+            uris
+        };
 
         let extractor = Extractor::new(true, false);
-        let uris_html5ever = extractor
+        let uris_html5ever: HashSet<Uri> = extractor
             .extract(&input_content)
             .into_iter()
             .filter_map(|raw_uri| Uri::try_from(raw_uri).ok())
             .collect();
+        let uris_html5ever_sorted: Vec<Uri> = {
+            let mut uris = uris_html5ever.into_iter().collect::<Vec<_>>();
+            uris.sort();
+            uris
+        };
 
-        assert_eq!(uris_html5gum, uris_html5ever);
+        assert_eq!(
+            uris_html5gum_sorted, uris_html5ever_sorted,
+            "Mismatch between html5gum and html5ever"
+        );
         uris_html5gum
     }
 

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -5,7 +5,7 @@ pub mod markdown;
 mod plaintext;
 
 use markdown::extract_markdown;
-use plaintext::extract_plaintext;
+use plaintext::extract_raw_uri_from_plaintext;
 
 /// A handler for extracting links from various input formats like Markdown and
 /// HTML. Allocations should be avoided if possible as this is a
@@ -50,7 +50,7 @@ impl Extractor {
                     html::html5gum::extract_html(&input_content.content, self.include_verbatim)
                 }
             }
-            FileType::Plaintext => extract_plaintext(&input_content.content),
+            FileType::Plaintext => extract_raw_uri_from_plaintext(&input_content.content),
         }
     }
 }

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -241,7 +241,8 @@ mod tests {
         let expected_links = IntoIterator::into_iter([
             website("https://example.com/"),
             website("https://example.com/favicon.ico"),
-            website("https://fonts.externalsite.com"),
+            // Note that we exclude `preconnect` links:
+            // website("https://fonts.externalsite.com"),
             website("https://example.com/docs/"),
             website("https://example.com/forum"),
         ])

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -1,7 +1,7 @@
 use crate::{types::uri::raw::RawUri, utils::url};
 
 /// Extract unparsed URL strings from plaintext
-pub(crate) fn extract_plaintext(input: &str) -> Vec<RawUri> {
+pub(crate) fn extract_raw_uri_from_plaintext(input: &str) -> Vec<RawUri> {
     url::find_links(input)
         .map(|uri| RawUri::from(uri.as_str()))
         .collect()
@@ -14,7 +14,7 @@ mod tests {
     #[test]
     fn test_extract_local_links() {
         let input = "http://127.0.0.1/ and http://127.0.0.1:8888/ are local links.";
-        let links: Vec<RawUri> = extract_plaintext(input);
+        let links: Vec<RawUri> = extract_raw_uri_from_plaintext(input);
         assert_eq!(
             links,
             [
@@ -29,7 +29,7 @@ mod tests {
         let input = "https://www.apache.org/licenses/LICENSE-2.0\n";
         let uri = RawUri::from(input.trim_end());
 
-        let uris: Vec<RawUri> = extract_plaintext(input);
+        let uris: Vec<RawUri> = extract_raw_uri_from_plaintext(input);
         assert_eq!(vec![uri], uris);
     }
 }


### PR DESCRIPTION
Preconnect links are used to establish a server connection without loading a specific resource yet.
Not always do these links point to a URL that should return a 200, and they are not user-facing, i.e. they don't show up in the final rendered version of a page.

Therefore, I think we should exclude them at all; not even in `--include-verbatim`
mode, as they might not point to a valid resource.

Fixes #897