### PR TITLE
Fix false-positive example domains

### DIFF
--- a/fixtures/TEST_EXAMPLE_DOMAINS.md
+++ b/fixtures/TEST_EXAMPLE_DOMAINS.md
@@ -6,6 +6,7 @@ http://example.org
 https://www.rust-lang.org/
 test@foo.example.org
 http://foo.example.org
+https://www.example.com
 mailto:foo@bar.dev
 mailto:hello@example.com?subject=hello
 http://example.net/foo/bar

--- a/fixtures/TEST_EXAMPLE_DOMAINS_FALSE_POSITIVES.md
+++ b/fixtures/TEST_EXAMPLE_DOMAINS_FALSE_POSITIVES.md
@@ -1,0 +1,3 @@
+http://gobyexample.com/
+https://examples.com/
+https://texample.net/

--- a/lychee-bin/tests/example_domains.rs
+++ b/lychee-bin/tests/example_domains.rs
@@ -47,4 +47,26 @@ mod cli {
 
         Ok(())
     }
+
+    #[test]
+    fn test_do_not_exclude_false_positive_example_domains() -> Result<()> {
+        let mut cmd = main_command();
+        let input = fixtures_path().join("TEST_EXAMPLE_DOMAINS_FALSE_POSITIVES.md");
+
+        let cmd = cmd
+            .arg(input)
+            .arg("--include-mail")
+            .arg("--dump")
+            .assert()
+            .success()
+            .stdout(contains("https://examples.com"))
+            .stdout(contains("https://texample.net"))
+            .stdout(contains("http://gobyexample.com"));
+
+        let output = cmd.get_output();
+        let output = std::str::from_utf8(&output.stdout).unwrap();
+        assert_eq!(output.lines().count(), 3);
+
+        Ok(())
+    }
 }

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -58,12 +58,15 @@ pub fn is_false_positive(input: &str) -> bool {
 /// Check if the host belongs to a known example domain as defined in
 /// [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606)
 pub fn is_example_domain(uri: &Uri) -> bool {
-    let res = match uri.domain() {
+    match uri.domain() {
         Some(domain) => {
-            // It is not enough to use `EXAMPLE_DOMAINS.contains(domain)` here
-            // as this would not include checks for subdomains, such as
-            // `foo.example.com`
-            EXAMPLE_DOMAINS.iter().any(|tld| domain.ends_with(tld))
+            // Check if the domain is exactly an example domain or a subdomain of it.
+            EXAMPLE_DOMAINS.iter().any(|&example| {
+                domain == example
+                    || domain
+                        .split_once('.')
+                        .map_or(false, |(_subdomain, tld_part)| tld_part == example)
+            })
         }
         None => {
             // Check if the URI is an email address.
@@ -75,8 +78,7 @@ pub fn is_example_domain(uri: &Uri) -> bool {
                 false
             }
         }
-    };
-    res
+    }
 }
 
 #[inline]


### PR DESCRIPTION
Websites like https://gobyexample.com were incorrectly classified as example domains as defined by IETF.

Related to #1312.