### PR TITLE
chore: release v0.18.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,7 +2454,7 @@ dependencies = [
 
 [[package]]
 name = "lychee"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.17.0...lychee-v0.18.0) - 2024-12-18
+
+### Other
+
+- Bump the dependencies group across 1 directory with 11 updates ([#1589](https://github.com/lycheeverse/lychee/pull/1589))
+- Introduce --root-dir ([#1576](https://github.com/lycheeverse/lychee/pull/1576))
+- Fix retries ([#1573](https://github.com/lycheeverse/lychee/pull/1573))
+- Pass along --max-retries config option ([#1572](https://github.com/lycheeverse/lychee/pull/1572))
+- Bump the dependencies group with 4 updates ([#1571](https://github.com/lycheeverse/lychee/pull/1571))
+- Bump the dependencies group with 4 updates ([#1570](https://github.com/lycheeverse/lychee/pull/1570))
+- Bump the dependencies group with 4 updates ([#1566](https://github.com/lycheeverse/lychee/pull/1566))
+- Rename `fail_map` to `error_map` for improved clarity in response statistics ([#1560](https://github.com/lycheeverse/lychee/pull/1560))
+- Add quirks support for `youtube-nocookie.com` and youtube embed URLs ([#1563](https://github.com/lycheeverse/lychee/pull/1563))
+- Support excluded paths in `--dump-inputs` ([#1556](https://github.com/lycheeverse/lychee/pull/1556))
+- Improve robustness of cache integration test ([#1557](https://github.com/lycheeverse/lychee/pull/1557))
+- Bump the dependencies group across 1 directory with 7 updates ([#1552](https://github.com/lycheeverse/lychee/pull/1552))
+- Bring back error output for links (#1553)
+
 ## [0.17.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.16.1...lychee-v0.17.0) - 2024-11-06
 
 ### Fixed

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.17.0", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.18.0", default-features = false }
 
 anyhow = "1.0.94"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.17.0...lychee-lib-v0.18.0) - 2024-12-18
+
+### Other
+
+- Bump the dependencies group across 1 directory with 11 updates ([#1589](https://github.com/lycheeverse/lychee/pull/1589))
+- Introduce --root-dir ([#1576](https://github.com/lycheeverse/lychee/pull/1576))
+- Fix retries ([#1573](https://github.com/lycheeverse/lychee/pull/1573))
+- Bump the dependencies group with 4 updates ([#1571](https://github.com/lycheeverse/lychee/pull/1571))
+- Bump the dependencies group with 4 updates ([#1570](https://github.com/lycheeverse/lychee/pull/1570))
+- Bump the dependencies group with 4 updates ([#1566](https://github.com/lycheeverse/lychee/pull/1566))
+- Rename `fail_map` to `error_map` for improved clarity in response statistics ([#1560](https://github.com/lycheeverse/lychee/pull/1560))
+- Add quirks support for `youtube-nocookie.com` and youtube embed URLs ([#1563](https://github.com/lycheeverse/lychee/pull/1563))
+- Support underscores in Markdown URLs ([#1555](https://github.com/lycheeverse/lychee/pull/1555))
+- Bump the dependencies group across 1 directory with 7 updates ([#1552](https://github.com/lycheeverse/lychee/pull/1552))
+- Bring back error output for links (#1553)
+
 ## [0.17.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.16.1...lychee-lib-v0.17.0) - 2024-11-06
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `lychee`: 0.17.0 -> 0.18.0
* `lychee-lib`: 0.17.0 -> 0.18.0 (⚠️ API breaking changes)

### ⚠️ `lychee-lib` breaking changes

```
--- failure inherent_method_const_removed: pub method is no longer const ---

Description:
A publicly-visible method or associated fn is no longer `const` and can no longer be used in a `const` context.
        ref: https://doc.rust-lang.org/reference/const_eval.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/inherent_method_const_removed.ron

Failed in:
  Collector::new in /tmp/.tmptebDB6/lychee/lychee-lib/src/collector.rs:51
  Collector::new in /tmp/.tmptebDB6/lychee/lychee-lib/src/collector.rs:51

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lychee_lib::collector::Collector::new now takes 2 parameters instead of 1, in /tmp/.tmptebDB6/lychee/lychee-lib/src/collector.rs:51
  lychee_lib::Collector::new now takes 2 parameters instead of 1, in /tmp/.tmptebDB6/lychee/lychee-lib/src/collector.rs:51
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee`
<blockquote>

## [0.18.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.17.0...lychee-v0.18.0) - 2024-12-18

### Other

- Bump the dependencies group across 1 directory with 11 updates ([#1589](https://github.com/lycheeverse/lychee/pull/1589))
- Introduce --root-dir ([#1576](https://github.com/lycheeverse/lychee/pull/1576))
- Fix retries ([#1573](https://github.com/lycheeverse/lychee/pull/1573))
- Pass along --max-retries config option ([#1572](https://github.com/lycheeverse/lychee/pull/1572))
- Bump the dependencies group with 4 updates ([#1571](https://github.com/lycheeverse/lychee/pull/1571))
- Bump the dependencies group with 4 updates ([#1570](https://github.com/lycheeverse/lychee/pull/1570))
- Bump the dependencies group with 4 updates ([#1566](https://github.com/lycheeverse/lychee/pull/1566))
- Rename `fail_map` to `error_map` for improved clarity in response statistics ([#1560](https://github.com/lycheeverse/lychee/pull/1560))
- Add quirks support for `youtube-nocookie.com` and youtube embed URLs ([#1563](https://github.com/lycheeverse/lychee/pull/1563))
- Support excluded paths in `--dump-inputs` ([#1556](https://github.com/lycheeverse/lychee/pull/1556))
- Improve robustness of cache integration test ([#1557](https://github.com/lycheeverse/lychee/pull/1557))
- Bump the dependencies group across 1 directory with 7 updates ([#1552](https://github.com/lycheeverse/lychee/pull/1552))
- Bring back error output for links (#1553)
</blockquote>

## `lychee-lib`
<blockquote>

## [0.18.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.17.0...lychee-lib-v0.18.0) - 2024-12-18

### Other

- Bump the dependencies group across 1 directory with 11 updates ([#1589](https://github.com/lycheeverse/lychee/pull/1589))
- Introduce --root-dir ([#1576](https://github.com/lycheeverse/lychee/pull/1576))
- Fix retries ([#1573](https://github.com/lycheeverse/lychee/pull/1573))
- Bump the dependencies group with 4 updates ([#1571](https://github.com/lycheeverse/lychee/pull/1571))
- Bump the dependencies group with 4 updates ([#1570](https://github.com/lycheeverse/lychee/pull/1570))
- Bump the dependencies group with 4 updates ([#1566](https://github.com/lycheeverse/lychee/pull/1566))
- Rename `fail_map` to `error_map` for improved clarity in response statistics ([#1560](https://github.com/lycheeverse/lychee/pull/1560))
- Add quirks support for `youtube-nocookie.com` and youtube embed URLs ([#1563](https://github.com/lycheeverse/lychee/pull/1563))
- Support underscores in Markdown URLs ([#1555](https://github.com/lycheeverse/lychee/pull/1555))
- Bump the dependencies group across 1 directory with 7 updates ([#1552](https://github.com/lycheeverse/lychee/pull/1552))
- Bring back error output for links (#1553)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).