### PR TITLE
Update README.md with exit code 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,7 @@ Options:
 - `0` for success (all links checked successfully or excluded/skipped as configured)
 - `1` for missing inputs and any unexpected runtime failures or config errors
 - `2` for link check failures (if any non-excluded link failed the check)
+- `3` for errors in the config file
 
 ### Ignoring links
 


### PR DESCRIPTION
Add missing exit code to the README.md

Corresponding `enum` in `main.rs`

```rust
enum ExitCode {
    Success = 0,
    UnexpectedFailure = 1,
    LinkCheckFailure = 2,
    ConfigFile = 3,
}
```