### PR TITLE
Set URI to HTTPS for ErrorKind::InsecureURL

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -531,7 +531,7 @@ impl Client {
                     .await
                     .is_success()
                 {
-                    Ok(Status::Error(ErrorKind::InsecureURL(uri.clone())))
+                    Ok(Status::Error(ErrorKind::InsecureURL(uri.to_https()?)))
                 } else {
                     // HTTPS is not available for this URI,
                     // so the original HTTP URL is fine.

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -107,7 +107,7 @@ pub enum ErrorKind {
     MissingGitHubToken,
 
     /// Used an insecure URI where a secure variant was reachable
-    #[error("This URI is available in HTTPS protocol, but HTTP is provided, use '{0}' instead")]
+    #[error("This URI is available in HTTPS protocol, but HTTP is provided. Use '{0}' instead")]
     InsecureURL(Uri),
 
     /// Error while sending/receiving messages from MPSC channel


### PR DESCRIPTION
Closes #1368. Note that this is only a way of solving the issue.

Environment:

OS: Windows x64
Shell: PowerShell 7.4.1

![image](https://github.com/lycheeverse/lychee/assets/11015675/3f997778-3624-4c3f-83f2-965f641709da)
