### PR TITLE
chore(docs): mention MacPorts install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,16 @@ zypper in lychee
 
 ### macOS
 
+Via [Homebrew](https://brew.sh):
+
 ```sh
 brew install lychee
+```
+
+Via [MacPorts](https://www.macports.org):
+
+```sh
+sudo port install lychee
 ```
 
 ### Docker


### PR DESCRIPTION
_It works on my machine!_ ©

```
❯ sudo port install lychee
--->  Computing dependencies for lychee
--->  Fetching archive for lychee
--->  Attempting to fetch lychee-0.14.3_0.darwin_20.x86_64.tbz2 from https://packages.macports.org/lychee
--->  Attempting to fetch lychee-0.14.3_0.darwin_20.x86_64.tbz2.rmd160 from https://packages.macports.org/lychee
--->  Installing lychee @0.14.3_0
--->  Activating lychee @0.14.3_0
--->  Cleaning lychee
--->  Scanning binaries for linking errors
--->  No broken files found.
--->  No broken ports found.

❯ lychee --help
A fast, async link checker

Finds broken URLs and mail addresses inside Markdown, HTML, `reStructuredText`, websites and more!
```