### PR TITLE
fix nightly release bash script

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,11 +22,16 @@ jobs:
           fetch-depth: 0
       - if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
+          gh release delete ${{ github.event.inputs.tag_name }} --yes --cleanup-tag || true
+          git tag -d ${{ github.event.inputs.tag_name }}
           gh release create ${{ github.event.inputs.tag_name }} --title ${{ github.event.inputs.tag_name }} --generate-notes --prerelease
 
       - if: ${{ github.event_name == 'schedule' }}
         run: |
-          if [[ $(git diff nightly --name-only -B -M -C) ]]; then
+          if [[ -z $(git tag -l nightly) ]]; then
+            gh release create nightly --title nightly --generate-notes --prerelease
+          elif [[ $(git diff nightly --name-only -B -M -C) ]]; then
             gh release delete nightly --yes --cleanup-tag || true
+            git tag -d nightly
             gh release create nightly --title nightly --generate-notes --prerelease
           fi


### PR DESCRIPTION
There are two errors in the past nightly CI:

- https://github.com/lycheeverse/lychee/actions/runs/5876633509/job/15935180970
  - because the `gh release delete --cleanup-tag`  won't delete the local tag, refer to https://github.com/cli/cli/blob/4a57a812f5db9db72812030f19b214c93b18b297/pkg/cmd/release/delete/delete.go#L136
- https://github.com/lycheeverse/lychee/actions/runs/5888738531/job/15970534873
  - because the previous nightly CI deleted the remote tag & release but failed to generate a new one

This PR should fix them. It will detect if the `nightly` tag exists:
- exist: check if there are new commits
- not exist: release a new `nightly`