### PR TITLE
Fix typos

### DIFF
--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -131,7 +131,7 @@ fn construct_url(base: &Option<Url>, text: &str) -> Option<Result<Url>> {
 }
 
 fn create_uri_from_path(src: &Path, dst: &str, base: &Option<Base>) -> Result<Option<Url>> {
-    let (dst, frag) = url::remove_get_params_and_seperate_fragment(dst);
+    let (dst, frag) = url::remove_get_params_and_separate_fragment(dst);
     // Avoid double-encoding already encoded destination paths by removing any
     // potential encoding (e.g. `web%20site` becomes `web site`).
     // That's because Url::from_file_path will encode the full URL in the end.

--- a/lychee-lib/src/utils/url.rs
+++ b/lychee-lib/src/utils/url.rs
@@ -4,9 +4,9 @@ use once_cell::sync::Lazy;
 
 static LINK_FINDER: Lazy<LinkFinder> = Lazy::new(LinkFinder::new);
 
-/// Remove all GET parameters from a URL and seperates out the fragment.
+/// Remove all GET parameters from a URL and separates out the fragment.
 /// The link is not a URL but a String as it may not have a base domain.
-pub(crate) fn remove_get_params_and_seperate_fragment(url: &str) -> (&str, Option<&str>) {
+pub(crate) fn remove_get_params_and_separate_fragment(url: &str) -> (&str, Option<&str>) {
     let (path, frag) = match url.split_once('#') {
         Some((path, fragment)) => (path, Some(fragment)),
         None => (url, None),
@@ -29,48 +29,48 @@ mod test_fs_tree {
 
     #[test]
     fn test_remove_get_params_and_fragment() {
-        assert_eq!(remove_get_params_and_seperate_fragment("/"), ("/", None));
+        assert_eq!(remove_get_params_and_separate_fragment("/"), ("/", None));
         assert_eq!(
-            remove_get_params_and_seperate_fragment("index.html?foo=bar"),
+            remove_get_params_and_separate_fragment("index.html?foo=bar"),
             ("index.html", None)
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("/index.html?foo=bar"),
+            remove_get_params_and_separate_fragment("/index.html?foo=bar"),
             ("/index.html", None)
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("/index.html?foo=bar&baz=zorx?bla=blub"),
+            remove_get_params_and_separate_fragment("/index.html?foo=bar&baz=zorx?bla=blub"),
             ("/index.html", None)
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("https://example.com/index.html?foo=bar"),
+            remove_get_params_and_separate_fragment("https://example.com/index.html?foo=bar"),
             ("https://example.com/index.html", None)
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("test.png?foo=bar"),
+            remove_get_params_and_separate_fragment("test.png?foo=bar"),
             ("test.png", None)
         );
 
         assert_eq!(
-            remove_get_params_and_seperate_fragment("https://example.com/index.html#anchor"),
+            remove_get_params_and_separate_fragment("https://example.com/index.html#anchor"),
             ("https://example.com/index.html", Some("anchor"))
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment(
+            remove_get_params_and_separate_fragment(
                 "https://example.com/index.html?foo=bar#anchor"
             ),
             ("https://example.com/index.html", Some("anchor"))
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("test.png?foo=bar#anchor"),
+            remove_get_params_and_separate_fragment("test.png?foo=bar#anchor"),
             ("test.png", Some("anchor"))
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("test.png#anchor?anchor!?"),
+            remove_get_params_and_separate_fragment("test.png#anchor?anchor!?"),
             ("test.png", Some("anchor?anchor!?"))
         );
         assert_eq!(
-            remove_get_params_and_seperate_fragment("test.png?foo=bar#anchor?anchor!"),
+            remove_get_params_and_separate_fragment("test.png?foo=bar#anchor?anchor!"),
             ("test.png", Some("anchor?anchor!"))
         );
     }


### PR DESCRIPTION
Found a typo with `typos`.
It is in a public function's name.
