### PR TITLE
README: The Git home page and Git Credential Manager use lychee

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,6 +685,8 @@ We collect a list of common workarounds for various websites in our [troubleshoo
 - https://github.com/bencherdev/bencher
 - https://github.com/sindresorhus/execa
 - https://github.com/tldr-pages/tldr-maintenance
+- https://github.com/git-ecosystem/git-credential-manager
+- https://git-scm.com/
 - https://github.com/lycheeverse/lychee (yes, the lychee docs are checked with lychee 🤯)
 
 If you are using lychee for your project, **please add it here**.


### PR DESCRIPTION
As of almost two weeks ago, Git's home page at https://git-scm.com/ was switched to a static website that uses lychee to verify links (already catching a broken one: https://github.com/gitgitgadget/git/pull/1812).

For substantially longer, the Git Credential Manager uses lychee to validate the links in its documentation.