### PR TITLE
Better TOML parsing error message

### DIFF
--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -408,8 +408,7 @@ impl Config {
     pub(crate) fn load_from_file(path: &Path) -> Result<Config> {
         // Read configuration file
         let contents = fs::read_to_string(path)?;
-        toml::from_str(&contents)
-            .map_err(|err| anyhow::anyhow!("Failed to parse configuration file: {}", err))
+        toml::from_str(&contents).with_context(|| "Failed to parse configuration file")
     }
 
     /// Merge the configuration from TOML into the CLI configuration

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -12,7 +12,10 @@ mod cli {
     use assert_json_diff::assert_json_include;
     use http::StatusCode;
     use lychee_lib::{InputSource, ResponseBody};
-    use predicates::str::{contains, is_empty};
+    use predicates::{
+        prelude::predicate,
+        str::{contains, is_empty},
+    };
     use pretty_assertions::assert_eq;
     use regex::Regex;
     use serde::Serialize;
@@ -602,7 +605,11 @@ mod cli {
             .arg("-")
             .env_clear()
             .assert()
-            .failure();
+            .failure()
+            .stderr(predicate::str::contains("Cannot load configuration file"))
+            .stderr(predicate::str::contains("Failed to parse"))
+            .stderr(predicate::str::contains("TOML parse error"))
+            .stderr(predicate::str::contains("expected newline"));
     }
 
     #[tokio::test]

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -203,7 +203,7 @@ impl Input {
                 InputSource::FsPath(ref path) => {
                     if path.is_dir() {
                         for entry in WalkDir::new(path).skip_hidden(true)
-                        .process_read_dir(move |_, _, _, children| {
+                        .process_read_dir(move |_, _, (), children| {
                             children.retain(|child| {
                                 let Ok(entry) = child.as_ref() else { return true };
 


### PR DESCRIPTION
The error handling for config loading was pretty poor.
That's because we didn't use the correct syntax to show the entire context with `anhow`.
See ["Display representations"](https://docs.rs/anyhow/latest/anyhow/struct.Error.html#display-representations).