### PR TITLE
Allow Docker pushes on release branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -94,7 +94,9 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
-          push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+          push: ${{ (github.event_name != 'pull_request' &&
+                     github.actor != 'dependabot[bot]') ||
+                     startsWith(github.ref, 'lychee-v') }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
@@ -104,7 +106,9 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE_ALPINE }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
-          push: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+          push: ${{ (github.event_name != 'pull_request' &&
+                     github.actor != 'dependabot[bot]') ||
+                     startsWith(github.ref, 'lychee-v') }}
           tags: ${{ steps.meta-alpine.outputs.tags }}
           labels: ${{ steps.meta-alpine.outputs.labels }}
 


### PR DESCRIPTION
As outlined in https://github.com/lycheeverse/lychee/issues/1432#issuecomment-2477830138, the current workflow won't push to the Docker registry when a release is cut because releases now include a pull request.

This pull request increases the number of conditions under which a Docker image can be pushed.

Closes https://github.com/lycheeverse/lychee/issues/1432.