### PR TITLE
status.rs: Make json output more verbose

### DIFF
--- a/fixtures/TEST_DETAILED_JSON_OUTPUT_ERROR.md
+++ b/fixtures/TEST_DETAILED_JSON_OUTPUT_ERROR.md
@@ -1,0 +1,8 @@
+# Test detailed JSON output error
+
+This file is used to test if the error details are parsed properly in the json
+format.
+
+[The website](https://expired.badssl.com/) produce SSL expired certificate
+error. Such network error has no status code but it can be identified by error
+status details.

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -68,6 +68,10 @@ impl Serialize for Status {
             s = serializer.serialize_struct("Status", 2)?;
             s.serialize_field("text", &self.to_string())?;
             s.serialize_field("code", &code.as_u16())?;
+        } else if let Some(details) = self.details() {
+            s = serializer.serialize_struct("Status", 2)?;
+            s.serialize_field("text", &self.to_string())?;
+            s.serialize_field("details", &details.to_string())?;
         } else {
             s = serializer.serialize_struct("Status", 1)?;
             s.serialize_field("text", &self.to_string())?;


### PR DESCRIPTION
Currently if the status response has no status code, json output contains only a text field which gives no real information about the cause of the problem. The patch adds field with more detailed information when the status response contains some details.