### PR TITLE
Fix rustls-tls feature

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -73,7 +73,6 @@ use log::{error, info, warn};
 #[cfg(feature = "native-tls")]
 use openssl_sys as _; // required for vendored-openssl feature
 
-use openssl_sys as _;
 use options::LYCHEE_CONFIG_FILE;
 use ring as _; // required for apple silicon
 

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -41,7 +41,7 @@ pulldown-cmark = "0.9.3"
 regex = "1.9.1"
 # Use trust-dns to avoid lookup failures on high concurrency
 # https://github.com/seanmonstar/reqwest/issues/296
-reqwest = { version = "0.11.18", features = ["gzip", "trust-dns", "cookies"] }
+reqwest = { version = "0.11.18", default-features = false, features = ["gzip", "trust-dns", "cookies"] }
 reqwest_cookie_store = "0.6.0"
 # Make build work on Apple Silicon.
 # See https://github.com/briansmith/ring/issues/1163

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -715,8 +715,12 @@ impl Client {
         }
     }
 
+    /// Check a mail address, or equivalently a `mailto` URI.
+    ///
+    /// This implementation simply excludes all email addresses.
     #[cfg(not(all(feature = "email-check", feature = "native-tls")))]
-    pub async fn check_mail(&self, uri: &Uri) -> Status {
+    #[allow(clippy::unused_async)]
+    pub async fn check_mail(&self, _uri: &Uri) -> Status {
         Status::Excluded
     }
 }


### PR DESCRIPTION
Commit 14e74879 (cookie support #1146) re-introduced an unconditional
dependency on the openssl-sys crate. That is, building Lychee with the
Rustls TLS backend now requires OpenSSL. I suppose this change was
unintended, maybe due to automatic conflict resolution. If not, please
let me know.

You can review the re-introduced dependency like so:

```
cargo tree --no-default-features --features rustls-tls -i openssl-sys
```

This commit puts the OpenSSL dependency behind the native-tls feature
flag again.

You can check the TLS features like so:

```
cargo check --workspace --all-targets --features vendored-openssl

cargo check --workspace --all-targets --all-features

cargo check --workspace --all-targets --no-default-features --features rustls-tls
```

Maybe this should be added to CI. But I don't want to waste anybody's
time.
