### PR TITLE
Update all Docker images to Debian Bookworm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/rust/.devcontainer/base.Dockerfile
-# [Choice] Debian OS version (use bullseye on local arm64/Apple Silicon): buster, bullseye
-ARG VARIANT="buster"
+# [Choice] Debian OS version (use bookworm on local arm64/Apple Silicon): buster, bullseye, bookworm
+ARG VARIANT="bookworm"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
-			// Use bullseye when on local on arm64/Apple Silicon.
-			"VARIANT": "bullseye"
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye, bookworm
+			// Use bookworm when on local on arm64/Apple Silicon.
+			"VARIANT": "bookworm"
 		}
 	},
 	"runArgs": [

--- a/Dockerfile-CI.Dockerfile
+++ b/Dockerfile-CI.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS builder
+FROM debian:bookworm-slim AS builder
 WORKDIR /builder
 
 RUN apt-get update \
@@ -17,7 +17,7 @@ RUN apt-get update \
     esac \
     && chmod +x lychee
 
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
In our migration to Bookworm, we missed a few places. The outdated images might be a reason why we see more Docker build errors lately. In any case, it's best if we use the latest image everywhere.