### PR TITLE
fix(tests): update the asserts in expired SSL certificate test

### DIFF
--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -153,13 +153,11 @@ mod cli {
         // Parse site error status from the fail_map
         let output_json = serde_json::from_slice::<Value>(&output.stdout).unwrap();
         let site_error_status = &output_json["fail_map"][&test_path.to_str().unwrap()][0]["status"];
+        let error_details = site_error_status["details"].to_string();
 
-        assert_eq!(
-            "error:0A000086:SSL routines:tls_post_process_server_certificate:\
-            certificate verify failed:../ssl/statem/statem_clnt.c:1883: \
-            (certificate has expired)",
-            site_error_status["details"]
-        );
+        assert!(error_details
+            .contains("error:0A000086:SSL routines:tls_post_process_server_certificate:"));
+        assert!(error_details.contains("(certificate has expired)"));
         Ok(())
     }
 


### PR DESCRIPTION
I'm getting the following test failure locally while build the latest version for Arch Linux:

```diff
-"error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:../ssl/statem/statem_clnt.c:1883: (certificate has expired)"
+String("error:0A000086:SSL routines:tls_post_process_server_certificate:certificate verify failed:ssl/statem/statem_clnt.c:2091: (certificate has expired)")
```

This PR fixes that via performing separate `assert` checks on the output (since the line number in `statem_clnt.c` depends on the platform)

I already built the Arch Linux package with this patch but I'm open to other suggestions. Just wanted to bring this up to your attention! :bear:
