### PR TITLE
add tel

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -707,6 +707,7 @@ impl Client {
     /// Check a tel
     ///
     /// This implementation simply excludes all tel.
+    #[allow(clippy::unused_async)]
     pub async fn check_tel(&self, _uri: &Uri) -> Status {
         Status::Excluded
     }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -378,7 +378,6 @@ impl ClientBuilder {
             exclude_link_local_ips: self.exclude_all_private || self.exclude_link_local_ips,
             exclude_loopback_ips: self.exclude_all_private || self.exclude_loopback_ips,
             include_mail: self.include_mail,
-            include_tel: false,
         };
 
         Ok(Client {

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -500,6 +500,7 @@ impl Client {
         let status = match uri.scheme() {
             _ if uri.is_file() => self.check_file(uri).await,
             _ if uri.is_mail() => self.check_mail(uri).await,
+            _ if uri.is_tel() => Status::Excluded,
             _ => self.check_website(uri, default_chain).await?,
         };
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -500,7 +500,7 @@ impl Client {
         let status = match uri.scheme() {
             _ if uri.is_file() => self.check_file(uri).await,
             _ if uri.is_mail() => self.check_mail(uri).await,
-            _ if uri.is_tel() => Status::Excluded,
+            _ if uri.is_tel() => self.check_tel(uri).await,
             _ => self.check_website(uri, default_chain).await?,
         };
 
@@ -701,6 +701,13 @@ impl Client {
     #[cfg(not(all(feature = "email-check", feature = "native-tls")))]
     #[allow(clippy::unused_async)]
     pub async fn check_mail(&self, _uri: &Uri) -> Status {
+        Status::Excluded
+    }
+
+    /// Check a tel
+    ///
+    /// This implementation simply excludes all tel.
+    pub async fn check_tel(&self, _uri: &Uri) -> Status {
         Status::Excluded
     }
 }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -378,6 +378,7 @@ impl ClientBuilder {
             exclude_link_local_ips: self.exclude_all_private || self.exclude_link_local_ips,
             exclude_loopback_ips: self.exclude_all_private || self.exclude_loopback_ips,
             include_mail: self.include_mail,
+            include_tel: false,
         };
 
         Ok(Client {
@@ -913,6 +914,14 @@ mod tests {
             .unwrap();
         assert!(!client.is_excluded(&Uri {
             url: "mailto://mail@example.com".try_into().unwrap()
+        }));
+    }
+
+    #[tokio::test]
+    async fn test_include_tel() {
+        let client = ClientBuilder::builder().build().client().unwrap();
+        assert!(client.is_excluded(&Uri {
+            url: "tel:1234567890".try_into().unwrap()
         }));
     }
 

--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -89,9 +89,10 @@ impl TokenSink for LinkExtractor {
                                 // This ignores links like `<img srcset="v2@1.5x.png">`
                                 let is_email = is_email_link(url);
                                 let is_mailto = url.starts_with("mailto:");
+                                let is_phone = url.starts_with("tel:");
                                 let is_href = attr.name.local.as_ref() == "href";
 
-                                !is_email || (is_mailto && is_href)
+                                !is_email || (is_mailto && is_href) || (is_phone && is_href)
                             })
                             .map(|url| RawUri {
                                 text: url.to_string(),

--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -319,6 +319,29 @@ mod tests {
         let uris = extract_html(input, false);
         assert_eq!(uris, expected);
     }
+
+    #[test]
+    fn test_valid_tel() {
+        let input = r#"<!DOCTYPE html>
+        <html lang="en-US">
+          <head>
+            <meta charset="utf-8">
+            <title>Test</title>
+          </head>
+          <body>
+            <a href="tel:1234567890">
+          </body>
+        </html>"#;
+
+        let expected = vec![RawUri {
+            text: "tel:1234567890".to_string(),
+            element: Some("a".to_string()),
+            attribute: Some("href".to_string()),
+        }];
+        let uris = extract_html(input, false);
+        assert_eq!(uris, expected);
+    }
+
     #[test]
     fn test_exclude_email_without_mailto() {
         let input = r#"<!DOCTYPE html>

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -172,9 +172,10 @@ impl LinkExtractor {
                         // This ignores links like `<img srcset="v2@1.5x.png">`
                         let is_email = is_email_link(url);
                         let is_mailto = url.starts_with("mailto:");
+                        let is_phone = url.starts_with("tel:");
                         let is_href = attr == "href";
 
-                        !is_email || (is_mailto && is_href)
+                        !is_email || (is_mailto && is_href) || (is_phone && is_href)
                     })
                     .map(|url| RawUri {
                         text: url.to_string(),

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -455,6 +455,28 @@ mod tests {
     }
 
     #[test]
+    fn test_valid_tel() {
+        let input = r#"<!DOCTYPE html>
+        <html lang="en-US">
+          <head>
+            <meta charset="utf-8">
+            <title>Test</title>
+          </head>
+          <body>
+            <a href="tel:1234567890">
+          </body>
+        </html>"#;
+
+        let expected = vec![RawUri {
+            text: "tel:1234567890".to_string(),
+            element: Some("a".to_string()),
+            attribute: Some("href".to_string()),
+        }];
+        let uris = extract_html(input, false);
+        assert_eq!(uris, expected);
+    }
+
+    #[test]
     fn test_valid_email() {
         let input = r#"<!DOCTYPE html>
         <html lang="en-US">

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -128,6 +128,8 @@ pub struct Filter {
     pub exclude_loopback_ips: bool,
     /// Example: octocat@github.com
     pub include_mail: bool,
+    /// Example: 1234567890
+    pub include_tel: bool,
 }
 
 impl Filter {
@@ -136,6 +138,13 @@ impl Filter {
     /// Whether e-mails aren't checked (which is the default)
     pub fn is_mail_excluded(&self, uri: &Uri) -> bool {
         uri.is_mail() && !self.include_mail
+    }
+
+    #[inline]
+    #[must_use]
+    /// Whether tel aren't checked (which is the default)
+    pub fn is_tel_excluded(&self, uri: &Uri) -> bool {
+        uri.is_tel() && !self.include_tel
     }
 
     #[must_use]
@@ -214,6 +223,7 @@ impl Filter {
             || self.is_host_excluded(uri)
             || self.is_ip_excluded(uri)
             || self.is_mail_excluded(uri)
+            || self.is_tel_excluded(uri)
             || is_example_domain(uri)
             || is_unsupported_domain(uri)
         {

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -128,8 +128,6 @@ pub struct Filter {
     pub exclude_loopback_ips: bool,
     /// Example: octocat@github.com
     pub include_mail: bool,
-    /// Example: 1234567890
-    pub include_tel: bool,
 }
 
 impl Filter {

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -140,13 +140,6 @@ impl Filter {
         uri.is_mail() && !self.include_mail
     }
 
-    #[inline]
-    #[must_use]
-    /// Whether tel aren't checked (which is the default)
-    pub fn is_tel_excluded(&self, uri: &Uri) -> bool {
-        uri.is_tel() && !self.include_tel
-    }
-
     #[must_use]
     /// Whether the IP address is excluded from checking
     pub fn is_ip_excluded(&self, uri: &Uri) -> bool {

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -216,7 +216,7 @@ impl Filter {
             || self.is_host_excluded(uri)
             || self.is_ip_excluded(uri)
             || self.is_mail_excluded(uri)
-            || self.is_tel_excluded(uri)
+            || uri.is_tel()
             || is_example_domain(uri)
             || is_unsupported_domain(uri)
         {

--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -333,6 +333,14 @@ mod tests {
     }
 
     #[test]
+    fn test_uri_tel() {
+        assert_eq!(
+            Uri::try_from("tel:1234567890"),
+            Ok(Uri::try_from("tel:1234567890").unwrap())
+        );
+    }
+
+    #[test]
     fn test_uri_host_ip_v4() {
         assert_eq!(
             website("http://127.0.0.1").host_ip(),

--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -98,6 +98,13 @@ impl Uri {
 
     #[inline]
     #[must_use]
+    /// Check if the URI is a tel
+    pub fn is_tel(&self) -> bool {
+        self.scheme() == "tel"
+    }
+
+    #[inline]
+    #[must_use]
     /// Check if the URI is a file
     pub fn is_file(&self) -> bool {
         self.scheme() == "file"


### PR DESCRIPTION
add tel detection in href ?

Currently it's 

```
 [IGNORED] tel:xxxx | Unsupported: Error creating request client: builder error for url (tel:xxxx): URL scheme is not allowed
```