### PR TITLE
fix(docker): match Debian version in base images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,8 +4,6 @@ assets
 fixtures
 .github
 .vscode
-examples
-benches
 docs
 .editorconfig
 lychee.example.toml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest as builder
+FROM rust:bookworm as builder
 
 RUN USER=root cargo new --bin lychee
 WORKDIR /lychee
@@ -18,11 +18,12 @@ RUN cargo build --release \
 # dependencies were already built above.
 COPY . ./
 RUN rm ./target/release/deps/lychee* \
-    && cargo build --release
+    && cargo build --release \
+    && strip target/release/lychee
 
 # Our production image starts here, which uses
 # the files from the builder image above.
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Closes #1393 & #1394 

* fixed libssl version conflict by matching Debain versions of `Dockerfile`'s base images
* fixed cargo complaints in docker when examples/ bench/ are missing by including them

Final docker image is 103MB; note that, this image is not what is published to docker.io, see discussion [here](https://github.com/lycheeverse/lychee/issues/1393#issuecomment-2024176406).