### PR TITLE
Fixed fragment generation for headings with inline code

### DIFF
--- a/fixtures/fragments/file1.md
+++ b/fixtures/fragments/file1.md
@@ -16,6 +16,9 @@ This is a test file for the fragment loader.
 
 [Link to missing fragment in file2](file2.md#missing-fragment)
 
+### `Code` ``Heading
+[Link to code heading](#code-heading)
+
 ## HTML Fragments
 
 Explicit fragment links are currently not supported.

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1537,6 +1537,7 @@ mod cli {
             .failure()
             .stderr(contains("fixtures/fragments/file1.md#fragment-1"))
             .stderr(contains("fixtures/fragments/file1.md#fragment-2"))
+            .stderr(contains("fixtures/fragments/file1.md#code-heading"))
             .stderr(contains("fixtures/fragments/file2.md#custom-id"))
             .stderr(contains("fixtures/fragments/file1.md#missing-fragment"))
             .stderr(contains("fixtures/fragments/file2.md#fragment-1"))
@@ -1552,8 +1553,8 @@ mod cli {
             .stderr(contains(
                 "fixtures/fragments/file1.md#kebab-case-fragment-1",
             ))
-            .stdout(contains("14 Total"))
-            .stdout(contains("11 OK"))
+            .stdout(contains("15 Total"))
+            .stdout(contains("12 OK"))
             // 3 failures because of missing fragments
             .stdout(contains("3 Errors"));
     }

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -112,7 +112,7 @@ pub(crate) fn extract_markdown_fragments(input: &str) -> HashSet<String> {
 
                 in_heading = false;
             }
-            Event::Text(text) => {
+            Event::Text(text) | Event::Code(text) => {
                 if in_heading {
                     heading.push_str(&text);
                 };
@@ -183,6 +183,8 @@ https://bar.com/123
 
 or inline like `https://bar.org` for instance.
 
+### Some `code` in a heading.
+
 [example](http://example.com)
 
 <span id="the-end">The End</span>
@@ -194,6 +196,7 @@ or inline like `https://bar.org` for instance.
             "a-test".to_string(),
             "a-test-1".to_string(),
             "well-still-the-same-test".to_string(),
+            "some-code-in-a-heading".to_string(),
             "the-end".to_string(),
         ]);
         let actual = extract_markdown_fragments(MD_INPUT);


### PR DESCRIPTION
Fixes issue https://github.com/lycheeverse/lychee/issues/1366, where headings with inline code did not have their fragments generated properly.