### PR TITLE
Don't trim mailto: prefix when converting a Uri into a string

### DIFF
--- a/lychee-lib/src/types/uri/valid.rs
+++ b/lychee-lib/src/types/uri/valid.rs
@@ -22,13 +22,10 @@ pub struct Uri {
 
 impl Uri {
     /// Returns the string representation of the `Uri`.
-    ///
-    /// If it's an email address, returns the string with scheme stripped.
-    /// Otherwise returns the string as-is.
     #[inline]
     #[must_use]
     pub fn as_str(&self) -> &str {
-        self.url.as_ref().trim_start_matches("mailto:")
+        self.url.as_ref()
     }
 
     #[inline]


### PR DESCRIPTION
Fixes #1436

So actually I think it's never necessary to remove the `mailto:` prefix. @mre tell me if you disagree. I assume that this was done for cosmetic purposes in the CLI output. But I even prefer to keep the scheme in the CLI output since it feels more correct and terminal emulators then detect the address as correct URL so that you can click on it to send a mail to that address using your email application. (noticed in Alacritty)