### PR TITLE
Address warnings of the new clippy lints

### DIFF
--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -207,7 +207,7 @@ mod tests {
     fn test_render_stats() {
         let stats = ResponseStats::default();
         let table = stats_table(&stats);
-        let expected = r#"| Status        | Count |
+        let expected = "| Status        | Count |
 |---------------|-------|
 | 🔍 Total      | 0     |
 | ✅ Successful | 0     |
@@ -215,7 +215,7 @@ mod tests {
 | 🔀 Redirected | 0     |
 | 👻 Excluded   | 0     |
 | ❓ Unknown    | 0     |
-| 🚫 Errors     | 0     |"#;
+| 🚫 Errors     | 0     |";
         assert_eq!(table, expected.to_string());
     }
 
@@ -239,7 +239,7 @@ mod tests {
                 original: Url::parse("https://example.com/original").unwrap(),
             });
         let summary = MarkdownResponseStats(stats);
-        let expected = r#"## Summary
+        let expected = "## Summary
 
 | Status        | Count |
 |---------------|-------|
@@ -262,7 +262,7 @@ mod tests {
 ### Suggestions in stdin
 
 * https://example.com/original --> https://example.com/suggestion
-"#;
+";
         assert_eq!(summary.to_string(), expected.to_string());
     }
 }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -32,8 +32,8 @@ mod cli {
     macro_rules! mock_server {
         ($status:expr $(, $func:tt ($($arg:expr),*))*) => {{
             let mock_server = wiremock::MockServer::start().await;
-            let template = wiremock::ResponseTemplate::new(http::StatusCode::from($status));
-            let template = template$(.$func($($arg),*))*;
+            let response_template = wiremock::ResponseTemplate::new(http::StatusCode::from($status));
+            let template = response_template$(.$func($($arg),*))*;
             wiremock::Mock::given(wiremock::matchers::method("GET")).respond_with(template).mount(&mock_server).await;
             mock_server
         }};

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -300,10 +300,10 @@ mod tests {
 
         let input = Input {
             source: InputSource::String(
-                r#"This is [an internal url](@/internal.md)
+                "This is [an internal url](@/internal.md)
         This is [an internal url](@/internal.markdown)
         This is [an internal url](@/internal.markdown#example)
-        This is [an internal url](@/internal.md#example)"#
+        This is [an internal url](@/internal.md#example)"
                     .to_string(),
             ),
             file_type_hint: Some(FileType::Markdown),
@@ -379,7 +379,7 @@ mod tests {
     async fn test_email_with_query_params() {
         let input = Input {
             source: InputSource::String(
-                r#"This is a mailto:user@example.com?subject=Hello link"#.to_string(),
+                "This is a mailto:user@example.com?subject=Hello link".to_string(),
             ),
             file_type_hint: None,
             excluded_paths: None,

--- a/lychee-lib/src/extract/mod.rs
+++ b/lychee-lib/src/extract/mod.rs
@@ -91,11 +91,7 @@ mod tests {
 
     #[test]
     fn verbatim_elem() {
-        let input = r#"
-        <pre>
-        https://example.com
-        </pre>
-        "#;
+        let input = "<pre>https://example.com</pre>";
         let uris = extract_uris(input, FileType::Html);
         assert!(uris.is_empty());
     }

--- a/lychee-lib/src/test_utils.rs
+++ b/lychee-lib/src/test_utils.rs
@@ -10,8 +10,8 @@ use crate::{ClientBuilder, ErrorKind, Request, Uri};
 macro_rules! mock_server {
     ($status:expr $(, $func:tt ($($arg:expr),*))*) => {{
         let mock_server = wiremock::MockServer::start().await;
-        let template = wiremock::ResponseTemplate::new(http::StatusCode::from($status));
-        let template = template$(.$func($($arg),*))*;
+        let response_template = wiremock::ResponseTemplate::new(http::StatusCode::from($status));
+        let template = response_template$(.$func($($arg),*))*;
         wiremock::Mock::given(wiremock::matchers::method("GET")).respond_with(template).mount(&mock_server).await;
         mock_server
     }};

--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -85,7 +85,7 @@ impl Uri {
         let mut https_uri = self.clone();
         https_uri
             .set_scheme("https")
-            .map_err(|_| ErrorKind::InvalidURI(self.clone()))?;
+            .map_err(|()| ErrorKind::InvalidURI(self.clone()))?;
         Ok(https_uri)
     }
 


### PR DESCRIPTION
With Rust 1.73 and 1.74 [new lints were added to clippy](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-174). Some of these new lints caused new warnings and the linting step to fail.