### PR TITLE
Fix typo in pre-commit config in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -566,7 +566,7 @@ Lychee can also be used as a [pre-commit](https://pre-commit.com/) hook.
 # .pre-commit-config.yaml
 repos:
   - repo: https://github.com/lycheeverse/lychee.git
-    rev: 0.15.1
+    rev: v0.15.1
     hooks:
       - id: lychee
         # Optionally include additional CLI arguments


### PR DESCRIPTION
First of all, thank you for this very useful tool!

I ran into an issue while trying to add lychee to the pre-commit hook. Here is the account of the steps that I took.

1. I copied the following pre-commit config code from the [README](https://github.com/lycheeverse/lychee?tab=readme-ov-file#pre-commit-usage) into my project's `.pre-commit-config.yaml`:
    ```sh
    # .pre-commit-config.yaml
    repos:
      - repo: https://github.com/lycheeverse/lychee.git
        rev: 0.15.1
        hooks:
          - id: lychee
            # Optionally include additional CLI arguments
            args: ["--no-progress", "--exclude", "file://"]
    ```
2. While committing files, pre-commit returned this:
    ```console
    An unexpected error has occurred: CalledProcessError: command: ('/usr/lib/git-core/git', 'checkout', '0.15.1')
    return code: 1
    stdout: (none)
    stderr:
        error: pathspec '0.15.1' did not match any file(s) known to git
    Check the log at ...
    ```
3. Updating the line `rev: 0.15.1` to `rev: v0.15.1` fixed the issue.

Hence, this PR is offered to fix the typo in the provided pre-commit config.