### PR TITLE
Add Checkbox Formatting Option for Markdown Reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Options:
           Set the output display mode. Determines how results are presented in the terminal
 
           [default: color]
-          [possible values: plain, color, emoji]
+          [possible values: plain, color, emoji, task]
 
   -f, --format <FORMAT>
           Output format of final status report

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -30,7 +30,7 @@ You have two options:
    conservative like 32. This works, but it also comes with a performance
    penalty.
 2. Increase the number of maximum file handles. See instructions
-   [here](https://wilsonmar.github.io/maximum-limits/) or
+   [here](https://web.archive.org/web/20241127024709/https://wilsonmar.github.io/maximum-limits/) or
    [here](https://synthomat.de/blog/2020/01/increasing-the-file-descriptor-limit-on-macos/).
 
 ## Unexpected Status Codes

--- a/lychee-bin/src/formatters/mod.rs
+++ b/lychee-bin/src/formatters/mod.rs
@@ -37,5 +37,6 @@ pub(crate) fn get_response_formatter(mode: &OutputMode) -> Box<dyn ResponseForma
         OutputMode::Plain => Box::new(response::PlainFormatter),
         OutputMode::Color => Box::new(response::ColorFormatter),
         OutputMode::Emoji => Box::new(response::EmojiFormatter),
+        OutputMode::Task => Box::new(response::TaskFormatter),
     }
 }

--- a/lychee-bin/src/formatters/response/mod.rs
+++ b/lychee-bin/src/formatters/response/mod.rs
@@ -3,10 +3,12 @@ use lychee_lib::ResponseBody;
 mod color;
 mod emoji;
 mod plain;
+mod task;
 
 pub(crate) use color::ColorFormatter;
 pub(crate) use emoji::EmojiFormatter;
 pub(crate) use plain::PlainFormatter;
+pub(crate) use task::TaskFormatter;
 
 /// Desired total width of formatted string for color formatter
 ///

--- a/lychee-bin/src/formatters/response/task.rs
+++ b/lychee-bin/src/formatters/response/task.rs
@@ -1,6 +1,5 @@
-use lychee_lib::ResponseBody;
 use super::ResponseFormatter;
-
+use lychee_lib::ResponseBody;
 
 pub(crate) struct TaskFormatter;
 
@@ -83,4 +82,3 @@ mod task_tests {
         );
     }
 }
-

--- a/lychee-bin/src/formatters/response/task.rs
+++ b/lychee-bin/src/formatters/response/task.rs
@@ -1,0 +1,86 @@
+use lychee_lib::ResponseBody;
+use super::ResponseFormatter;
+
+
+pub(crate) struct TaskFormatter;
+
+impl ResponseFormatter for TaskFormatter {
+    fn format_response(&self, body: &ResponseBody) -> String {
+        format!("- [ ] [{}] {}", body.status.code_as_string(), body)
+    }
+}
+
+#[cfg(test)]
+mod task_tests {
+    use super::*;
+    use http::StatusCode;
+    use lychee_lib::{ErrorKind, Status, Uri};
+
+    // Helper function to create a ResponseBody with a given status and URI
+    fn mock_response_body(status: Status, uri: &str) -> ResponseBody {
+        ResponseBody {
+            uri: Uri::try_from(uri).unwrap(),
+            status,
+        }
+    }
+
+    #[test]
+    fn test_format_response_with_ok_status() {
+        let formatter = TaskFormatter;
+        let body = mock_response_body(Status::Ok(StatusCode::OK), "https://example.com");
+        assert_eq!(
+            formatter.format_response(&body),
+            "- [ ] [200] https://example.com/"
+        );
+    }
+
+    #[test]
+    fn test_format_response_with_error_status() {
+        let formatter = TaskFormatter;
+        let body = mock_response_body(
+            Status::Error(ErrorKind::InvalidUrlHost),
+            "https://example.com/404",
+        );
+        assert_eq!(
+            formatter.format_response(&body),
+            "- [ ] [ERROR] https://example.com/404 | URL is missing a host"
+        );
+    }
+
+    #[test]
+    fn test_format_response_with_excluded_status() {
+        let formatter = TaskFormatter;
+        let body = mock_response_body(Status::Excluded, "https://example.com/not-checked");
+        assert_eq!(
+            formatter.format_response(&body),
+            "- [ ] [EXCLUDED] https://example.com/not-checked"
+        );
+    }
+
+    #[test]
+    fn test_format_response_with_redirect_status() {
+        let formatter = TaskFormatter;
+        let body = mock_response_body(
+            Status::Redirected(StatusCode::MOVED_PERMANENTLY),
+            "https://example.com/redirect",
+        );
+        assert_eq!(
+            formatter.format_response(&body),
+            "- [ ] [301] https://example.com/redirect | Redirect (301 Moved Permanently): Moved Permanently"
+        );
+    }
+
+    #[test]
+    fn test_format_response_with_unknown_status_code() {
+        let formatter = TaskFormatter;
+        let body = mock_response_body(
+            Status::UnknownStatusCode(StatusCode::from_u16(999).unwrap()),
+            "https://example.com/unknown",
+        );
+        assert_eq!(
+            formatter.format_response(&body),
+            "- [ ] [999] https://example.com/unknown | Unknown status (999 <unknown status code>)"
+        );
+    }
+}
+

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -109,6 +109,14 @@ pub(crate) enum OutputMode {
     #[serde(rename = "emoji")]
     #[strum(serialize = "emoji", ascii_case_insensitive)]
     Emoji,
+
+    /// Task output.
+    ///
+    /// This mode uses Markdown-styled checkboxes to represent the status of the requests.
+    /// Some people may find this mode more intuitive and useful for task tracking.
+    #[serde(rename = "task")]
+    #[strum(serialize = "task", ascii_case_insensitive)]
+    Task,
 }
 
 impl OutputMode {


### PR DESCRIPTION
fixes #1610

- Implemented OutputMode::Task for checkbox formatting
- Updated task.rs formatter to support the new feature
- Fixed Broken Link Using Wayback Machine (https://wilsonmar.github.io/maximum-limits/ -> )