### PR TITLE
Decode percent escapes in fragments

### DIFF
--- a/fixtures/fragments/file1.md
+++ b/fixtures/fragments/file1.md
@@ -40,3 +40,5 @@ Therefore we put the test into a code block for now to prevent false positives.
 # Kebab Case Fragment
 
 [Link to another file type](empty_file#fragment)
+
+##### Lets wear a hat: être

--- a/fixtures/fragments/file2.md
+++ b/fixtures/fragments/file2.md
@@ -5,3 +5,6 @@ This is a test file for the fragment loader.
 ### Some other heading with custom id {#custom-id}
 
 #### Fragment 1
+
+[hats](file1.md#lets-wear-a-hat-être)
+

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1440,7 +1440,9 @@ mod cli {
             .stderr(contains("fixtures/fragments/file1.md#missing-fragment"))
             .stderr(contains("fixtures/fragments/file2.md#fragment-1"))
             .stderr(contains("fixtures/fragments/file1.md#kebab-case-fragment"))
-            .stderr(contains("fixtures/fragments/file1.md#lets-wear-a-hat-être"))
+            .stderr(contains(
+                "fixtures/fragments/file1.md#lets-wear-a-hat-%C3%AAtre",
+            ))
             .stderr(contains("fixtures/fragments/file2.md#missing-fragment"))
             .stderr(contains("fixtures/fragments/empty_file#fragment"))
             .stderr(contains("fixtures/fragments/file.html#a-word"))

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1440,6 +1440,7 @@ mod cli {
             .stderr(contains("fixtures/fragments/file1.md#missing-fragment"))
             .stderr(contains("fixtures/fragments/file2.md#fragment-1"))
             .stderr(contains("fixtures/fragments/file1.md#kebab-case-fragment"))
+            .stderr(contains("fixtures/fragments/file1.md#lets-wear-a-hat-être"))
             .stderr(contains("fixtures/fragments/file2.md#missing-fragment"))
             .stderr(contains("fixtures/fragments/empty_file#fragment"))
             .stderr(contains("fixtures/fragments/file.html#a-word"))
@@ -1448,8 +1449,8 @@ mod cli {
             .stderr(contains(
                 "fixtures/fragments/file1.md#kebab-case-fragment-1",
             ))
-            .stdout(contains("13 Total"))
-            .stdout(contains("10 OK"))
+            .stdout(contains("14 Total"))
+            .stdout(contains("11 OK"))
             // 3 failures because of missing fragments
             .stdout(contains("3 Errors"));
     }


### PR DESCRIPTION
The `Url` struct percent escapes fragments which breaks checks for titles containing utf8 characters.

This PR has a test for this eventuality and a suggested bug fix.