### PR TITLE
Add support for custom file extensions in link checking.

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,13 @@ Options:
           Do not show progress bar.
           This is recommended for non-interactive shells (e.g. for continuous integration)
 
+      --extensions <EXTENSIONS>
+          Test the specified file extensions for URIs when checking files locally.
+
+          Multiple extensions can be separated by commas. Note that if you want to check filetypes,
+          which have multiple extensions, e.g. HTML files with both .html and .htm extensions, you need to
+          specify both extensions explicitly.
+
       --cache
           Use request cache stored on disk at `.lycheecache`
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ Options:
           which have multiple extensions, e.g. HTML files with both .html and .htm extensions, you need to
           specify both extensions explicitly.
 
+          [default: md,mkd,mdx,mdown,mdwn,mkdn,mkdown,markdown,html,htm,txt]
+
       --cache
           Use request cache stored on disk at `.lycheecache`
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -332,7 +332,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         collector
     };
 
-    let requests = collector.collect_links_with_ext(inputs, opts.config.extensions.clone());
+    let requests = collector.collect_links_from_file_types(inputs, opts.config.extensions.clone());
 
     let cache = load_cache(&opts.config).unwrap_or_default();
     let cache = Arc::new(cache);

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -332,7 +332,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         collector
     };
 
-    let requests = collector.collect_links(inputs);
+    let requests = collector.collect_links_with_ext(inputs, opts.config.extensions.clone());
 
     let cache = load_cache(&opts.config).unwrap_or_default();
     let cache = Arc::new(cache);

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -238,9 +238,6 @@ pub(crate) struct Config {
     /// want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
     #[arg(
         long,
-        value_parser = |s: &str| -> Result<FileExtensions, String> {
-            Ok(FileExtensions::from(s.split(',').map(String::from).collect::<Vec<_>>()))
-        },
         long_help = "Test the specified file extensions for URIs when checking files locally.
     
 Multiple extensions can be separated by commas. Note that if you want to check filetypes,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -6,9 +6,9 @@ use clap::builder::PossibleValuesParser;
 use clap::{arg, builder::TypedValueParser, Parser};
 use const_format::{concatcp, formatcp};
 use lychee_lib::{
-    Base, BasicAuthSelector, FileType, Input, StatusCodeExcluder, StatusCodeSelector,
-    DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS,
-    DEFAULT_USER_AGENT,
+    Base, BasicAuthSelector, FileExtensions, FileType, Input, StatusCodeExcluder,
+    StatusCodeSelector, DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS,
+    DEFAULT_TIMEOUT_SECS, DEFAULT_USER_AGENT,
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
@@ -238,15 +238,17 @@ pub(crate) struct Config {
     /// want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
     #[arg(
         long,
-        value_delimiter = ',',
+        value_parser = |s: &str| -> Result<FileExtensions, String> {
+            Ok(FileExtensions::from(s.split(',').map(String::from).collect::<Vec<_>>()))
+        },
         long_help = "Test the specified file extensions for URIs when checking files locally.
-
+    
 Multiple extensions can be separated by commas. Note that if you want to check filetypes,
 which have multiple extensions, e.g. HTML files with both .html and .htm extensions, you need to
 specify both extensions explicitly."
     )]
-    #[serde(default = "FileType::default_extensions")]
-    pub(crate) extensions: Vec<String>,
+    #[serde(default = "FileExtensions::default")]
+    pub(crate) extensions: FileExtensions,
 
     #[arg(help = HELP_MSG_CACHE)]
     #[arg(long)]

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -238,6 +238,7 @@ pub(crate) struct Config {
     /// want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
     #[arg(
         long,
+        default_value_t = FileExtensions::default(),
         long_help = "Test the specified file extensions for URIs when checking files locally.
     
 Multiple extensions can be separated by commas. Note that if you want to check filetypes,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -229,7 +229,7 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) no_progress: bool,
 
-    /// A list of custom extensions for link checking
+    /// A list of file extensions. Files not matching the specified extensions are skipped.
     ///
     /// E.g. a user can specify `--extensions html,htm,php,asp,aspx,jsp,cgi`
     /// to check for links in files with these extensions.

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -6,8 +6,9 @@ use clap::builder::PossibleValuesParser;
 use clap::{arg, builder::TypedValueParser, Parser};
 use const_format::{concatcp, formatcp};
 use lychee_lib::{
-    Base, BasicAuthSelector, Input, StatusCodeExcluder, StatusCodeSelector, DEFAULT_MAX_REDIRECTS,
-    DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS, DEFAULT_USER_AGENT,
+    Base, BasicAuthSelector, FileType, Input, StatusCodeExcluder, StatusCodeSelector,
+    DEFAULT_MAX_REDIRECTS, DEFAULT_MAX_RETRIES, DEFAULT_RETRY_WAIT_TIME_SECS, DEFAULT_TIMEOUT_SECS,
+    DEFAULT_USER_AGENT,
 };
 use secrecy::{ExposeSecret, SecretString};
 use serde::Deserialize;
@@ -227,6 +228,25 @@ pub(crate) struct Config {
     #[arg(short, long, verbatim_doc_comment)]
     #[serde(default)]
     pub(crate) no_progress: bool,
+
+    /// A list of custom extensions for link checking
+    ///
+    /// E.g. a user can specify `--extensions html,htm,php,asp,aspx,jsp,cgi`
+    /// to check for links in files with these extensions.
+    ///
+    /// This is useful when the default extensions are not enough and you don't
+    /// want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
+    #[arg(
+        long,
+        value_delimiter = ',',
+        long_help = "Test the specified file extensions for URIs when checking files locally.
+
+Multiple extensions can be separated by commas. Note that if you want to check filetypes,
+which have multiple extensions, e.g. HTML files with both .html and .htm extensions, you need to
+specify both extensions explicitly."
+    )]
+    #[serde(default = "FileType::default_extensions")]
+    pub(crate) extensions: Vec<String>,
 
     #[arg(help = HELP_MSG_CACHE)]
     #[arg(long)]
@@ -584,6 +604,7 @@ impl Config {
             cookie_jar: None;
             include_fragments: false;
             accept: StatusCodeSelector::default();
+            extensions: FileType::default_extensions();
         }
 
         if self

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -119,6 +119,12 @@ impl Collector {
             .flatten()
     }
 
+    /// Convenience method to fetch all unique links from inputs
+    /// with the default extensions.
+    pub fn collect_links(self, inputs: Vec<Input>) -> impl Stream<Item = Result<Request>> {
+        self.collect_links_with_ext(inputs, crate::types::FileType::default_extensions())
+    }
+
     /// Fetch all unique links from inputs
     /// All relative URLs get prefixed with `base` (if given).
     /// (This can be a directory or a base URL)
@@ -126,7 +132,11 @@ impl Collector {
     /// # Errors
     ///
     /// Will return `Err` if links cannot be extracted from an input
-    pub fn collect_links(self, inputs: Vec<Input>) -> impl Stream<Item = Result<Request>> {
+    pub fn collect_links_with_ext(
+        self,
+        inputs: Vec<Input>,
+        extensions: Vec<String>,
+    ) -> impl Stream<Item = Result<Request>> {
         let skip_missing_inputs = self.skip_missing_inputs;
         let skip_hidden = self.skip_hidden;
         let skip_ignored = self.skip_ignored;
@@ -134,13 +144,14 @@ impl Collector {
         stream::iter(inputs)
             .par_then_unordered(None, move |input| {
                 let default_base = global_base.clone();
+                let extensions = extensions.clone();
                 async move {
                     let base = match &input.source {
                         InputSource::RemoteUrl(url) => Base::try_from(url.as_str()).ok(),
                         _ => default_base,
                     };
                     input
-                        .get_contents(skip_missing_inputs, skip_hidden, skip_ignored)
+                        .get_contents(skip_missing_inputs, skip_hidden, skip_ignored, extensions)
                         .map(move |content| (content, base.clone()))
                 }
             })
@@ -191,15 +202,19 @@ mod tests {
         Ok(responses.map(|r| r.unwrap().uri).collect().await)
     }
 
-    // Helper function for collecting verbatim links
+    /// Helper function for collecting verbatim links
+    ///
+    /// A verbatim link is a link that is not parsed by the HTML parser.
+    /// For example, a link in a code block or a script tag.
     async fn collect_verbatim(
         inputs: Vec<Input>,
         root_dir: Option<PathBuf>,
         base: Option<Base>,
+        extensions: Vec<String>,
     ) -> Result<HashSet<Uri>> {
         let responses = Collector::new(root_dir, base)?
             .include_verbatim(true)
-            .collect_links(inputs);
+            .collect_links_with_ext(inputs, extensions);
         Ok(responses.map(|r| r.unwrap().uri).collect().await)
     }
 
@@ -217,7 +232,7 @@ mod tests {
         let _file = File::create(&file_path).unwrap();
         let input = Input::new(&file_path.as_path().display().to_string(), None, true, None)?;
         let contents: Vec<_> = input
-            .get_contents(true, true, true)
+            .get_contents(true, true, true, FileType::default_extensions())
             .collect::<Vec<_>>()
             .await;
 
@@ -230,7 +245,7 @@ mod tests {
     async fn test_url_without_extension_is_html() -> Result<()> {
         let input = Input::new("https://example.com/", None, true, None)?;
         let contents: Vec<_> = input
-            .get_contents(true, true, true)
+            .get_contents(true, true, true, FileType::default_extensions())
             .collect::<Vec<_>>()
             .await;
 
@@ -288,7 +303,7 @@ mod tests {
             },
         ];
 
-        let links = collect_verbatim(inputs, None, None).await.ok().unwrap();
+        let links = collect_verbatim(inputs, None, None, FileType::default_extensions()).await.ok().unwrap();
 
         let expected_links = HashSet::from_iter([
             website(TEST_STRING),

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -97,8 +97,8 @@ pub use crate::{
     filter::{Excludes, Filter, Includes},
     types::{
         uri::valid::Uri, AcceptRange, AcceptRangeError, Base, BasicAuthCredentials,
-        BasicAuthSelector, CacheStatus, CookieJar, ErrorKind, FileType, Input, InputContent,
-        InputSource, Request, Response, ResponseBody, Result, Status, StatusCodeExcluder,
-        StatusCodeSelector,
+        BasicAuthSelector, CacheStatus, CookieJar, ErrorKind, FileExtensions, FileType, Input,
+        InputContent, InputSource, Request, Response, ResponseBody, Result, Status,
+        StatusCodeExcluder, StatusCodeSelector,
     },
 };

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -46,6 +46,10 @@ impl FileExtensions {
     pub fn contains<T: Into<String>>(&self, file_extension: T) -> bool {
         self.0.contains(&file_extension.into())
     }
+}
+
+impl TryFrom<FileExtensions> for Types {
+    type Error = super::ErrorKind;
 
     /// Build the current list of file extensions into a file type matcher.
     ///
@@ -53,9 +57,9 @@ impl FileExtensions {
     ///
     /// Fails if an extension is `all` or otherwise contains any character that
     /// is not a Unicode letter or number.
-    pub fn all(&self) -> super::Result<Types> {
+    fn try_from(value: FileExtensions) -> super::Result<Self> {
         let mut types_builder = TypesBuilder::new();
-        for ext in self.0.clone() {
+        for ext in value.0.clone() {
             types_builder.add(&ext, &format!("*.{ext}"))?;
         }
         Ok(types_builder.select("all").build()?)

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -20,7 +20,7 @@ pub struct FileExtensions(Vec<String>);
 
 impl Default for FileExtensions {
     fn default() -> Self {
-        FileType::default_extensions().into()
+        FileType::default_extensions()
     }
 }
 

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -226,7 +226,7 @@ mod tests {
         assert!(extensions.contains("html"));
         assert!(extensions.contains("markdown"));
         assert!(extensions.contains("htm"));
-        // Test the count matches our static arrays
+        // Test that the count matches our static arrays
         let all_extensions: Vec<_> = extensions.into();
         assert_eq!(
             all_extensions.len(),

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -177,6 +177,8 @@ impl FileType {
             Some(Self::Markdown)
         } else if Self::HTML_EXTENSIONS.contains(&ext.as_str()) {
             Some(Self::Html)
+        } else if Self::PLAINTEXT_EXTENSIONS.contains(&ext.as_str()) {
+            Some(Self::Plaintext)
         } else {
             None
         }
@@ -253,7 +255,9 @@ mod tests {
         let all_extensions: Vec<_> = extensions.into();
         assert_eq!(
             all_extensions.len(),
-            FileType::MARKDOWN_EXTENSIONS.len() + FileType::HTML_EXTENSIONS.len()
+            FileType::MARKDOWN_EXTENSIONS.len()
+                + FileType::HTML_EXTENSIONS.len()
+                + FileType::PLAINTEXT_EXTENSIONS.len()
         );
     }
 

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -73,7 +73,7 @@ impl From<FileType> for FileExtensions {
         match file_type {
             FileType::Html => FileType::html_extensions(),
             FileType::Markdown => FileType::markdown_extensions(),
-            FileType::Plaintext => Self::empty(),
+            FileType::Plaintext => FileType::plaintext_extensions(),
         }
     }
 }
@@ -120,12 +120,16 @@ impl FileType {
     /// All known HTML extensions
     const HTML_EXTENSIONS: &'static [&'static str] = &["htm", "html"];
 
-    /// Default extensions which are supported by lychee
+    /// All known plaintext extensions
+    const PLAINTEXT_EXTENSIONS: &'static [&'static str] = &["txt"];
+
+    /// Default extensions which are checked by lychee
     #[must_use]
     pub fn default_extensions() -> FileExtensions {
         let mut extensions = FileExtensions::empty();
         extensions.extend(Self::markdown_extensions());
         extensions.extend(Self::html_extensions());
+        extensions.extend(Self::plaintext_extensions());
         extensions
     }
 
@@ -142,6 +146,15 @@ impl FileType {
     #[must_use]
     pub fn html_extensions() -> FileExtensions {
         Self::HTML_EXTENSIONS
+            .iter()
+            .map(|&s| s.to_string())
+            .collect()
+    }
+
+    /// All known plaintext extensions
+    #[must_use]
+    pub fn plaintext_extensions() -> FileExtensions {
+        Self::PLAINTEXT_EXTENSIONS
             .iter()
             .map(|&s| s.to_string())
             .collect()

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -92,6 +92,14 @@ impl Iterator for FileExtensions {
     }
 }
 
+impl std::str::FromStr for FileExtensions {
+    type Err = std::convert::Infallible; // Cannot fail parsing
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Self(s.split(',').map(String::from).collect()))
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 /// `FileType` defines which file types lychee can handle
 pub enum FileType {

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -20,7 +20,13 @@ pub struct FileExtensions(Vec<String>);
 
 impl Default for FileExtensions {
     fn default() -> Self {
-        FileType::default().into()
+        FileType::default_extensions().into()
+    }
+}
+
+impl std::fmt::Display for FileExtensions {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.join(","))
     }
 }
 

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -100,8 +100,8 @@ impl std::str::FromStr for FileExtensions {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 /// `FileType` defines which file types lychee can handle
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum FileType {
     /// File in HTML format
     Html,

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -3,7 +3,6 @@ use crate::{utils, ErrorKind, Result};
 use async_stream::try_stream;
 use futures::stream::Stream;
 use glob::glob_with;
-use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -12,6 +11,8 @@ use std::fmt::Display;
 use std::fs;
 use std::path::{Path, PathBuf};
 use tokio::io::{stdin, AsyncReadExt};
+
+use super::file::FileExtensions;
 
 const STDIN: &str = "-";
 
@@ -194,6 +195,9 @@ impl Input {
 
     /// Retrieve the contents from the input
     ///
+    /// If the input is a path, only search through files that match the given
+    /// file extensions.
+    ///
     /// # Errors
     ///
     /// Returns an error if the contents can not be retrieved
@@ -204,7 +208,9 @@ impl Input {
         skip_missing: bool,
         skip_hidden: bool,
         skip_gitignored: bool,
-        extensions: Vec<String>,
+        // If `Input` is a file path, try the given file extensions in order.
+        // Stop on the first match.
+        file_extensions: FileExtensions,
     ) -> impl Stream<Item = Result<InputContent>> {
         try_stream! {
             match self.source {
@@ -227,15 +233,9 @@ impl Input {
                 }
                 InputSource::FsPath(ref path) => {
                     if path.is_dir() {
-
-                        let mut types_builder = TypesBuilder::new();
-                        for ext in extensions {
-                            types_builder.add(&ext, &format!("*.{ext}"))?;
-                        }
-
                         for entry in WalkBuilder::new(path)
                             .standard_filters(skip_gitignored)
-                            .types(types_builder.select("all").build()?)
+                            .types(file_extensions.all()?)
                             .hidden(skip_hidden)
                             .build()
                         {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -235,7 +235,7 @@ impl Input {
                     if path.is_dir() {
                         for entry in WalkBuilder::new(path)
                             .standard_filters(skip_gitignored)
-                            .types(file_extensions.all()?)
+                            .types(file_extensions.try_into()?)
                             .hidden(skip_hidden)
                             .build()
                         {

--- a/lychee-lib/src/types/mod.rs
+++ b/lychee-lib/src/types/mod.rs
@@ -21,7 +21,7 @@ pub use basic_auth::{BasicAuthCredentials, BasicAuthSelector};
 pub use cache::CacheStatus;
 pub use cookies::CookieJar;
 pub use error::ErrorKind;
-pub use file::FileType;
+pub use file::{FileExtensions, FileType};
 pub use input::{Input, InputContent, InputSource};
 pub use request::Request;
 pub use response::{Response, ResponseBody};


### PR DESCRIPTION
This adds support for overwriting extensions:

```
lychee . --extensions md,html,txt,json,yaml
```

The above would only check these extensions.

This was enabled by moving to `ignore` (#1500 by @thomas-zahner).

I'm not 100% convinced about the design yet. Feedback welcome!
Guess we should use whatever [`ignore::types::Types`](https://docs.rs/ignore/0.4.23/ignore/types/struct.Types.html) for file extension matching as it's well-maintained and more exhaustive. Switching this would remove some custom code we have in `FileType`.

Fixes #410