### PR TITLE
markdown.rs: make first line a top-level heading

### DIFF
--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -96,7 +96,7 @@ impl Display for MarkdownResponseStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let stats = &self.0;
 
-        writeln!(f, "## Summary")?;
+        writeln!(f, "# Summary")?;
         writeln!(f)?;
         writeln!(f, "{}", stats_table(&self.0))?;
 
@@ -237,7 +237,7 @@ mod tests {
                 original: Url::parse("https://example.com/original").unwrap(),
             });
         let summary = MarkdownResponseStats(stats);
-        let expected = "## Summary
+        let expected = "# Summary
 
 | Status        | Count |
 |---------------|-------|


### PR DESCRIPTION
Fixes [`MD041` - First line in a file should be a top-level heading](https://github.com/DavidAnson/markdownlint/blob/v0.35.0/doc/md041.md)