### PR TITLE
Box Octocrab error as it is too large

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -364,9 +364,9 @@ impl ClientBuilder {
                 Octocrab::builder()
                     .personal_token(token.to_string())
                     .build()
-                    // this is essentially the same reqwest::ClientBuilder::build error
+                    // this is essentially the same `reqwest::ClientBuilder::build` error
                     // see https://docs.rs/octocrab/0.18.1/src/octocrab/lib.rs.html#360-364
-                    .map_err(ErrorKind::BuildGithubClient)?,
+                    .map_err(|e: octocrab::Error| ErrorKind::BuildGithubClient(Box::new(e)))?,
             ),
             _ => None,
         };
@@ -638,7 +638,7 @@ impl Client {
         };
         let repo = match client.repos(&uri.owner, &uri.repo).get().await {
             Ok(repo) => repo,
-            Err(e) => return ErrorKind::GithubRequest(e).into(),
+            Err(e) => return ErrorKind::GithubRequest(Box::new(e)).into(),
         };
         if let Some(true) = repo.private {
             // The private repo exists. Assume a given endpoint exists as well

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -26,7 +26,7 @@ pub enum ErrorKind {
 
     /// Network error while using GitHub API
     #[error("Network error (GitHub client)")]
-    GithubRequest(#[from] octocrab::Error),
+    GithubRequest(#[from] Box<octocrab::Error>),
 
     /// Error while executing a future on the Tokio runtime
     #[error("Task failed to execute to completion")]
@@ -46,7 +46,7 @@ pub enum ErrorKind {
 
     /// The GitHub client required for making requests cannot be created
     #[error("Error creating GitHub client")]
-    BuildGithubClient(#[source] octocrab::Error),
+    BuildGithubClient(#[source] Box<octocrab::Error>),
 
     /// Invalid GitHub URL
     #[error("GitHub URL is invalid: {0}")]
@@ -168,10 +168,13 @@ impl ErrorKind {
                     Some(utils::reqwest::trim_error_output(e))
                 }
             }
-            ErrorKind::GithubRequest(e) => match e {
-                octocrab::Error::GitHub { source, .. } => Some(source.message.to_string()),
-                _ => None,
-            },
+            ErrorKind::GithubRequest(e) => {
+                if let octocrab::Error::GitHub { source, .. } = &**e {
+                    Some(source.message.clone())
+                } else {
+                    None
+                }
+            }
             _ => self.source().map(ToString::to_string),
         }
     }


### PR DESCRIPTION
This pull request fixes an issue where our error type was too large. The `octocrab` error variant is now boxed using `Box<octocrab::Error>`. This should fix the current clippy issues.