### PR TITLE
Simple plugin system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,9 +435,9 @@ checksum = "fbb36e985947064623dbd357f727af08ffd077f93d696782f3c56365fa2e2799"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2394,6 +2394,7 @@ name = "lychee-lib"
 version = "0.14.3"
 dependencies = [
  "async-stream",
+ "async-trait",
  "cached",
  "check-if-email-exists",
  "doc-comment",

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -13,6 +13,7 @@ version.workspace = true
 
 [dependencies]
 async-stream = "0.3.5"
+async-trait = "0.1.78"
 cached = "0.46.1"
 check-if-email-exists = { version = "0.9.1", optional = true }
 email_address = "0.2.4"

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -1,7 +1,5 @@
-use crate::{BasicAuthCredentials, Response};
+use crate::Response;
 use core::fmt::Debug;
-use headers::authorization::Credentials;
-use http::header::AUTHORIZATION;
 use reqwest::Request;
 
 #[derive(Debug, PartialEq)]
@@ -41,27 +39,6 @@ impl<T, R> Chain<T, R> {
 
 pub(crate) trait Chainable<T, R>: Debug {
     fn handle(&mut self, input: T) -> ChainResult<T, R>;
-}
-
-#[derive(Debug)]
-pub(crate) struct BasicAuth {
-    credentials: BasicAuthCredentials,
-}
-
-impl BasicAuth {
-    pub(crate) fn new(credentials: BasicAuthCredentials) -> Self {
-        Self { credentials }
-    }
-}
-
-impl Chainable<Request, Response> for BasicAuth {
-    fn handle(&mut self, mut request: Request) -> ChainResult<Request, Response> {
-        request.headers_mut().append(
-            AUTHORIZATION,
-            self.credentials.to_authorization().0.encode(),
-        );
-        ChainResult::Chained(request)
-    }
 }
 
 mod test {

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -37,3 +37,24 @@ impl Chainable<Request> for BasicAuth {
         request
     }
 }
+
+mod test {
+    use super::Chainable;
+
+    struct Add(i64);
+
+    struct Request(i64);
+
+    impl Chainable<Request> for Add {
+        fn handle(&mut self, req: Request) -> Request {
+            Request(req.0 + self.0)
+        }
+    }
+
+    #[test]
+    fn example_chain() {
+        let chain: crate::chain::Chain<Request> = vec![Box::new(Add(10)), Box::new(Add(-3))];
+        let result = crate::chain::traverse(chain, Request(0));
+        assert_eq!(result.0, 7);
+    }
+}

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -1,35 +1,46 @@
+use crate::{BasicAuthCredentials, Response};
 use core::fmt::Debug;
 use headers::authorization::Credentials;
 use http::header::AUTHORIZATION;
 use reqwest::Request;
 
-use crate::BasicAuthCredentials;
+#[derive(Debug, PartialEq)]
+pub(crate) enum ChainResult<T, R> {
+    Chained(T),
+    EarlyExit(R),
+}
 
-pub(crate) type RequestChain = Chain<reqwest::Request>;
+pub(crate) type RequestChain = Chain<Request, Response>;
 
 #[derive(Debug)]
-pub struct Chain<T>(Vec<Box<dyn Chainable<T> + Send>>);
+pub struct Chain<T, R>(Vec<Box<dyn Chainable<T, R> + Send>>);
 
-impl<T> Chain<T> {
-    pub(crate) fn new(values: Vec<Box<dyn Chainable<T> + Send>>) -> Self {
+impl<T, R> Chain<T, R> {
+    pub(crate) fn new(values: Vec<Box<dyn Chainable<T, R> + Send>>) -> Self {
         Self(values)
     }
 
-    pub(crate) fn traverse(&mut self, mut input: T) -> T {
+    pub(crate) fn traverse(&mut self, mut input: T) -> ChainResult<T, R> {
+        use ChainResult::*;
         for e in self.0.iter_mut() {
-            input = e.handle(input)
+            match e.handle(input) {
+                Chained(r) => input = r,
+                EarlyExit(r) => {
+                    return EarlyExit(r);
+                }
+            }
         }
 
-        input
+        Chained(input)
     }
 
-    pub(crate) fn push(&mut self, value: Box<dyn Chainable<T> + Send>) {
+    pub(crate) fn push(&mut self, value: Box<dyn Chainable<T, R> + Send>) {
         self.0.push(value);
     }
 }
 
-pub(crate) trait Chainable<T>: Debug {
-    fn handle(&mut self, input: T) -> T;
+pub(crate) trait Chainable<T, R>: Debug {
+    fn handle(&mut self, input: T) -> ChainResult<T, R>;
 }
 
 #[derive(Debug)]
@@ -43,36 +54,51 @@ impl BasicAuth {
     }
 }
 
-impl Chainable<Request> for BasicAuth {
-    fn handle(&mut self, mut request: Request) -> Request {
+impl Chainable<Request, Response> for BasicAuth {
+    fn handle(&mut self, mut request: Request) -> ChainResult<Request, Response> {
         request.headers_mut().append(
             AUTHORIZATION,
             self.credentials.to_authorization().0.encode(),
         );
-        request
+        ChainResult::Chained(request)
     }
 }
 
 mod test {
-    use super::Chainable;
+    use super::{ChainResult, ChainResult::*, Chainable};
 
     #[derive(Debug)]
     struct Add(i64);
 
-    #[derive(Debug)]
-    struct Request(i64);
+    #[derive(Debug, PartialEq, Eq)]
+    struct Result(i64);
 
-    impl Chainable<Request> for Add {
-        fn handle(&mut self, req: Request) -> Request {
-            Request(req.0 + self.0)
+    impl Chainable<Result, Result> for Add {
+        fn handle(&mut self, req: Result) -> ChainResult<Result, Result> {
+            let added = req.0 + self.0;
+            if added > 100 {
+                EarlyExit(Result(req.0))
+            } else {
+                Chained(Result(added))
+            }
         }
     }
 
     #[test]
-    fn example_chain() {
+    fn simple_chain() {
         use super::Chain;
-        let mut chain: Chain<Request> = Chain::new(vec![Box::new(Add(10)), Box::new(Add(-3))]);
-        let result = chain.traverse(Request(0));
-        assert_eq!(result.0, 7);
+        let mut chain: Chain<Result, Result> =
+            Chain::new(vec![Box::new(Add(10)), Box::new(Add(-3))]);
+        let result = chain.traverse(Result(0));
+        assert_eq!(result, Chained(Result(7)));
+    }
+
+    #[test]
+    fn early_exit_chain() {
+        use super::Chain;
+        let mut chain: Chain<Result, Result> =
+            Chain::new(vec![Box::new(Add(80)), Box::new(Add(30)), Box::new(Add(1))]);
+        let result = chain.traverse(Result(0));
+        assert_eq!(result, EarlyExit(Result(80)));
     }
 }

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -1,0 +1,39 @@
+use headers::authorization::Credentials;
+use http::header::AUTHORIZATION;
+use reqwest::Request;
+
+use crate::BasicAuthCredentials;
+
+pub(crate) type Chain<T> = Vec<Box<dyn Chainable<T> + Send>>;
+
+pub(crate) fn traverse<T>(chain: Chain<T>, mut input: T) -> T {
+    for mut e in chain {
+        input = e.handle(input)
+    }
+
+    input
+}
+
+pub(crate) trait Chainable<T> {
+    fn handle(&mut self, input: T) -> T;
+}
+
+pub(crate) struct BasicAuth {
+    credentials: BasicAuthCredentials,
+}
+
+impl BasicAuth {
+    pub(crate) fn new(credentials: BasicAuthCredentials) -> Self {
+        Self { credentials }
+    }
+}
+
+impl Chainable<Request> for BasicAuth {
+    fn handle(&mut self, mut request: Request) -> Request {
+        request.headers_mut().append(
+            AUTHORIZATION,
+            self.credentials.to_authorization().0.encode(),
+        );
+        request
+    }
+}

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -1,6 +1,4 @@
-use crate::Response;
 use core::fmt::Debug;
-use reqwest::Request;
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum ChainResult<T, R> {
@@ -8,7 +6,7 @@ pub(crate) enum ChainResult<T, R> {
     EarlyExit(R),
 }
 
-pub(crate) type RequestChain = Chain<Request, Response>;
+pub(crate) type RequestChain = Chain<reqwest::Request, crate::Response>;
 
 #[derive(Debug)]
 pub struct Chain<T, R>(Vec<Box<dyn Chainable<T, R> + Send>>);

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -25,7 +25,6 @@ impl<T, R> Clone for Chain<T, R> {
     }
 }
 
-
 impl<T, R> Chain<T, R> {
     pub(crate) fn new(values: Vec<Box<dyn Chainable<T, R> + Send>>) -> Self {
         Self(Arc::new(Mutex::new(values)))
@@ -55,7 +54,7 @@ impl<T, R> Chain<T, R> {
 }
 
 pub(crate) trait Chainable<T, R>: Debug {
-    fn chain(&mut self, input: T) -> ChainResult<T, R>;
+    async fn chain(&mut self, input: T) -> ChainResult<T, R>;
 }
 
 mod test {
@@ -72,7 +71,7 @@ mod test {
     struct Result(usize);
 
     impl Chainable<Result, Result> for Add {
-        fn chain(&mut self, req: Result) -> ChainResult<Result, Result> {
+        async fn chain(&mut self, req: Result) -> ChainResult<Result, Result> {
             let added = req.0 + self.0;
             if added > 100 {
                 Done(Result(req.0))

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -29,8 +29,8 @@ impl<T, R> Chain<T, R> {
     }
 
     pub(crate) fn traverse(&mut self, mut input: T) -> ChainResult<T, R> {
-        use ChainResult::*;
-        for e in self.0.iter_mut() {
+        use ChainResult::{Done, Next};
+        for e in &mut self.0 {
             match e.chain(input) {
                 Next(r) => input = r,
                 Done(r) => {
@@ -52,7 +52,7 @@ pub(crate) trait Chainable<T, R>: Debug {
 }
 
 mod test {
-    use super::{ChainResult, ChainResult::*, Chainable};
+    use super::{ChainResult, ChainResult::{Done, Next}, Chainable};
 
     #[derive(Debug)]
     struct Add(usize);

--- a/lychee-lib/src/checker.rs
+++ b/lychee-lib/src/checker.rs
@@ -1,5 +1,5 @@
 use crate::{
-    chain::{ChainResult, Chainable},
+    chain::{ChainResult, Handler},
     retry::RetryExt,
     Status,
 };
@@ -73,7 +73,7 @@ fn clone_unwrap(request: &Request) -> Request {
 }
 
 #[async_trait]
-impl Chainable<Request, Status> for Checker {
+impl Handler<Request, Status> for Checker {
     async fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
         ChainResult::Done(self.retry_request(input).await)
     }

--- a/lychee-lib/src/checker.rs
+++ b/lychee-lib/src/checker.rs
@@ -1,8 +1,9 @@
 use crate::{
-    chain::{Chain, ChainResult, Chainable},
+    chain::{ChainResult, Chainable},
     retry::RetryExt,
     Status,
 };
+use async_trait::async_trait;
 use http::StatusCode;
 use reqwest::Request;
 use std::{collections::HashSet, time::Duration};
@@ -58,6 +59,7 @@ impl Checker {
     }
 }
 
+#[async_trait]
 impl Chainable<Request, Status> for Checker {
     async fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
         ChainResult::Done(self.retry_request(input).await)

--- a/lychee-lib/src/checker.rs
+++ b/lychee-lib/src/checker.rs
@@ -8,7 +8,7 @@ use http::StatusCode;
 use reqwest::Request;
 use std::{collections::HashSet, time::Duration};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Checker {
     retry_wait_time: Duration,
     max_retries: u64,

--- a/lychee-lib/src/checker.rs
+++ b/lychee-lib/src/checker.rs
@@ -17,7 +17,7 @@ pub(crate) struct Checker {
 }
 
 impl Checker {
-    pub(crate) fn new(
+    pub(crate) const fn new(
         retry_wait_time: Duration,
         max_retries: u64,
         reqwest_client: reqwest::Client,
@@ -33,7 +33,7 @@ impl Checker {
 
     /// Retry requests up to `max_retries` times
     /// with an exponential backoff.
-    pub(crate) async fn retry_request(&self, request: reqwest::Request) -> Status {
+    pub(crate) async fn retry_request(&self, request: Request) -> Status {
         let mut retries: u64 = 0;
         let mut wait_time = self.retry_wait_time;
 
@@ -51,7 +51,7 @@ impl Checker {
     }
 
     /// Check a URI using [reqwest](https://github.com/seanmonstar/reqwest).
-    async fn check_default(&self, request: reqwest::Request) -> Status {
+    async fn check_default(&self, request: Request) -> Status {
         match self.reqwest_client.execute(request).await {
             Ok(ref response) => Status::new(response, self.accepted.clone()),
             Err(e) => e.into(),

--- a/lychee-lib/src/checker.rs
+++ b/lychee-lib/src/checker.rs
@@ -1,0 +1,65 @@
+use crate::{
+    chain::{Chain, ChainResult, Chainable},
+    retry::RetryExt,
+    Status,
+};
+use http::StatusCode;
+use reqwest::Request;
+use std::{collections::HashSet, time::Duration};
+
+#[derive(Debug)]
+pub(crate) struct Checker {
+    retry_wait_time: Duration,
+    max_retries: u64,
+    reqwest_client: reqwest::Client,
+    accepted: Option<HashSet<StatusCode>>,
+}
+
+impl Checker {
+    pub(crate) fn new(
+        retry_wait_time: Duration,
+        max_retries: u64,
+        reqwest_client: reqwest::Client,
+        accepted: Option<HashSet<StatusCode>>,
+    ) -> Self {
+        Self {
+            retry_wait_time,
+            max_retries,
+            reqwest_client,
+            accepted,
+        }
+    }
+
+    /// Retry requests up to `max_retries` times
+    /// with an exponential backoff.
+    pub(crate) async fn retry_request(&self, request: reqwest::Request) -> Status {
+        let mut retries: u64 = 0;
+        let mut wait_time = self.retry_wait_time;
+
+        let mut status = self.check_default(request.try_clone().unwrap()).await; // TODO: try_clone
+        while retries < self.max_retries {
+            if status.is_success() || !status.should_retry() {
+                return status;
+            }
+            retries += 1;
+            tokio::time::sleep(wait_time).await;
+            wait_time = wait_time.saturating_mul(2);
+            status = self.check_default(request.try_clone().unwrap()).await; // TODO: try_clone
+        }
+        status
+    }
+
+    /// Check a URI using [reqwest](https://github.com/seanmonstar/reqwest).
+    async fn check_default(&self, request: reqwest::Request) -> Status {
+        match self.reqwest_client.execute(request).await {
+            Ok(ref response) => Status::new(response, self.accepted.clone()),
+            Err(e) => e.into(),
+        }
+    }
+}
+
+impl Chainable<Request, Status> for Checker {
+    async fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
+        ChainResult::Done(self.retry_request(input).await)
+    }
+}

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -838,15 +838,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_auth() {
-        let mut r = Request::new(
-            "https://authenticationtest.com/HTTPAuth/"
-                .try_into()
-                .unwrap(),
-            crate::InputSource::Stdin,
-            None,
-            None,
-            None,
-        );
+        let mut r: Request = "https://authenticationtest.com/HTTPAuth/"
+            .try_into()
+            .unwrap();
 
         let res = get_mock_client_response(r.clone()).await;
         assert_eq!(res.status().code(), Some(401.try_into().unwrap()));
@@ -856,7 +850,7 @@ mod tests {
             password: "pass".into(),
         });
 
-        let res = get_mock_client_response(r.clone()).await;
+        let res = get_mock_client_response(r).await;
         assert!(res.status().is_success());
     }
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -36,7 +36,8 @@ use crate::{
     quirks::Quirks,
     remap::Remaps,
     types::uri::github::GithubUri,
-    utils::fragment_checker::FragmentChecker, ErrorKind, Request, Response, Result, Status, Uri,
+    utils::fragment_checker::FragmentChecker,
+    ErrorKind, Request, Response, Result, Status, Uri,
 };
 
 #[cfg(all(feature = "email-check", feature = "native-tls"))]
@@ -465,7 +466,7 @@ impl Client {
     {
         let Request {
             ref mut uri,
-            ref credentials,
+            credentials,
             source,
             ..
         } = request.try_into()?;
@@ -486,7 +487,9 @@ impl Client {
         }
 
         let request_chain: RequestChain = Chain::new(vec![
+            // TODO: insert self.request_chain
             Box::<Quirks>::default(),
+            Box::new(credentials),
             Box::new(Checker::new(
                 self.retry_wait_time,
                 self.max_retries,

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -16,7 +16,7 @@
 use std::{
     collections::HashSet,
     path::Path,
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::Duration,
 };
 
@@ -288,7 +288,7 @@ pub struct ClientBuilder {
     /// can modify the request. A chained item can also decide to exit
     /// early and return a status, so that subsequent chain items are
     /// skipped and no HTTP request is ever made.
-    request_chain: Arc<Mutex<RequestChain>>,
+    request_chain: RequestChain,
 }
 
 impl Default for ClientBuilder {
@@ -452,7 +452,7 @@ pub struct Client {
     /// Caches Fragments
     fragment_checker: FragmentChecker,
 
-    request_chain: Arc<Mutex<RequestChain>>,
+    request_chain: RequestChain,
 }
 
 impl Client {
@@ -538,7 +538,7 @@ impl Client {
     ) -> Result<Status> {
         let quirks = Quirks::default();
         let mut request_chain: RequestChain = Chain::new(vec![Box::new(quirks)]);
-        request_chain.append(&mut self.request_chain.lock().unwrap());
+        request_chain.append(&self.request_chain);
 
         if let Some(c) = credentials {
             request_chain.push(Box::new(c.clone()));
@@ -774,7 +774,6 @@ where
 mod tests {
     use std::{
         fs::File,
-        sync::{Arc, Mutex},
         time::{Duration, Instant},
     };
 
@@ -1126,9 +1125,9 @@ mod tests {
             }
         }
 
-        let chain = Arc::new(Mutex::new(RequestChain::new(vec![Box::new(
+        let chain = RequestChain::new(vec![Box::new(
             ExampleHandler {},
-        )])));
+        )]);
 
         let client = ClientBuilder::builder()
             .request_chain(chain)

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -750,7 +750,7 @@ mod tests {
 
     use super::ClientBuilder;
     use crate::{
-        chain::{ChainResult, Chainable, RequestChain},
+        chain::{ChainResult, Handler, RequestChain},
         mock_server,
         test_utils::get_mock_client_response,
         Request, Status, Uri,
@@ -1086,7 +1086,7 @@ mod tests {
         struct ExampleHandler();
 
         #[async_trait]
-        impl Chainable<Request, Status> for ExampleHandler {
+        impl Handler<Request, Status> for ExampleHandler {
             async fn chain(&mut self, _: Request) -> ChainResult<Request, Status> {
                 ChainResult::Done(Status::Excluded)
             }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -660,16 +660,13 @@ impl Client {
             Err(e) => return e.into(),
         };
 
-        let mut chain: Chain<reqwest::Request> = vec![];
+        let mut chain: Chain<reqwest::Request> = vec![Box::new(self.quirks.clone())];
 
         if let Some(c) = credentials {
             chain.push(Box::new(BasicAuth::new(c.clone())));
         }
 
         let request = traverse(chain, request);
-
-        // todo: quirks middleware
-        let request = self.quirks.apply(request);
 
         match self.reqwest_client.execute(request).await {
             Ok(ref response) => Status::new(response, self.accepted.clone()),

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -35,7 +35,6 @@ use crate::{
     filter::{Excludes, Filter, Includes},
     quirks::Quirks,
     remap::Remaps,
-    retry::RetryExt,
     types::uri::github::GithubUri,
     utils::fragment_checker::FragmentChecker,
     BasicAuthCredentials, ErrorKind, Request, Response, Result, Status, Uri,
@@ -743,6 +742,7 @@ mod tests {
         time::{Duration, Instant},
     };
 
+    use async_trait::async_trait;
     use http::{header::HeaderMap, StatusCode};
     use reqwest::header;
     use tempfile::tempdir;
@@ -1085,6 +1085,7 @@ mod tests {
         #[derive(Debug)]
         struct ExampleHandler();
 
+        #[async_trait]
         impl Chainable<Request, Status> for ExampleHandler {
             async fn chain(&mut self, _: Request) -> ChainResult<Request, Status> {
                 ChainResult::Done(Status::Excluded)

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -31,7 +31,7 @@ use typed_builder::TypedBuilder;
 
 use crate::{
     chain::ChainResult::*,
-    chain::{BasicAuth, Chain, RequestChain},
+    chain::{Chain, RequestChain},
     filter::{Excludes, Filter, Includes},
     quirks::Quirks,
     remap::Remaps,
@@ -482,7 +482,7 @@ impl Client {
         let mut request_chain: RequestChain = Chain::new(vec![Box::new(quirks)]);
 
         if let Some(c) = credentials {
-            request_chain.push(Box::new(BasicAuth::new(c.clone())));
+            request_chain.push(Box::new(c.clone()));
         }
 
         let status = match uri.scheme() {

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -37,7 +37,7 @@ use typed_builder::TypedBuilder;
 use crate::{
     chain::{
         Chain,
-        ChainResult::{Chained, EarlyExit},
+        ChainResult::{Next, Done},
         RequestChain,
     },
     filter::{Excludes, Filter, Includes},
@@ -676,8 +676,8 @@ impl Client {
         let result = request_chain.traverse(request);
 
         match result {
-            EarlyExit(status) => status,
-            Chained(r) => match self.reqwest_client.execute(r).await {
+            Done(status) => status,
+            Next(r) => match self.reqwest_client.execute(r).await {
                 Ok(ref response) => Status::new(response, self.accepted.clone()),
                 Err(e) => e.into(),
             },
@@ -1121,8 +1121,8 @@ mod tests {
         struct ExampleHandler();
 
         impl Chainable<Request, Status> for ExampleHandler {
-            fn handle(&mut self, _: Request) -> ChainResult<Request, Status> {
-                ChainResult::EarlyExit(Status::Excluded)
+            fn chain(&mut self, _: Request) -> ChainResult<Request, Status> {
+                ChainResult::Done(Status::Excluded)
             }
         }
 

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -51,10 +51,11 @@
 doc_comment::doctest!("../../README.md");
 
 mod basic_auth;
+mod chain;
+mod checker;
 mod client;
 /// A pool of clients, to handle concurrent checks
 pub mod collector;
-mod chain;
 mod quirks;
 mod retry;
 mod types;

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -54,6 +54,7 @@ mod basic_auth;
 mod client;
 /// A pool of clients, to handle concurrent checks
 pub mod collector;
+mod chain;
 mod quirks;
 mod retry;
 mod types;

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -85,8 +85,8 @@ use openssl_sys as _; // required for vendored-openssl feature
 #[doc(inline)]
 pub use crate::{
     basic_auth::BasicAuthExtractor,
-    // Expose the `Chainable` trait to allow defining external handlers (plugins)
-    chain::{ChainResult, Chainable},
+    // Expose the `Handler` trait to allow defining external handlers (plugins)
+    chain::{ChainResult, Handler},
     // Constants get exposed so that the CLI can use the same defaults as the library
     client::{
         check, Client, ClientBuilder, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES,

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    chain::{ChainResult, Chainable},
+    chain::{ChainResult, Handler},
     Status,
 };
 use async_trait::async_trait;
@@ -92,7 +92,7 @@ impl Quirks {
 }
 
 #[async_trait]
-impl Chainable<Request, Status> for Quirks {
+impl Handler<Request, Status> for Quirks {
     async fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
         ChainResult::Next(self.apply(input))
     }

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     chain::{ChainResult, Chainable},
-    Response,
+    Status,
 };
 use header::HeaderValue;
 use http::header;
@@ -90,8 +90,8 @@ impl Quirks {
     }
 }
 
-impl Chainable<Request, Response> for Quirks {
-    fn handle(&mut self, input: Request) -> ChainResult<Request, Response> {
+impl Chainable<Request, Status> for Quirks {
+    fn handle(&mut self, input: Request) -> ChainResult<Request, Status> {
         ChainResult::Chained(self.apply(input))
     }
 }

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -2,6 +2,7 @@ use crate::{
     chain::{ChainResult, Chainable},
     Status,
 };
+use async_trait::async_trait;
 use header::HeaderValue;
 use http::header;
 use once_cell::sync::Lazy;
@@ -90,6 +91,7 @@ impl Quirks {
     }
 }
 
+#[async_trait]
 impl Chainable<Request, Status> for Quirks {
     async fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
         ChainResult::Next(self.apply(input))

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -91,8 +91,8 @@ impl Quirks {
 }
 
 impl Chainable<Request, Status> for Quirks {
-    fn handle(&mut self, input: Request) -> ChainResult<Request, Status> {
-        ChainResult::Chained(self.apply(input))
+    fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
+        ChainResult::Next(self.apply(input))
     }
 }
 

--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -91,7 +91,7 @@ impl Quirks {
 }
 
 impl Chainable<Request, Status> for Quirks {
-    fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
+    async fn chain(&mut self, input: Request) -> ChainResult<Request, Status> {
         ChainResult::Next(self.apply(input))
     }
 }

--- a/lychee-lib/src/types/basic_auth/credentials.rs
+++ b/lychee-lib/src/types/basic_auth/credentials.rs
@@ -1,3 +1,4 @@
+use async_trait::async_trait;
 use std::str::FromStr;
 
 use headers::authorization::Credentials;
@@ -73,6 +74,7 @@ impl BasicAuthCredentials {
     }
 }
 
+#[async_trait]
 impl Chainable<Request, Status> for BasicAuthCredentials {
     async fn chain(&mut self, mut request: Request) -> ChainResult<Request, Status> {
         request

--- a/lychee-lib/src/types/basic_auth/credentials.rs
+++ b/lychee-lib/src/types/basic_auth/credentials.rs
@@ -75,11 +75,14 @@ impl BasicAuthCredentials {
 }
 
 #[async_trait]
-impl Chainable<Request, Status> for BasicAuthCredentials {
+impl Chainable<Request, Status> for Option<BasicAuthCredentials> {
     async fn chain(&mut self, mut request: Request) -> ChainResult<Request, Status> {
-        request
-            .headers_mut()
-            .append(AUTHORIZATION, self.to_authorization().0.encode());
+        if let Some(credentials) = self {
+            request
+                .headers_mut()
+                .append(AUTHORIZATION, credentials.to_authorization().0.encode());
+        }
+
         ChainResult::Next(request)
     }
 }

--- a/lychee-lib/src/types/basic_auth/credentials.rs
+++ b/lychee-lib/src/types/basic_auth/credentials.rs
@@ -7,10 +7,8 @@ use reqwest::Request;
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::{
-    chain::{ChainResult, Chainable},
-    Response,
-};
+use crate::chain::{ChainResult, Chainable};
+use crate::Status;
 
 #[derive(Copy, Clone, Debug, Error, PartialEq)]
 pub enum BasicAuthCredentialsParseError {
@@ -75,8 +73,8 @@ impl BasicAuthCredentials {
     }
 }
 
-impl Chainable<Request, Response> for BasicAuthCredentials {
-    fn handle(&mut self, mut request: Request) -> ChainResult<Request, Response> {
+impl Chainable<Request, Status> for BasicAuthCredentials {
+    fn handle(&mut self, mut request: Request) -> ChainResult<Request, Status> {
         request
             .headers_mut()
             .append(AUTHORIZATION, self.to_authorization().0.encode());

--- a/lychee-lib/src/types/basic_auth/credentials.rs
+++ b/lychee-lib/src/types/basic_auth/credentials.rs
@@ -74,7 +74,7 @@ impl BasicAuthCredentials {
 }
 
 impl Chainable<Request, Status> for BasicAuthCredentials {
-    fn chain(&mut self, mut request: Request) -> ChainResult<Request, Status> {
+    async fn chain(&mut self, mut request: Request) -> ChainResult<Request, Status> {
         request
             .headers_mut()
             .append(AUTHORIZATION, self.to_authorization().0.encode());

--- a/lychee-lib/src/types/basic_auth/credentials.rs
+++ b/lychee-lib/src/types/basic_auth/credentials.rs
@@ -74,10 +74,10 @@ impl BasicAuthCredentials {
 }
 
 impl Chainable<Request, Status> for BasicAuthCredentials {
-    fn handle(&mut self, mut request: Request) -> ChainResult<Request, Status> {
+    fn chain(&mut self, mut request: Request) -> ChainResult<Request, Status> {
         request
             .headers_mut()
             .append(AUTHORIZATION, self.to_authorization().0.encode());
-        ChainResult::Chained(request)
+        ChainResult::Next(request)
     }
 }

--- a/lychee-lib/src/types/basic_auth/credentials.rs
+++ b/lychee-lib/src/types/basic_auth/credentials.rs
@@ -8,7 +8,7 @@ use reqwest::Request;
 use serde::Deserialize;
 use thiserror::Error;
 
-use crate::chain::{ChainResult, Chainable};
+use crate::chain::{ChainResult, Handler};
 use crate::Status;
 
 #[derive(Copy, Clone, Debug, Error, PartialEq)]
@@ -75,7 +75,7 @@ impl BasicAuthCredentials {
 }
 
 #[async_trait]
-impl Chainable<Request, Status> for Option<BasicAuthCredentials> {
+impl Handler<Request, Status> for Option<BasicAuthCredentials> {
     async fn chain(&mut self, mut request: Request) -> ChainResult<Request, Status> {
         if let Some(credentials) = self {
             request


### PR DESCRIPTION
## Intro

As discussed with you @mre this is a first fully functional version of a simple plugin system in lychee. The first approach of using a middleware system turned out to be more complex than necessary and it would not be possible to use Extism in that case, because there would be no way to pass a `next` function to Extism. Instead I came up with `Chain` and `Chainable`. Conceptually having a request chain and a response chain would be very similar to the middleware approach. Instead of a `next` function an element in a chain returns a `ChainResult` which can prematurely return a result in the chain.

The field `request_chain` is added to `ClientBuilder` and `Client`. This chain is `traverse`d before making a request in `check_website`. `check_file` and `check_mail` are not affected. Remapping, exclusions and caching is not handled by the chain, because "they have no request".

## Questions and concerns

### Field in `Client` and `ClientBuilder`

Currently I have made `request_chain` of type `Arc<Mutex<RequestChain>>`. This is because `reqwest::Request` is not `Clone` but `Client` and `ClientBuilder` are `Clone`. Do you think it should be done this way? The alternative would probably be to update `RequestChain` to be `Chain<OurOwnRequestType, Status>`. When `OurOwnRequestType` implements `Copy` we probably would also facilitate the Extism plugins since copying data from/to the plugins is necessary.

### Response chain

There is no response chain yet. Should I try to implement one in this PR?

### Extism

This PR contains nothing related to Extism yet. I think it would be awesome if  WASM plugins could be provided on the command line. So this would probably be lychee-bin loading the plugins and passing it to lychee-lib. Should I try add this in this PR?