### PR TITLE
Allow excluding cache based on status code

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,22 @@ Options:
 
           [default: 1d]
 
+      --cache-exclude-status <CACHE_EXCLUDE_STATUS>
+          A List status codes that will be ignored from the cache
+          
+          The following accept range syntax is supported: [start]..[=]end|code. Some valid
+          examples are:
+          
+          - 429
+          - 500..=599
+          - 500..
+          
+          Use "lychee --cache-exclude-status '429, 500..502' <inputs>..." to provide a comma- separated
+          list of excluded status codes. This example will not cache results with a status code of 429, 500,
+          501 and 502.
+          
+          [default: 100..=103,200..=299]
+
       --dump
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked
 

--- a/README.md
+++ b/README.md
@@ -337,19 +337,19 @@ Options:
 
       --cache-exclude-status <CACHE_EXCLUDE_STATUS>
           A List status codes that will be ignored from the cache
-          
+
           The following accept range syntax is supported: [start]..[=]end|code. Some valid
           examples are:
-          
+
           - 429
           - 500..=599
           - 500..
-          
+
           Use "lychee --cache-exclude-status '429, 500..502' <inputs>..." to provide a comma- separated
           list of excluded status codes. This example will not cache results with a status code of 429, 500,
           501 and 502.
-          
-          [default: 100..=103,200..=299]
+
+          [default: ]
 
       --dump
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked

--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ Options:
           [default: 1d]
 
       --cache-exclude-status <CACHE_EXCLUDE_STATUS>
-          A List status codes that will be ignored from the cache
+          A list of status codes that will be ignored from the cache
 
           The following accept range syntax is supported: [start]..[=]end|code. Some valid
           examples are:

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -368,9 +368,9 @@ fn get_failed_urls(stats: &mut ResponseStats) -> Vec<(InputSource, Url)> {
 #[cfg(test)]
 mod tests {
     use crate::{formatters::get_response_formatter, options};
-    use log::info;
-    use lychee_lib::{CacheStatus, ErrorKind, ClientBuilder, InputSource, Uri};
     use http::StatusCode;
+    use log::info;
+    use lychee_lib::{CacheStatus, ClientBuilder, ErrorKind, InputSource, Uri};
 
     use super::*;
 

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -310,16 +310,15 @@ async fn handle(
 }
 
 fn ignore_cache(uri: &Uri, status: &Status, cache_exclude_status: &HashSet<u16>) -> bool {
-    let status_code = match status.code() {
-        None => 0,
-        Some(code) => code.as_u16(),
-    };
+    let status_code_excluded = status
+        .code()
+        .map_or(false, |code| cache_exclude_status.contains(&code.as_u16()));
 
     uri.is_file()
         || status.is_excluded()
         || status.is_unsupported()
         || status.is_unknown()
-        || cache_exclude_status.contains(&status_code)
+        || status_code_excluded
 }
 
 fn show_progress(

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -145,6 +145,7 @@ default_function! {
     retry_wait_time: usize = DEFAULT_RETRY_WAIT_TIME_SECS;
     method: String = DEFAULT_METHOD.to_string();
     verbosity: Verbosity = Verbosity::default();
+    cache_exclude_selector: StatusCodeSelector = StatusCodeSelector::new();
     accept_selector: StatusCodeSelector = StatusCodeSelector::default();
 }
 
@@ -248,7 +249,7 @@ Use \"lychee --cache-exclude-status '429, 500..502' <inputs>...\" to provide a c
 list of excluded status codes. This example will not cache results with a status code of 429, 500,
 501 and 502."
     )]
-    #[serde(default)]
+    #[serde(default = "cache_exclude_selector")]
     pub(crate) cache_exclude_status: StatusCodeSelector,
 
     /// Don't perform any link checking.

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -6,8 +6,8 @@ use clap::builder::PossibleValuesParser;
 use clap::{arg, builder::TypedValueParser, Parser};
 use const_format::{concatcp, formatcp};
 use lychee_lib::{
-    Base, BasicAuthSelector, Input, StatusCodeSelector, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES,
-    DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS, DEFAULT_USER_AGENT,
+    Base, BasicAuthSelector, Input, StatusCodeExcluder, StatusCodeSelector, DEFAULT_MAX_REDIRECTS,
+    DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS, DEFAULT_USER_AGENT,
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
@@ -145,7 +145,7 @@ default_function! {
     retry_wait_time: usize = DEFAULT_RETRY_WAIT_TIME_SECS;
     method: String = DEFAULT_METHOD.to_string();
     verbosity: Verbosity = Verbosity::default();
-    cache_exclude_selector: StatusCodeSelector = StatusCodeSelector::new();
+    cache_exclude_selector: StatusCodeExcluder = StatusCodeExcluder::new();
     accept_selector: StatusCodeSelector = StatusCodeSelector::default();
 }
 
@@ -250,7 +250,7 @@ list of excluded status codes. This example will not cache results with a status
 501 and 502."
     )]
     #[serde(default = "cache_exclude_selector")]
-    pub(crate) cache_exclude_status: StatusCodeSelector,
+    pub(crate) cache_exclude_status: StatusCodeExcluder,
 
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
@@ -530,7 +530,7 @@ impl Config {
             max_retries: DEFAULT_MAX_RETRIES;
             max_concurrency: DEFAULT_MAX_CONCURRENCY;
             max_cache_age: humantime::parse_duration(DEFAULT_MAX_CACHE_AGE).unwrap();
-            cache_exclude_status: StatusCodeSelector::new();
+            cache_exclude_status: StatusCodeExcluder::default();
             threads: None;
             user_agent: DEFAULT_USER_AGENT;
             insecure: false;
@@ -608,6 +608,6 @@ mod tests {
             cli.accept,
             StatusCodeSelector::from_str("100..=103,200..=299").expect("no error")
         );
-        assert_eq!(cli.cache_exclude_status, StatusCodeSelector::new());
+        assert_eq!(cli.cache_exclude_status, StatusCodeExcluder::new());
     }
 }

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -231,6 +231,26 @@ pub(crate) struct Config {
     #[serde(with = "humantime_serde")]
     pub(crate) max_cache_age: Duration,
 
+    /// A list of status codes that will be excluded from the cache
+    #[arg(
+        long,
+        default_value_t,
+        long_help = "A List status codes that will be ignored from the cache
+
+The following accept range syntax is supported: [start]..[=]end|code. Some valid
+examples are:
+
+- 429
+- 500..=599
+- 500..
+
+Use \"lychee --cache-exclude-status '429, 500..502' <inputs>...\" to provide a comma- separated
+list of excluded status codes. This example will not cache results with a status code of 429, 500,
+501 and 502."
+    )]
+    #[serde(default)]
+    pub(crate) cache_exclude_status: AcceptSelector,
+
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
     #[arg(long)]
@@ -509,6 +529,7 @@ impl Config {
             max_retries: DEFAULT_MAX_RETRIES;
             max_concurrency: DEFAULT_MAX_CONCURRENCY;
             max_cache_age: humantime::parse_duration(DEFAULT_MAX_CACHE_AGE).unwrap();
+            cache_exclude_status: AcceptSelector::new();
             threads: None;
             user_agent: DEFAULT_USER_AGENT;
             insecure: false;

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -236,7 +236,7 @@ pub(crate) struct Config {
     #[arg(
         long,
         default_value_t,
-        long_help = "A List status codes that will be ignored from the cache
+        long_help = "A list of status codes that will be ignored from the cache
 
 The following accept range syntax is supported: [start]..[=]end|code. Some valid
 examples are:

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -599,4 +599,15 @@ mod tests {
         assert!(cli.accept.contains(204));
         assert!(!cli.accept.contains(205));
     }
+
+    #[test]
+    fn test_default() {
+        let cli = Config::default();
+
+        assert_eq!(
+            cli.accept,
+            StatusCodeSelector::from_str("100..=103,200..=299").expect("no error")
+        );
+        assert_eq!(cli.cache_exclude_status, StatusCodeSelector::new());
+    }
 }

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -6,7 +6,7 @@ use clap::builder::PossibleValuesParser;
 use clap::{arg, builder::TypedValueParser, Parser};
 use const_format::{concatcp, formatcp};
 use lychee_lib::{
-    AcceptSelector, Base, BasicAuthSelector, Input, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES,
+    Base, BasicAuthSelector, Input, StatusCodeSelector, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES,
     DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS, DEFAULT_USER_AGENT,
 };
 use secrecy::{ExposeSecret, SecretString};
@@ -145,7 +145,7 @@ default_function! {
     retry_wait_time: usize = DEFAULT_RETRY_WAIT_TIME_SECS;
     method: String = DEFAULT_METHOD.to_string();
     verbosity: Verbosity = Verbosity::default();
-    accept_selector: AcceptSelector = AcceptSelector::default();
+    accept_selector: StatusCodeSelector = StatusCodeSelector::default();
 }
 
 // Macro for merging configuration values
@@ -249,7 +249,7 @@ list of excluded status codes. This example will not cache results with a status
 501 and 502."
     )]
     #[serde(default)]
-    pub(crate) cache_exclude_status: AcceptSelector,
+    pub(crate) cache_exclude_status: StatusCodeSelector,
 
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
@@ -414,7 +414,7 @@ separated list of accepted status codes. This example will accept 200, 201,
 202, 203, 204, 429, and 500 as valid status codes."
     )]
     #[serde(default = "accept_selector")]
-    pub(crate) accept: AcceptSelector,
+    pub(crate) accept: StatusCodeSelector,
 
     /// Enable the checking of fragments in links.
     #[arg(long)]
@@ -529,7 +529,7 @@ impl Config {
             max_retries: DEFAULT_MAX_RETRIES;
             max_concurrency: DEFAULT_MAX_CONCURRENCY;
             max_cache_age: humantime::parse_duration(DEFAULT_MAX_CACHE_AGE).unwrap();
-            cache_exclude_status: AcceptSelector::new();
+            cache_exclude_status: StatusCodeSelector::new();
             threads: None;
             user_agent: DEFAULT_USER_AGENT;
             insecure: false;
@@ -559,7 +559,7 @@ impl Config {
             require_https: false;
             cookie_jar: None;
             include_fragments: false;
-            accept: AcceptSelector::default();
+            accept: StatusCodeSelector::default();
         }
 
         if self
@@ -585,7 +585,7 @@ mod tests {
     #[test]
     fn test_accept_status_codes() {
         let toml = Config {
-            accept: AcceptSelector::from_str("200..=204, 429, 500").unwrap(),
+            accept: StatusCodeSelector::from_str("200..=204, 429, 500").unwrap(),
             ..Default::default()
         };
 

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -95,8 +95,8 @@ pub use crate::{
     collector::Collector,
     filter::{Excludes, Filter, Includes},
     types::{
-        uri::valid::Uri, AcceptRange, AcceptRangeError, AcceptSelector, Base, BasicAuthCredentials,
+        uri::valid::Uri, AcceptRange, AcceptRangeError, Base, BasicAuthCredentials,
         BasicAuthSelector, CacheStatus, CookieJar, ErrorKind, FileType, Input, InputContent,
-        InputSource, Request, Response, ResponseBody, Result, Status,
+        InputSource, Request, Response, ResponseBody, Result, Status, StatusCodeSelector,
     },
 };

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::{
     types::{
         uri::valid::Uri, AcceptRange, AcceptRangeError, Base, BasicAuthCredentials,
         BasicAuthSelector, CacheStatus, CookieJar, ErrorKind, FileType, Input, InputContent,
-        InputSource, Request, Response, ResponseBody, Result, Status, StatusCodeSelector,
+        InputSource, Request, Response, ResponseBody, Result, Status, StatusCodeExcluder,
+        StatusCodeSelector,
     },
 };

--- a/lychee-lib/src/types/accept/mod.rs
+++ b/lychee-lib/src/types/accept/mod.rs
@@ -1,5 +1,3 @@
 mod range;
-mod selector;
 
 pub use range::*;
-pub use selector::*;

--- a/lychee-lib/src/types/accept/range.rs
+++ b/lychee-lib/src/types/accept/range.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 static RANGE_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^([0-9]{3})?\.\.(=?)([0-9]{3})+$|^([0-9]{3})$").unwrap());
 
-/// The [`AcceptRangeParseError`] indicates that the parsing process of an
-/// [`AcceptRange`]  from a string failed due to various underlying reasons.
+/// Indicates that the parsing process of an [`AcceptRange`]  from a string
+/// failed due to various underlying reasons.
 #[derive(Debug, Error, PartialEq)]
 pub enum AcceptRangeError {
     /// The string input didn't contain any range pattern.

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use tokio::task::JoinError;
 
 use super::InputContent;
-use crate::types::AcceptSelectorError;
+use crate::types::StatusCodeSelectorError;
 use crate::{basic_auth::BasicAuthExtractorError, utils, Uri};
 
 /// Kinds of status errors
@@ -142,9 +142,9 @@ pub enum ErrorKind {
     #[error("Cannot load cookies")]
     Cookies(String),
 
-    /// Accept selector parse error
-    #[error("Accept range error")]
-    AcceptSelectorError(#[from] AcceptSelectorError),
+    /// Status code selector parse error
+    #[error("Status code range error")]
+    StatusCodeSelectorError(#[from] StatusCodeSelectorError),
 }
 
 impl ErrorKind {
@@ -290,7 +290,7 @@ impl Hash for ErrorKind {
             Self::TooManyRedirects(e) => e.to_string().hash(state),
             Self::BasicAuthExtractorError(e) => e.to_string().hash(state),
             Self::Cookies(e) => e.to_string().hash(state),
-            Self::AcceptSelectorError(e) => e.to_string().hash(state),
+            Self::StatusCodeSelectorError(e) => e.to_string().hash(state),
         }
     }
 }

--- a/lychee-lib/src/types/mod.rs
+++ b/lychee-lib/src/types/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod mail;
 mod request;
 mod response;
 mod status;
+mod status_code;
 pub(crate) mod uri;
 
 pub use accept::*;
@@ -25,6 +26,7 @@ pub use input::{Input, InputContent, InputSource};
 pub use request::Request;
 pub use response::{Response, ResponseBody};
 pub use status::Status;
+pub use status_code::*;
 
 /// The lychee `Result` type
 pub type Result<T> = std::result::Result<T, crate::ErrorKind>;

--- a/lychee-lib/src/types/status_code/excluder.rs
+++ b/lychee-lib/src/types/status_code/excluder.rs
@@ -6,10 +6,12 @@ use crate::{
     types::accept::AcceptRange, types::status_code::StatusCodeSelectorError, AcceptRangeError,
 };
 
-/// An [`StatusCodeExcluder`] holds ranges of HTTP status codes, and determines whether a specific
-/// code is matched, so the link can be counted as valid (not broken) or excluded.
-/// `StatusCodeExcluder` differs from `StatusCodeSelector` in the defaults it provides. As this is
-/// meant to exclude status codes, the default is to keep everything.
+/// A [`StatusCodeExcluder`] holds ranges of HTTP status codes, and determines
+/// whether a specific code is matched, so the link can be counted as valid (not
+/// broken) or excluded. `StatusCodeExcluder` differs from
+/// [`StatusCodeSelector`](super::selector::StatusCodeSelector) in the defaults
+/// it provides. As this is meant to exclude status codes, the default is to
+/// keep everything.
 #[derive(Clone, Debug, PartialEq)]
 pub struct StatusCodeExcluder {
     ranges: Vec<AcceptRange>,

--- a/lychee-lib/src/types/status_code/excluder.rs
+++ b/lychee-lib/src/types/status_code/excluder.rs
@@ -22,7 +22,7 @@ impl FromStr for StatusCodeExcluder {
         let input = input.trim();
 
         if input.is_empty() {
-            return Err(StatusCodeSelectorError::InvalidInput);
+            return Ok(Self::new());
         }
 
         let ranges = input
@@ -176,6 +176,7 @@ mod test {
     use rstest::rstest;
 
     #[rstest]
+    #[case("", vec![], vec![100, 110, 150, 200, 300, 175, 350], 0)]
     #[case("100..=150,200..=300", vec![100, 110, 150, 200, 300], vec![175, 350], 2)]
     #[case("200..=300,100..=250", vec![100, 150, 200, 250, 300], vec![350], 1)]
     #[case("100..=200,150..=200", vec![100, 150, 200], vec![250, 300], 1)]

--- a/lychee-lib/src/types/status_code/mod.rs
+++ b/lychee-lib/src/types/status_code/mod.rs
@@ -1,0 +1,3 @@
+mod selector;
+
+pub use selector::*;

--- a/lychee-lib/src/types/status_code/mod.rs
+++ b/lychee-lib/src/types/status_code/mod.rs
@@ -1,3 +1,5 @@
+mod excluder;
 mod selector;
 
+pub use excluder::*;
 pub use selector::*;

--- a/lychee-lib/src/types/status_code/selector.rs
+++ b/lychee-lib/src/types/status_code/selector.rs
@@ -14,10 +14,12 @@ pub enum StatusCodeSelectorError {
     AcceptRangeError(#[from] AcceptRangeError),
 }
 
-/// An [`StatusCodeSelector`] holds ranges of HTTP status codes, and determines whether a specific
-/// code is matched, so the link can be counted as valid (not broken) or excluded.
-/// `StatusCodeSelector` differs from `StatusCodeExcluder` in the defaults it provides. As this is
-/// meant to select valid status codes, the default includes every successful status.
+/// A [`StatusCodeSelector`] holds ranges of HTTP status codes, and determines
+/// whether a specific code is matched, so the link can be counted as valid (not
+/// broken) or excluded. `StatusCodeSelector` differs from
+/// [`StatusCodeExcluder`](super::excluder::StatusCodeExcluder)
+///  in the defaults it provides. As this is meant to
+/// select valid status codes, the default includes every successful status.
 #[derive(Clone, Debug, PartialEq)]
 pub struct StatusCodeSelector {
     ranges: Vec<AcceptRange>,


### PR DESCRIPTION
Closes #1400

This introduces an option `--cache-exclude-status`, which allows specifying a range of HTTP status codes which will be ignored from the cache.