### PR TITLE
Run cargo nextest in CI and enable all tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - uses: Swatinem/rust-cache@v2
       - name: Compile
-        run: cargo test --no-run --locked
+        run: cargo check --locked
       - name: Test
-        run: cargo test -- --nocapture --quiet
+        run: make test
 
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I don't know why this was previously enabled.
Perhaps an oversight or it was done on purpose.
At least the remaining tests in `cli` didn't run, apparently.