### PR TITLE
Fix skipping of email addresses in stylesheets

### DIFF
--- a/fixtures/TEST_STYLESHEET_LINK.md
+++ b/fixtures/TEST_STYLESHEET_LINK.md
@@ -1,0 +1,1 @@
+<link href="/@global/global.css" rel="stylesheet">

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -231,6 +231,17 @@ mod cli {
         Ok(())
     }
 
+    #[test]
+    fn test_stylesheet_misinterpreted_as_email() -> Result<()> {
+        test_json_output!(
+            "TEST_STYLESHEET_LINK.md",
+            MockResponseStats {
+                total: 0,
+                ..MockResponseStats::default()
+            }
+        )
+    }
+
     /// Test that a GitHub link can be checked without specifying the token.
     #[test]
     fn test_check_github_no_token() -> Result<()> {


### PR DESCRIPTION
This pull request fixes an issue where email addresses were being detected as links in elements with `ref="stylesheet"`.

The issue occurred when virtual/framework-specific stylesheet paths that start with "/@" or "@" were encountered. These paths are typically resolved by dev servers or build tools and are not real URLs. The fix ensures that these paths are skipped.

Fixes #1538.