### PR TITLE
Release the macOS binaries also as `.tar.gz`

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -123,13 +123,23 @@ jobs:
           hdiutil create -fs HFS+ -srcfolder dmg -volname lychee lychee.dmg
           tar -czvf lychee.tar.gz -C dmg/ lychee
 
-      - name: Upload binary
+      - name: Upload .dmg
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           asset_name: lychee-arm64-macos.dmg
           asset_path: target/release/lychee.dmg
+          upload_url: ${{needs.prepare.outputs.upload_url}}
+          asset_content_type: application/octet-stream
+
+      - name: Upload .tar.gz
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          asset_name: lychee-arm64-macos.tar.gz
+          asset_path: target/release/lychee.tar.gz
           upload_url: ${{needs.prepare.outputs.upload_url}}
           asset_content_type: application/octet-stream
 

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -121,6 +121,7 @@ jobs:
           mkdir dmg
           mv lychee dmg/
           hdiutil create -fs HFS+ -srcfolder dmg -volname lychee lychee.dmg
+          tar -czvf lychee.tar.gz -C dmg/ lychee
 
       - name: Upload binary
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
I tried to install Lychee with [Ubi](https://github.com/houseabsolute/ubi) through [Mise](https://mise.jdx.dev), and it fails in macOS because `ubi expects the binaries to be in a compressed file, and that's not the case for the macOS binaries.

This PR fixes that by also including the a `.tar.gz` version for the macOS binary.