### PR TITLE
fix(tests): update the expected output in cli tests

### DIFF
--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -387,7 +387,7 @@ mod cli {
             .stdout(contains(
                 "✗ [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man | Failed: Network error: Not Found"
             ))
-            .stdout(contains(
+            .stderr(contains(
                 "There were issues with Github URLs. You could try setting a Github token and running lychee again.",
             ));
     }


### PR DESCRIPTION
I was getting the following error while running the tests for the Arch Linux package:

````
--- STDOUT:              lychee::cli cli::test_failure_github_404_no_token ---

running 1 test
test cli::test_failure_github_404_no_token ... FAILED

failures:

failures:
    cli::test_failure_github_404_no_token

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 68 filtered out; finished in 0.27s


--- STDERR:              lychee::cli cli::test_failure_github_404_no_token ---
thread 'cli::test_failure_github_404_no_token' panicked at /usr/src/debug/rust/rustc-1.75.0-src/library/core/src/ops/function.rs:250:5:
Unexpected stdout, failed var.contains(There were issues with Github URLs. You could try setting a Github token and running lychee again.)
├── var: Issues found in 1 input. Find details below.
│
│   [/build/lychee/src/lychee-0.14.2/fixtures/TEST_GITHUB_404.md]:
│   ✗ [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man | Failed: Network error: Not Found
│
│   🔍 1 Total (in 0s) ✅ 0 OK 🚫 1 Error
└── var as str: Issues found in 1 input. Find details below.

    [/build/lychee/src/lychee-0.14.2/fixtures/TEST_GITHUB_404.md]:
    ✗ [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man | Failed: Network error: Not Found

    🔍 1 Total (in 0s) ✅ 0 OK 🚫 1 Error

command=`env -i "/build/lychee/src/lychee-0.14.2/target/debug/lychee" "/build/lychee/src/lychee-0.14.2/fixtures/TEST_GITHUB_404.md" "--no-progress"`
code=2
stdout=
Issues found in 1 input. Find details below.

[/build/lychee/src/lychee-0.14.2/fixtures/TEST_GITHUB_404.md]:
✗ [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man | Failed: Network error: Not Found

🔍 1 Total (in 0s) ✅ 0 OK 🚫 1 Error


stderr=`
✗ [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man | Failed: Network error: Not Found
💡 There were issues with Github URLs. You could try setting a Github token and running lychee again.`

note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

Canceling due to test failure
PASS [ 0.425s] lychee::cli cli::test_formatted_file_output

---

     Summary [   9.386s] 29/289 tests run: 28 passed, 1 failed, 0 skipped
        FAIL [   0.275s] lychee::cli cli::test_failure_github_404_no_token

error: test run failed
==> ERROR: A failure occurred in check().

````

Then I figured it must be because the second message should be in `stderr` instead of `stdout`.

I [applied the patch](https://gitlab.archlinux.org/archlinux/packaging/packages/lychee/-/commit/4844e8d1483c9e3857408968f83a200bf97b759a) from this PR and now the tests pass! 🥳

P.S. I don't know why this is not caught by the CI :/
