### PR TITLE
feat(clap): show help menu on no args as well

### DIFF
--- a/lychee-bin/src/verbosity.rs
+++ b/lychee-bin/src/verbosity.rs
@@ -13,6 +13,7 @@ use serde::Deserialize;
 /// - `-vv` show debug
 /// - `-vvv` show trace
 #[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq)]
+#[command(arg_required_else_help = true)]
 pub(crate) struct Verbosity {
     /// Pass many times for more log output
     ///


### PR DESCRIPTION
__This pr adds support for help menu when the end user doesn't provide any argument__ 

POC:

before: 

![old](https://github.com/lycheeverse/lychee/assets/90331517/5b6f41f7-4577-477c-84af-0cccda37918a)

now:

![new](https://github.com/lycheeverse/lychee/assets/90331517/85515add-a4b5-4379-a7a9-e3a607f8e228)

