### PR TITLE
renamed `base` to `base_url` (fixes #1607)

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Options:
 
           [default: get]
 
-  -b, --base-url <BASE>
+  -b, --base-url <BASE_URL>
           Base URL or website root directory to check relative URLs e.g. <https://example.com> or `/path/to/public`
 
       --root-dir <ROOT_DIR>

--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ Options:
 
   -b, --base-url <BASE_URL>
           Base URL used to resolve relative URLs during link checking Example: <https://example.com>
-          
+
       --root-dir <ROOT_DIR>
           Root path to use when checking absolute local links, must be an absolute path
 

--- a/README.md
+++ b/README.md
@@ -484,9 +484,12 @@ Options:
 
           [default: get]
 
-  -b, --base-url <BASE_URL>
-          Base URL or website root directory to check relative URLs e.g. <https://example.com> or `/path/to/public`
+      --base <BASE>
+          Deprecated; use `--base-url` instead
 
+  -b, --base-url <BASE_URL>
+          Base URL used to resolve relative URLs during link checking Example: <https://example.com>
+          
       --root-dir <ROOT_DIR>
           Root path to use when checking absolute local links, must be an absolute path
 

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ Options:
 
           [default: get]
 
-  -b, --base <BASE>
+  -b, --base-url <BASE>
           Base URL or website root directory to check relative URLs e.g. <https://example.com> or `/path/to/public`
 
       --root-dir <ROOT_DIR>

--- a/fixtures/configs/smoketest.toml
+++ b/fixtures/configs/smoketest.toml
@@ -80,7 +80,7 @@ remap = [
 ]
 
 # Base URL or website root directory to check relative URLs.
-base-url = "https://example.com"
+base_url = "https://example.com"
 
 # HTTP basic auth support. This will be the username and password passed to the
 # authorization HTTP header. See

--- a/fixtures/configs/smoketest.toml
+++ b/fixtures/configs/smoketest.toml
@@ -80,7 +80,7 @@ remap = [
 ]
 
 # Base URL or website root directory to check relative URLs.
-base = "https://example.com"
+base-url = "https://example.com"
 
 # HTTP basic auth support. This will be the username and password passed to the
 # authorization HTTP header. See

--- a/lychee-bin/src/client.rs
+++ b/lychee-bin/src/client.rs
@@ -55,7 +55,7 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
 
     ClientBuilder::builder()
         .remaps(remaps)
-        .base(cfg.base.clone())
+        .base(cfg.base_url.clone())
         .includes(includes)
         .excludes(excludes)
         .exclude_all_private(cfg.exclude_all_private)

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -177,6 +177,11 @@ fn load_config() -> Result<LycheeOptions> {
         warn!("WARNING: `--exclude-mail` is deprecated and will soon be removed; E-Mail is no longer checked by default. Use `--include-mail` to enable E-Mail checking.");
     }
 
+    // TODO: Remove this warning and the parameter with 1.0
+    if opts.config.base.is_some() {
+        warn!("WARNING: `--base` is deprecated and will soon be removed; use `--base-url` instead.");
+    }
+
     // Load excludes from file
     for path in &opts.config.exclude_file {
         let file = File::open(path)?;

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -179,7 +179,9 @@ fn load_config() -> Result<LycheeOptions> {
 
     // TODO: Remove this warning and the parameter with 1.0
     if opts.config.base.is_some() {
-        warn!("WARNING: `--base` is deprecated and will soon be removed; use `--base-url` instead.");
+        warn!(
+            "WARNING: `--base` is deprecated and will soon be removed; use `--base-url` instead."
+        );
     }
 
     // Load excludes from file

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -288,7 +288,7 @@ fn underlying_io_error_kind(error: &Error) -> Option<io::ErrorKind> {
 async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs()?;
 
-    let mut collector = Collector::new(opts.config.root_dir.clone(), opts.config.base.clone())?
+    let mut collector = Collector::new(opts.config.root_dir.clone(), opts.config.base_url.clone())?
         .skip_missing_inputs(opts.config.skip_missing)
         .skip_hidden(!opts.config.hidden)
         .skip_ignored(!opts.config.no_ignore)

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -449,8 +449,13 @@ separated list of accepted status codes. This example will accept 200, 201,
     #[serde(default = "method")]
     pub(crate) method: String,
 
-    /// Base URL or website root directory to check relative URLs
-    /// e.g. <https://example.com> or `/path/to/public`
+    /// Deprecated; use `--base-url` instead
+    #[arg(long, value_parser = parse_base)]
+    #[serde(skip)]
+    pub(crate) base: Option<Base>,
+
+    /// Base URL used to resolve relative URLs during link checking
+    /// Example: <https://example.com>
     #[arg(short, long, value_parser= parse_base)]
     #[serde(default)]
     pub(crate) base_url: Option<Base>,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -453,7 +453,7 @@ separated list of accepted status codes. This example will accept 200, 201,
     /// e.g. <https://example.com> or `/path/to/public`
     #[arg(short, long, value_parser= parse_base)]
     #[serde(default)]
-    pub(crate) base: Option<Base>,
+    pub(crate) base_url: Option<Base>,
 
     /// Root path to use when checking absolute local links,
     /// must be an absolute path
@@ -568,7 +568,7 @@ impl Config {
             timeout: DEFAULT_TIMEOUT_SECS;
             retry_wait_time: DEFAULT_RETRY_WAIT_TIME_SECS;
             method: DEFAULT_METHOD;
-            base: None;
+            base_url: None;
             basic_auth: None;
             skip_missing: false;
             include_verbatim: false;

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -383,7 +383,7 @@ mod cli {
         let dir = fixtures_path().join("resolve_paths");
 
         cmd.arg("--offline")
-            .arg("--base")
+            .arg("--base-url")
             .arg(&dir)
             .arg(dir.join("index.html"))
             .env_clear()
@@ -419,7 +419,7 @@ mod cli {
         cmd.arg("--offline")
             .arg("--root-dir")
             .arg("/resolve_paths")
-            .arg("--base")
+            .arg("--base-url")
             .arg(&dir)
             .arg(dir.join("resolve_paths").join("index.html"))
             .env_clear()

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -75,7 +75,7 @@ header = ["name=value", "other=value"]
 remap = ["https://example.com http://example.invalid"]
 
 # Base URL or website root directory to check relative URLs.
-base-url = "https://example.com"
+base_url = "https://example.com"
 
 # HTTP basic auth support. This will be the username and password passed to the
 # authorization HTTP header. See

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -75,7 +75,7 @@ header = ["name=value", "other=value"]
 remap = ["https://example.com http://example.invalid"]
 
 # Base URL or website root directory to check relative URLs.
-base = "https://example.com"
+base-url = "https://example.com"
 
 # HTTP basic auth support. This will be the username and password passed to the
 # authorization HTTP header. See


### PR DESCRIPTION
Changed the configuration parameter `base` to `base_url` to improve clarity (fixes #1607)