### PR TITLE
README: Add Nixpkgs to Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ nix-env -iA nixos.lychee
 
 - [`lychee` package](https://search.nixos.org/packages?show=lychee&query=lychee) for configurations, Nix shells, etc.
 
-- Test a packaged site with [`testers.lycheeLinkCheck`](https://nixos.org/manual/nixpkgs/stable/#tester-lycheeLinkCheck) `{ site = …; }`
+- Let Nix check a packaged site with \
+  [`testers.lycheeLinkCheck`](https://nixos.org/manual/nixpkgs/stable/#tester-lycheeLinkCheck) `{ site = …; }`
 
 ### FreeBSD
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ docker pull lycheeverse/lychee
 nix-env -iA nixos.lychee
 ```
 
+### Nixpkgs
+
+- [`lychee` package](https://search.nixos.org/packages?show=lychee&query=lychee) for configurations, Nix shells, etc.
+
+- Test a packaged site with [`testers.lycheeLinkCheck`](https://nixos.org/manual/nixpkgs/stable/#tester-lycheeLinkCheck) `{ site = …; }`
+
 ### FreeBSD
 
 ```sh


### PR DESCRIPTION
Hi again :wave:

This adds the new `testers.lycheeLinkCheck` to the Installation section, as a follow-up to the conversation with @mre starting at https://github.com/lycheeverse/lychee/issues/1303#issuecomment-2016857155.

I think it's brief enough to fit the Installation section, and with infrastructure as code, putting something in file is the act of installing something, so I think it makes sense to put it here despite not being a shell command.

The text itself is sufficient to get users familiar with Nix started, and the links provide more details.

I can change it up if we need to, but here's the ~first~ second version, [rendered](https://github.com/roberth/lychee/blob/e25ef83/README.md#nixos).