### PR TITLE
feat: added support for pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,16 @@
 - id: lychee
   name: lychee
   description: "Run 'lychee' for fast, async, stream-based link checking"
-  entry: lycheeverse/lychee:0.14
-  language: docker_image
-  args: []
+  entry: lychee
+  language: system
   types: [text]
   pass_filenames: true
   require_serial: true
-  additional_dependencies: []
+- id: lychee-docker
+  name: lychee
+  description: "Run 'lychee' docker image for fast, async, stream-based link checking"
+  entry: lycheeverse/lychee:0.14
+  language: docker_image
+  types: [text]
+  pass_filenames: true
+  require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,6 +3,7 @@
   description: "Run 'lychee' for fast, async, stream-based link checking"
   entry: lychee
   language: system
+  args: ["--no-progress"]
   types: [text]
   pass_filenames: true
   require_serial: true
@@ -11,6 +12,7 @@
   description: "Run 'lychee' docker image for fast, async, stream-based link checking"
   entry: lycheeverse/lychee:0.14
   language: docker_image
+  args: ["--no-progress"]
   types: [text]
   pass_filenames: true
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,10 @@
+- id: lychee
+  name: lychee
+  description: "Run 'lychee' for fast, async, stream-based link checking"
+  entry: lycheeverse/lychee:0.14
+  language: docker_image
+  args: []
+  types: [text]
+  pass_filenames: true
+  require_serial: true
+  additional_dependencies: []

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Available as a command-line utility, a library and a [GitHub Action](https://git
 - [Commandline usage](#commandline-usage)
 - [Library usage](#library-usage)
 - [GitHub Action Usage](#github-action-usage)
+- [Pre-commit Usage](#pre-commit-usage)
 - [Contributing to lychee](#contributing-to-lychee)
 - [Debugging and improving async code](#debugging-and-improving-async-code)
 - [Troubleshooting and Workarounds](#troubleshooting-and-workarounds)
@@ -550,6 +551,27 @@ folder.
 
 A GitHub Action that uses lychee is available as a separate repository: [lycheeverse/lychee-action](https://github.com/lycheeverse/lychee-action)
 which includes usage instructions.
+
+## Pre-commit Usage
+
+Lychee can also be used as a [pre-commit](https://pre-commit.com/) hook.
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/lycheeverse/lychee.git
+    rev: 0.14.3
+    hooks:
+      - id: lychee
+      # Optionally include additional CLI arguments
+      args: ["--exclude", "file://"]
+```
+
+Rather than running on staged-files only, Lychee can be run against an entire repository.
+```yaml
+- id: lychee
+  args: ["."]
+  pass_filenames: false
+```
 
 ## Contributing to lychee
 

--- a/README.md
+++ b/README.md
@@ -562,14 +562,14 @@ repos:
     rev: 0.14.3
     hooks:
       - id: lychee
-      # Optionally include additional CLI arguments
-      args: ["--exclude", "file://"]
+        # Optionally include additional CLI arguments
+        args: ["--no-progress", "--exclude", "file://"]
 ```
 
 Rather than running on staged-files only, Lychee can be run against an entire repository.
 ```yaml
 - id: lychee
-  args: ["."]
+  args: ["--no-progress", "."]
   pass_filenames: false
 ```
 


### PR DESCRIPTION
Adds support for pre-commit as per discussion #1360   

Relies on the docker image releases, & this referenced image tag shouble be incremented with each package release; i.e. updating the `entry` field in `.pre-commit-hooks.yaml`.

An example `.pre-commit-config.yaml` is provided in the changes to the `README`.