### PR TITLE
chore: Move back to creates.io version of criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,14 +902,16 @@ dependencies = [
 [[package]]
 name = "criterion"
 version = "0.5.1"
-source = "git+https://github.com/bheisler/criterion.rs#b913e232edd98780961ecfbae836ec77ede49259"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools 0.12.0",
+ "is-terminal",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -926,10 +928,11 @@ dependencies = [
 [[package]]
 name = "criterion-plot"
 version = "0.5.0"
-source = "git+https://github.com/bheisler/criterion.rs#b913e232edd98780961ecfbae836ec77ede49259"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools 0.12.0",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -2186,18 +2189,18 @@ checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itertools"
-version = "0.12.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25db6b064527c5d482d0423354fcd07a89a2dfe07b67892e62411946db7f07b0"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -9,10 +9,7 @@ publish = false
 
 [dependencies]
 lychee-lib = { path = "../lychee-lib", default-features = false }
-# TODO: Move back to crates.io version once
-# https://github.com/bheisler/criterion.rs/pull/602
-# got released
-criterion = { git = "https://github.com/bheisler/criterion.rs"}
+criterion = "0.5.1"
 
 [features]
 email-check = ["lychee-lib/email-check"]


### PR DESCRIPTION
Follow up to this commit: https://github.com/lycheeverse/lychee/commit/91c8bc3ef5ed5b7650c73e9ca373d119f027f1ae

https://github.com/bheisler/criterion.rs/pull/602 has been merged and is included in 0.5.1 of criterion, so we can now start using the crates.io version again.