### PR TITLE
fix: Treat sites with 403 status codes as broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ Options:
           separated list of accepted status codes. This example will accept 200, 201,
           202, 203, 204, 429, and 500 as valid status codes.
           
-          [default: 100..=103,200..=299,403..=403]
+          [default: 100..=103,200..=299]
 
       --include-fragments
           Enable the checking of fragments in links

--- a/lychee-lib/src/types/accept/selector.rs
+++ b/lychee-lib/src/types/accept/selector.rs
@@ -45,7 +45,6 @@ impl Default for AcceptSelector {
         Self::new_from(vec![
             AcceptRange::new(100, 103),
             AcceptRange::new(200, 299),
-            AcceptRange::new(403, 403),
         ])
     }
 }

--- a/lychee-lib/src/types/accept/selector.rs
+++ b/lychee-lib/src/types/accept/selector.rs
@@ -42,10 +42,7 @@ impl FromStr for AcceptSelector {
 
 impl Default for AcceptSelector {
     fn default() -> Self {
-        Self::new_from(vec![
-            AcceptRange::new(100, 103),
-            AcceptRange::new(200, 299),
-        ])
+        Self::new_from(vec![AcceptRange::new(100, 103), AcceptRange::new(200, 299)])
     }
 }
 


### PR DESCRIPTION
Treat sites with 403 status codes as broken links, reverting back default behavior implemented under #1157 (PR #1167). 