### PR TITLE
chore: release v0.18.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2470,7 +2470,7 @@ dependencies = [
 
 [[package]]
 name = "lychee"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.1"
+version = "0.18.2"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.1...lychee-v0.18.2) - 2025-02-24
+
+### Other
+
+- Format Markdown URLs with `<>` instead of `[]()` ([#1638](https://github.com/lycheeverse/lychee/pull/1638))
+- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
+- add tests for URL extraction ending with a period (#1641)
+- renamed `base` to `base_url` (fixes [#1607](https://github.com/lycheeverse/lychee/pull/1607)) ([#1629](https://github.com/lycheeverse/lychee/pull/1629))
+- Sort compact/detailed/markdown error output by file path ([#1622](https://github.com/lycheeverse/lychee/pull/1622))
+
 ## [0.18.1](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.0...lychee-v0.18.1) - 2025-02-06
 
 ### Fixed

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.18.1", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.18.2", default-features = false }
 
 anyhow = "1.0.96"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.2](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.1...lychee-lib-v0.18.2) - 2025-02-24
+
+### Other
+
+- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
+
 ## [0.18.1](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.0...lychee-lib-v0.18.1) - 2025-02-06
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `lychee`: 0.18.1 -> 0.18.2
* `lychee-lib`: 0.18.1 -> 0.18.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee`

<blockquote>

## [0.18.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.1...lychee-v0.18.2) - 2025-02-24

### Other

- Format Markdown URLs with `<>` instead of `[]()` ([#1638](https://github.com/lycheeverse/lychee/pull/1638))
- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
- add tests for URL extraction ending with a period (#1641)
- renamed `base` to `base_url` (fixes [#1607](https://github.com/lycheeverse/lychee/pull/1607)) ([#1629](https://github.com/lycheeverse/lychee/pull/1629))
- Sort compact/detailed/markdown error output by file path ([#1622](https://github.com/lycheeverse/lychee/pull/1622))
</blockquote>

## `lychee-lib`

<blockquote>

## [0.18.2](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.1...lychee-lib-v0.18.2) - 2025-02-24

### Other

- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).