### PR TITLE
format markdown URLs with <> instead of []() (#1636)

### DIFF
--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -67,9 +67,8 @@ fn stats_table(stats: &ResponseStats) -> String {
 /// Optional details get added if available.
 fn markdown_response(response: &ResponseBody) -> Result<String> {
     let mut formatted = format!(
-        "* [{}] [{}]({})",
+        "* [{}] <{}>",
         response.status.code_as_string(),
-        response.uri,
         response.uri,
     );
 

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -172,7 +172,7 @@ mod tests {
         let markdown = markdown_response(&response).unwrap();
         assert_eq!(
             markdown,
-            "* [200] [http://example.com/](http://example.com/)"
+            "* [200] <http://example.com/>"
         );
     }
 
@@ -185,7 +185,7 @@ mod tests {
         let markdown = markdown_response(&response).unwrap();
         assert_eq!(
             markdown,
-            "* [200] [http://example.com/](http://example.com/) | OK (cached)"
+            "* [200] <http://example.com/> | OK (cached)"
         );
     }
 
@@ -198,7 +198,7 @@ mod tests {
         let markdown = markdown_response(&response).unwrap();
         assert_eq!(
             markdown,
-            "* [400] [http://example.com/](http://example.com/) | Error (cached)"
+            "* [400] <http://example.com/> | Error (cached)"
         );
     }
 
@@ -252,7 +252,7 @@ mod tests {
 
 ### Errors in stdin
 
-* [404] [http://127.0.0.1/](http://127.0.0.1/) | Error (cached)
+* [404] <http://127.0.0.1/> | Error (cached)
 
 ## Suggestions per input
 

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -170,10 +170,7 @@ mod tests {
             status: Status::Ok(StatusCode::OK),
         };
         let markdown = markdown_response(&response).unwrap();
-        assert_eq!(
-            markdown,
-            "* [200] <http://example.com/>"
-        );
+        assert_eq!(markdown, "* [200] <http://example.com/>");
     }
 
     #[test]
@@ -183,10 +180,7 @@ mod tests {
             status: Status::Cached(CacheStatus::Ok(200)),
         };
         let markdown = markdown_response(&response).unwrap();
-        assert_eq!(
-            markdown,
-            "* [200] <http://example.com/> | OK (cached)"
-        );
+        assert_eq!(markdown, "* [200] <http://example.com/> | OK (cached)");
     }
 
     #[test]
@@ -196,10 +190,7 @@ mod tests {
             status: Status::Cached(CacheStatus::Error(Some(400))),
         };
         let markdown = markdown_response(&response).unwrap();
-        assert_eq!(
-            markdown,
-            "* [400] <http://example.com/> | Error (cached)"
-        );
+        assert_eq!(markdown, "* [400] <http://example.com/> | Error (cached)");
     }
 
     #[test]


### PR DESCRIPTION
Changes formatting of URLs in markdown output so it works well with GitHub Actions output (#1636, https://github.com/lycheeverse/lychee-action/issues/271)