### PR TITLE
ci: fix wrong cpu-arch tag on macos release assets

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -90,7 +90,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: lychee-${{ github.sha }}-x86_64-macos.dmg
+          name: lychee-${{ github.sha }}-arm64-macos.dmg
           path: target/release/lychee.dmg
 
   windows:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          asset_name: lychee-x86_64-macos.dmg
+          asset_name: lychee-arm64-macos.dmg
           asset_path: target/release/lychee.dmg
           upload_url: ${{needs.prepare.outputs.upload_url}}
           asset_content_type: application/octet-stream


### PR DESCRIPTION
closes #1475 