### PR TITLE
Update `pkg-url` for cargo binstall

### DIFF
--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -97,6 +97,6 @@ required-features = ["check_example_domains"]
 
 # Metadata for cargo-binstall to get the right artifacts
 [package.metadata.binstall]
-pkg-url = "{ repo }/releases/download/v{ version }/{ name }-v{ version }-{ target }{ archive-suffix }"
+pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }"
 bin-dir = "{ bin }{ binary-ext }"
 pkg-fmt = "tgz"


### PR DESCRIPTION
- Since release-plz has been added (#1510), now releases have tags like `{{ package }}-v{{ version }}` ([see `git_tag_name`](https://release-plz.ieni.dev/docs/config#the-git_tag_name-field)).
- The change in #1464 removed the usage of versions (really tag name) in the archive name.

Previous to this patch, `cargo binstall` is using third-party source QuickInstall to install binaries.

```
$ cargo binstall lychee --manifest-path lychee-bin/Cargo.toml --dry-run
 INFO resolve: Resolving package: 'lychee'
 INFO resolve: Verified signature for package 'lychee-0.16.1-x86_64-unknown-linux-gnu': timestamp:1728250139	file:lychee-0.16.1-x86_64-unknown-linux-gnu.tar.gz	hashed
 WARN The package lychee v0.16.1 (x86_64-unknown-linux-gnu) has been downloaded from third-party source QuickInstall
```

After this, is using github.com releases:

```
$ cargo binstall lychee --manifest-path lychee-bin/Cargo.toml --dry-run
 INFO resolve: Resolving package: 'lychee'
 WARN The package lychee v0.16.1 (x86_64-unknown-linux-gnu) has been downloaded from github.com
```

I would like to add a regression test for this, but not sure where to put it. Are you testing package managers releases?