### PR TITLE
Bump to version; move to workspace versioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2346,7 +2346,7 @@ dependencies = [
 
 [[package]]
 name = "lychee"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2391,7 +2391,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "async-stream",
  "cached",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,9 @@
 [workspace]
-members = [
-    "lychee-bin",
-    "lychee-lib",
-    "examples/*",
-    "benches",
-]
+members = ["lychee-bin", "lychee-lib", "examples/*", "benches"]
 resolver = "2"
+
+[workspace.package]
+version = "0.14.3"
 
 [profile.release]
 debug = true

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Options:
   -u, --user-agent <USER_AGENT>
           User agent
           
-          [default: lychee/0.14.2]
+          [default: lychee/x.y.z]
 
   -i, --insecure
           Proceed for server connections considered insecure (invalid TLS)

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.14.2", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.14.3", default-features = false }
 
 anyhow = "1.0.78"
 assert-json-diff = "2.0.2"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -9,12 +9,12 @@ keywords = ["link", "checker", "cli", "link-checker", "validator"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/lycheeverse/lychee"
 readme = "../README.md"
-version.workspace = true
+version= "0.14.3"
 
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.14.2", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "^0.14.3", default-features = false }
 
 anyhow = "1.0.78"
 assert-json-diff = "2.0.2"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 keywords = ["link", "checker", "cli", "link-checker", "validator"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/lycheeverse/lychee"
-version = "0.14.2"
 readme = "../README.md"
+version.workspace = true
 
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -9,12 +9,12 @@ keywords = ["link", "checker", "cli", "link-checker", "validator"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/lycheeverse/lychee"
 readme = "../README.md"
-version= "0.14.3"
+version.workspace = true
 
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "^0.14.3", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.14.2", default-features = false }
 
 anyhow = "1.0.78"
 assert-json-diff = "2.0.2"

--- a/lychee-bin/tests/usage.rs
+++ b/lychee-bin/tests/usage.rs
@@ -31,14 +31,34 @@ mod readme {
         let mut cmd = main_command();
 
         let help_cmd = cmd.env_clear().arg("--help").assert().success();
-        let help_output = std::str::from_utf8(&help_cmd.get_output().stdout).unwrap();
-        let usage_in_help_start = help_output.find(USAGE_STRING).unwrap();
+        let help_output = std::str::from_utf8(&help_cmd.get_output().stdout)?;
+        let usage_in_help_start = help_output
+            .find(USAGE_STRING)
+            .ok_or("Usage not found in help")?;
         let usage_in_help = &help_output[usage_in_help_start..];
 
+        // Remove line `[default: lychee/0.1.0]` from the help output
+        let usage_in_help = usage_in_help
+            .lines()
+            .filter(|line| !line.contains("[default: lychee/"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
         let readme = load_readme_text();
-        let usage_start = readme.find(USAGE_STRING).unwrap();
-        let usage_end = readme[usage_start..].find("\n```").unwrap();
+        let usage_start = readme
+            .find(USAGE_STRING)
+            .ok_or("Usage not found in README")?;
+        let usage_end = readme[usage_start..]
+            .find("\n```")
+            .ok_or("End of usage not found in README")?;
         let usage_in_readme = &readme[usage_start..usage_start + usage_end];
+
+        // Remove line `[default: lychee/0.1.0]` from the README
+        let usage_in_readme = usage_in_readme
+            .lines()
+            .filter(|line| !line.contains("[default: lychee/"))
+            .collect::<Vec<_>>()
+            .join("\n");
 
         assert_eq!(usage_in_readme, usage_in_help);
         Ok(())

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -8,8 +8,8 @@ homepage = "https://github.com/lycheeverse/lychee"
 keywords = ["link", "checker", "cli", "link-checker", "validator"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/lycheeverse/lychee"
-version = "0.14.2"
 readme = "../README.md"
+version.workspace = true
 
 [dependencies]
 async-stream = "0.3.5"

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["link", "checker", "cli", "link-checker", "validator"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/lycheeverse/lychee"
 readme = "../README.md"
-version.workspace = true
+version= "0.14.3"
 
 [dependencies]
 async-stream = "0.3.5"

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["link", "checker", "cli", "link-checker", "validator"]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/lycheeverse/lychee"
 readme = "../README.md"
-version= "0.14.3"
+version.workspace = true
 
 [dependencies]
 async-stream = "0.3.5"


### PR DESCRIPTION
This way, we have the version number in fewer places. Makes missing version numbers less likely.