### PR TITLE
ci: fix missing permissions for uploading release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
 
   linux:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: prepare
     strategy:
@@ -87,6 +89,8 @@ jobs:
           asset_content_type: application/gzip
 
   macos:
+    permissions:
+      contents: write
     runs-on: macos-latest
     needs: prepare
     steps:
@@ -121,6 +125,8 @@ jobs:
           asset_content_type: application/octet-stream
 
   windows:
+    permissions:
+      contents: write
     runs-on: windows-latest
     needs: prepare
     env:

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -180,6 +180,7 @@ impl Input {
     /// Returns an error if the contents can not be retrieved
     /// because of an underlying I/O error (e.g. an error while making a
     /// network request or retrieving the contents from the file system)
+    #[allow(clippy::ignored_unit_patterns)]
     pub fn get_contents(self, skip_missing: bool) -> impl Stream<Item = Result<InputContent>> {
         try_stream! {
             match self.source {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -180,7 +180,6 @@ impl Input {
     /// Returns an error if the contents can not be retrieved
     /// because of an underlying I/O error (e.g. an error while making a
     /// network request or retrieving the contents from the file system)
-    #[allow(clippy::ignored_unit_patterns)]
     pub fn get_contents(self, skip_missing: bool) -> impl Stream<Item = Result<InputContent>> {
         try_stream! {
             match self.source {


### PR DESCRIPTION
Dear @mre ,
I've noticed the release workflow was not updated since long time and I think we are missing proper token permissions for uploading release assets. Please take a look and I hope you will like it.

Cheers,
Arek