### PR TITLE
Refactor input dumping and path retrieval with extension filtering

### DIFF
--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -1,7 +1,6 @@
 use log::error;
 use lychee_lib::Request;
 use lychee_lib::Result;
-use lychee_lib::filter::PathExcludes;
 use std::fs;
 use std::io::{self, Write};
 use tokio_stream::StreamExt;

--- a/lychee-bin/src/commands/dump.rs
+++ b/lychee-bin/src/commands/dump.rs
@@ -4,31 +4,12 @@ use lychee_lib::Result;
 use lychee_lib::filter::PathExcludes;
 use std::fs;
 use std::io::{self, Write};
-use std::path::PathBuf;
 use tokio_stream::StreamExt;
 
 use crate::ExitCode;
 use crate::verbosity::Verbosity;
 
 use super::CommandParams;
-
-// Helper function to create an output writer.
-//
-// If the output file is not specified, it will use `stdout`.
-//
-// # Errors
-//
-// If the output file cannot be opened, an error is returned.
-fn create_writer(output: Option<PathBuf>) -> Result<Box<dyn Write>> {
-    let out = if let Some(output) = output {
-        let out = fs::OpenOptions::new().append(true).open(output)?;
-        Box::new(out) as Box<dyn Write>
-    } else {
-        let out = io::stdout();
-        Box::new(out.lock()) as Box<dyn Write>
-    };
-    Ok(out)
-}
 
 /// Dump all detected links to stdout without checking them
 pub(crate) async fn dump<S>(params: CommandParams<S>) -> Result<ExitCode>
@@ -42,7 +23,7 @@ where
         fs::File::create(out_file)?;
     }
 
-    let mut writer = create_writer(params.cfg.output)?;
+    let mut writer = super::create_writer(params.cfg.output)?;
 
     while let Some(request) = requests.next().await {
         let mut request = request?;
@@ -66,36 +47,6 @@ where
                 return Ok(ExitCode::UnexpectedFailure);
             }
         }
-    }
-
-    Ok(ExitCode::Success)
-}
-
-/// Dump all input sources to stdout without extracting any links and checking
-/// them.
-pub(crate) async fn dump_inputs<S>(
-    sources: S,
-    output: Option<&PathBuf>,
-    excluded_paths: &PathExcludes,
-) -> Result<ExitCode>
-where
-    S: futures::Stream<Item = Result<String>>,
-{
-    if let Some(out_file) = output {
-        fs::File::create(out_file)?;
-    }
-
-    let mut writer = create_writer(output.cloned())?;
-
-    tokio::pin!(sources);
-    while let Some(source) = sources.next().await {
-        let source = source?;
-
-        if excluded_paths.is_match(&source) {
-            continue;
-        }
-
-        writeln!(writer, "{source}")?;
     }
 
     Ok(ExitCode::Success)
@@ -133,98 +84,4 @@ fn write(
 
 fn write_out(writer: &mut Box<dyn Write>, out_str: &str) -> io::Result<()> {
     writeln!(writer, "{out_str}")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures::stream;
-    use tempfile::NamedTempFile;
-
-    #[tokio::test]
-    async fn test_dump_inputs_basic() -> Result<()> {
-        // Create temp file for output
-        let temp_file = NamedTempFile::new()?;
-        let output_path = temp_file.path().to_path_buf();
-
-        // Create test input stream
-        let inputs = vec![
-            Ok(String::from("test/path1")),
-            Ok(String::from("test/path2")),
-            Ok(String::from("test/path3")),
-        ];
-        let stream = stream::iter(inputs);
-
-        // Run dump_inputs
-        let result = dump_inputs(stream, Some(&output_path), &PathExcludes::empty()).await?;
-        assert_eq!(result, ExitCode::Success);
-
-        // Verify output
-        let contents = fs::read_to_string(&output_path)?;
-        assert_eq!(contents, "test/path1\ntest/path2\ntest/path3\n");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dump_inputs_with_excluded_paths() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let output_path = temp_file.path().to_path_buf();
-
-        let inputs = vec![
-            Ok(String::from("test/path1")),
-            Ok(String::from("excluded/path")),
-            Ok(String::from("test/path2")),
-        ];
-        let stream = stream::iter(inputs);
-
-        let excluded = &PathExcludes::new(["excluded"]).unwrap();
-        let result = dump_inputs(stream, Some(&output_path), excluded).await?;
-        assert_eq!(result, ExitCode::Success);
-
-        let contents = fs::read_to_string(&output_path)?;
-        assert_eq!(contents, "test/path1\ntest/path2\n");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dump_inputs_empty_stream() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let output_path = temp_file.path().to_path_buf();
-
-        let stream = stream::iter::<Vec<Result<String>>>(vec![]);
-        let result = dump_inputs(stream, Some(&output_path), &PathExcludes::empty()).await?;
-        assert_eq!(result, ExitCode::Success);
-
-        let contents = fs::read_to_string(&output_path)?;
-        assert_eq!(contents, "");
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dump_inputs_error_in_stream() -> Result<()> {
-        let temp_file = NamedTempFile::new()?;
-        let output_path = temp_file.path().to_path_buf();
-
-        let inputs: Vec<Result<String>> = vec![
-            Ok(String::from("test/path1")),
-            Err(io::Error::other("test error").into()),
-            Ok(String::from("test/path2")),
-        ];
-        let stream = stream::iter(inputs);
-
-        let result = dump_inputs(stream, Some(&output_path), &PathExcludes::empty()).await;
-        assert!(result.is_err());
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_dump_inputs_to_stdout() -> Result<()> {
-        // When output path is None, should write to stdout
-        let inputs = vec![Ok(String::from("test/path1"))];
-        let stream = stream::iter(inputs);
-
-        let result = dump_inputs(stream, None, &PathExcludes::empty()).await?;
-        assert_eq!(result, ExitCode::Success);
-        Ok(())
-    }
 }

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -31,7 +31,7 @@ pub(crate) async fn dump_inputs(
 
     // Collect all sources with deduplication
     let mut seen_sources = HashSet::new();
-    
+
     for input in inputs {
         let sources_stream = input.get_sources(
             valid_extensions.clone(),

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -29,6 +29,9 @@ pub(crate) async fn dump_inputs(
     // Create the path filter once outside the loop for better performance
     let excluded_path_filter = lychee_lib::filter::PathExcludes::new(excluded_paths)?;
 
+    // Collect all sources with deduplication
+    let mut seen_sources = HashSet::new();
+    
     for input in inputs {
         let sources_stream = input.get_sources(
             valid_extensions.clone(),
@@ -40,7 +43,10 @@ pub(crate) async fn dump_inputs(
 
         while let Some(source_result) = sources_stream.next().await {
             let source = source_result?;
-            write_out(&mut writer, &source)?;
+            // Only print if we haven't seen this source before
+            if seen_sources.insert(source.clone()) {
+                write_out(&mut writer, &source)?;
+            }
         }
     }
 

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -1,4 +1,5 @@
 use lychee_lib::{FileExtensions, Input, Result};
+use std::collections::HashSet;
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ use crate::ExitCode;
 /// by lychee, including file paths, URLs, and special sources like stdin.
 /// It respects file extension filtering and path exclusions.
 pub(crate) async fn dump_inputs(
-    inputs: Vec<Input>,
+    inputs: HashSet<Input>,
     output: Option<&PathBuf>,
     excluded_paths: &[String],
     valid_extensions: &FileExtensions,

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -24,7 +24,7 @@ pub(crate) async fn dump_inputs(
     }
 
     let mut writer = super::create_writer(output.cloned())?;
-    
+
     // Create the path filter once outside the loop for better performance
     let excluded_path_filter = lychee_lib::filter::PathExcludes::new(excluded_paths)?;
 
@@ -33,7 +33,7 @@ pub(crate) async fn dump_inputs(
             valid_extensions.clone(),
             skip_hidden,
             skip_gitignored,
-            excluded_path_filter.clone(),
+            &excluded_path_filter,
         );
         tokio::pin!(sources_stream);
 

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -1,0 +1,53 @@
+use lychee_lib::{FileExtensions, Input, Result};
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use tokio_stream::StreamExt;
+
+use crate::ExitCode;
+
+/// Dump all input sources to stdout without extracting any links and checking
+/// them.
+///
+/// Uses the Input handler to properly handle different input sources and respect
+/// file extension filtering.
+pub(crate) async fn dump_inputs(
+    inputs: Vec<Input>,
+    output: Option<&PathBuf>,
+    excluded_paths: &[PathBuf],
+    valid_extensions: &FileExtensions,
+    skip_hidden: bool,
+    skip_gitignored: bool,
+) -> Result<ExitCode> {
+    if let Some(out_file) = output {
+        fs::File::create(out_file)?;
+    }
+
+    let mut writer = super::create_writer(output.cloned())?;
+
+    for input in inputs {
+        let paths_stream =
+            input.get_file_paths(valid_extensions.clone(), skip_hidden, skip_gitignored);
+        tokio::pin!(paths_stream);
+
+        while let Some(path_result) = paths_stream.next().await {
+            let path = path_result?;
+
+            // Skip excluded paths
+            if excluded_paths
+                .iter()
+                .any(|excluded| path.starts_with(excluded))
+            {
+                continue;
+            }
+
+            write_out(&mut writer, &path.to_string_lossy())?;
+        }
+    }
+
+    Ok(ExitCode::Success)
+}
+
+fn write_out(writer: &mut Box<dyn Write>, out_str: &str) -> io::Result<()> {
+    writeln!(writer, "{out_str}")
+}

--- a/lychee-bin/src/commands/mod.rs
+++ b/lychee-bin/src/commands/mod.rs
@@ -1,10 +1,14 @@
 pub(crate) mod check;
 pub(crate) mod dump;
+pub(crate) mod dump_inputs;
 
 pub(crate) use check::check;
 pub(crate) use dump::dump;
-pub(crate) use dump::dump_inputs;
+pub(crate) use dump_inputs::dump_inputs;
 
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::cache::Cache;
@@ -18,4 +22,16 @@ pub(crate) struct CommandParams<S: futures::Stream<Item = Result<Request>>> {
     pub(crate) cache: Arc<Cache>,
     pub(crate) requests: S,
     pub(crate) cfg: Config,
+}
+
+/// Creates a writer that outputs to a file or stdout.
+///
+/// # Errors
+///
+/// Returns an error if the output file cannot be opened.
+fn create_writer(output: Option<PathBuf>) -> Result<Box<dyn Write>> {
+    Ok(match output {
+        Some(path) => Box::new(fs::OpenOptions::new().append(true).open(path)?),
+        None => Box::new(io::stdout().lock()),
+    })
 }

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -316,6 +316,20 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         }
     };
 
+    if opts.config.dump_inputs {
+        let exit_code = commands::dump_inputs(
+            inputs,
+            opts.config.output.as_ref(),
+            &opts.config.exclude_path,
+            &opts.config.extensions,
+            !opts.config.hidden,
+            opts.config.no_ignore,
+        )
+        .await?;
+
+        return Ok(exit_code as i32);
+    }
+
     let mut collector = Collector::new(opts.config.root_dir.clone(), base)?
         .skip_missing_inputs(opts.config.skip_missing)
         .skip_hidden(!opts.config.hidden)
@@ -325,19 +339,6 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         .excluded_paths(PathExcludes::new(opts.config.exclude_path.clone())?)
         // File a bug if you rely on this envvar! It's going to go away eventually.
         .use_html5ever(std::env::var("LYCHEE_USE_HTML5EVER").is_ok_and(|x| x == "1"));
-
-    if opts.config.dump_inputs {
-        let sources = collector.collect_sources(inputs);
-        let exit_code = commands::dump_inputs(
-            sources,
-            opts.config.output.as_ref(),
-            &PathExcludes::new(&opts.config.exclude_path)?,
-        )
-        .await?;
-
-        return Ok(exit_code as i32);
-    }
-
     collector = if let Some(ref basic_auth) = opts.config.basic_auth {
         collector.basic_auth_extractor(BasicAuthExtractor::new(basic_auth)?)
     } else {

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1844,7 +1844,6 @@ mod cli {
             .stdout(contains("fixtures/dump_inputs/subfolder/file2.md"))
             .stdout(contains("fixtures/dump_inputs/subfolder"))
             .stdout(contains("fixtures/dump_inputs/markdown.md"))
-            .stdout(contains("fixtures/dump_inputs/subfolder/example.bin"))
             .stdout(contains("fixtures/dump_inputs/some_file.txt"));
 
         Ok(())
@@ -1899,7 +1898,7 @@ mod cli {
             .arg("-")
             .assert()
             .success()
-            .stdout(contains("Stdin"));
+            .stdout(contains("stdin"));
 
         Ok(())
     }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -79,6 +79,12 @@ mod cli {
         root_path().join("fixtures")
     }
 
+    /// Helper function to convert a relative path to an absolute path string
+    /// starting from a base directory.
+    fn path_str(base: &Path, relative_path: &str) -> String {
+        base.join(relative_path).to_string_lossy().to_string()
+    }
+
     #[derive(Default, Serialize)]
     struct MockResponseStats {
         detailed_stats: bool,
@@ -1911,26 +1917,14 @@ mod cli {
 
         let base_path = fixtures_path().join("dump_inputs");
         let mut expected_lines = vec![
-            base_path
-                .join("some_file.txt")
-                .to_string_lossy()
-                .to_string(),
-            base_path
-                .join("subfolder")
-                .join("file2.md")
-                .to_string_lossy()
-                .to_string(),
-            base_path
-                .join("subfolder")
-                .join("test.html")
-                .to_string_lossy()
-                .to_string(),
-            base_path.join("markdown.md").to_string_lossy().to_string(),
+            path_str(&base_path, "some_file.txt"),
+            path_str(&base_path, "subfolder/file2.md"),
+            path_str(&base_path, "subfolder/test.html"),
+            path_str(&base_path, "markdown.md"),
         ];
         expected_lines.sort();
 
         assert_eq!(actual_lines, expected_lines);
-
         Ok(())
     }
 
@@ -1960,16 +1954,9 @@ mod cli {
 
         let base_path = fixtures_path().join("dump_inputs");
         let mut expected_lines = vec![
-            base_path
-                .join("some_file.txt")
-                .to_string_lossy()
-                .to_string(),
-            base_path
-                .join("subfolder")
-                .join("file2.md")
-                .to_string_lossy()
-                .to_string(),
-            base_path.join("markdown.md").to_string_lossy().to_string(),
+            path_str(&base_path, "some_file.txt"),
+            path_str(&base_path, "subfolder/file2.md"),
+            path_str(&base_path, "markdown.md"),
         ];
         expected_lines.sort();
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1905,13 +1905,71 @@ mod cli {
     // Ensures that dumping stdin does not panic and results in an empty output
     // as `stdin` is not a path
     #[test]
+    fn test_dump_inputs_with_extensions() -> Result<()> {
+        let mut cmd = main_command();
+        let test_dir = fixtures_path().join("dump_inputs");
+
+        cmd.arg("--dump-inputs")
+            .arg("--extensions")
+            .arg("md,txt")
+            .arg(test_dir)
+            .assert()
+            .success()
+            .stdout(contains("markdown.md"))
+            .stdout(contains("some_file.txt"))
+            .stdout(contains("subfolder/file2.md"))
+            .stdout(contains("example.bin").not()); // Should be excluded
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_dump_inputs_skip_hidden() -> Result<()> {
+        let test_dir = fixtures_path().join("hidden");
+
+        // Test default behavior (skip hidden)
+        main_command()
+            .arg("--dump-inputs")
+            .arg(&test_dir)
+            .assert()
+            .success()
+            .stdout(is_empty());
+
+        // Test with --hidden flag
+        main_command()
+            .arg("--dump-inputs")
+            .arg("--hidden")
+            .arg(test_dir)
+            .assert()
+            .success()
+            .stdout(contains(".hidden"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_dump_inputs_individual_file() -> Result<()> {
+        let mut cmd = main_command();
+        let test_file = fixtures_path().join("TEST.md");
+
+        cmd.arg("--dump-inputs")
+            .arg(&test_file)
+            .assert()
+            .success()
+            .stdout(contains("TEST.md"));
+
+        Ok(())
+    }
+
+    #[test]
     fn test_dump_inputs_stdin() -> Result<()> {
         let mut cmd = main_command();
+
         cmd.arg("--dump-inputs")
             .arg("-")
             .assert()
             .success()
-            .stdout(is_empty());
+            .stdout(contains("<stdin>"));
 
         Ok(())
     }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1993,7 +1993,7 @@ mod cli {
             .arg(test_dir)
             .assert()
             .success()
-            .stdout(contains(".hidden"));
+            .stdout(contains(".hidden/file.md"));
 
         Ok(())
     }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -2007,7 +2007,7 @@ mod cli {
             .arg(&test_file)
             .assert()
             .success()
-            .stdout(contains("TEST.md"));
+            .stdout(contains("fixtures/TEST.md"));
 
         Ok(())
     }

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -154,7 +154,6 @@ impl Collector {
         self.excluded_paths = excluded_paths;
         self
     }
-
     /// Collect all sources from a list of [`Input`]s. For further details,
     /// see also [`Input::get_sources`](crate::Input#method.get_sources).
     pub fn collect_sources(self, inputs: HashSet<Input>) -> impl Stream<Item = Result<String>> {
@@ -177,7 +176,6 @@ impl Collector {
                 }
             })
     }
-
     /// Convenience method to fetch all unique links from inputs
     /// with the default extensions.
     pub fn collect_links(self, inputs: HashSet<Input>) -> impl Stream<Item = Result<Request>> {

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -180,8 +180,8 @@ impl Collector {
                     let inputs = [input];
                     let mut result = Vec::new();
 
-                    for inp in inputs {
-                        let sources_stream = inp.get_input_sources(
+                    for input in inputs {
+                        let sources_stream = input.get_input_sources(
                             file_extensions.clone(),
                             skip_hidden,
                             skip_ignored,

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -223,24 +223,21 @@ mod tests {
 
     #[test]
     fn test_extension() {
-        assert_eq!(FileType::from(Path::new("foo.md")), FileType::Markdown);
-        assert_eq!(FileType::from(Path::new("foo.MD")), FileType::Markdown);
-        assert_eq!(FileType::from(Path::new("foo.mdx")), FileType::Markdown);
+        assert_eq!(FileType::from("foo.md"), FileType::Markdown);
+        assert_eq!(FileType::from("foo.MD"), FileType::Markdown);
+        assert_eq!(FileType::from("foo.mdx"), FileType::Markdown);
 
-        assert_eq!(
-            FileType::from(Path::new("test.unknown")),
-            FileType::Plaintext
-        );
-        assert_eq!(FileType::from(Path::new("test")), FileType::Plaintext);
-        assert_eq!(FileType::from(Path::new("test.txt")), FileType::Plaintext);
-        assert_eq!(FileType::from(Path::new("README.TXT")), FileType::Plaintext);
+        // Test that a file without an extension is considered plaintext
+        assert_eq!(FileType::from("README"), FileType::Plaintext);
+        assert_eq!(FileType::from("test"), FileType::Plaintext);
 
-        assert_eq!(FileType::from(Path::new("test.htm")), FileType::Html);
-        assert_eq!(FileType::from(Path::new("index.html")), FileType::Html);
-        assert_eq!(
-            FileType::from(Path::new("http://foo.com/index.html")),
-            FileType::Html
-        );
+        assert_eq!(FileType::from("test.unknown"), FileType::Plaintext);
+        assert_eq!(FileType::from("test.txt"), FileType::Plaintext);
+        assert_eq!(FileType::from("README.TXT"), FileType::Plaintext);
+
+        assert_eq!(FileType::from("test.htm"), FileType::Html);
+        assert_eq!(FileType::from("index.html"), FileType::Html);
+        assert_eq!(FileType::from("http://foo.com/index.html"), FileType::Html);
     }
 
     #[test]

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -233,9 +233,10 @@ impl Input {
     ) -> impl Stream<Item = Result<PathBuf>> + '_ {
         try_stream! {
             match &self.source {
-                InputSource::RemoteUrl(url) => {
-                    // For URLs, we just yield the URL string as a path
-                    yield PathBuf::from(url.to_string());
+                InputSource::RemoteUrl(_url) => {
+                    // Skip remote URLs when collecting file paths.
+                    // Converting a URL to a `PathBuf` can be misleading.
+                    // This behavior may be revisited in the future if the need arises.
                 },
                 InputSource::FsGlob { pattern, ignore_case } => {
                     // For glob patterns, we expand the pattern and yield matching paths

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -212,8 +212,11 @@ impl Input {
 
     /// Get all file paths matching this input source.
     ///
-    /// This method returns a stream of paths that match the input source,
-    /// taking into account file extensions and exclusions.
+    /// This method returns a stream of paths from the input source, taking into
+    /// account the matching file extensions and respecting exclusions.
+    ///
+    /// This can be used for retrieving all inputs which lychee would check for
+    /// links.
     ///
     /// # Parameters
     ///
@@ -221,7 +224,7 @@ impl Input {
     ///
     /// # Returns
     ///
-    /// Returns a stream of Result<PathBuf> for all matching file paths.
+    /// Returns a stream of `Result<PathBuf>` for all matching file paths.
     ///
     /// # Errors
     ///
@@ -304,14 +307,9 @@ impl Input {
                         }
                     }
                 },
-                InputSource::Stdin => {
-                    // Stdin is handled specially - we yield a marker path
-                    yield PathBuf::from("stdin");
-                },
-                InputSource::String(_) => {
-                    // For raw strings, we yield a marker path
-                    yield PathBuf::from("string");
-                },
+                InputSource::Stdin | InputSource::String(_) => {
+                    // Skip `stdin` and strings as they are not valid file paths
+                }
             }
         }
     }
@@ -370,12 +368,6 @@ impl Input {
             while let Some(path_result) = paths_stream.next().await {
                 match path_result {
                     Ok(path) => {
-                        // Handle special marker paths
-                        let path_str = path.to_string_lossy();
-                        if path_str == "stdin" || path_str == "string" {
-                            continue;
-                        }
-
                         // Process the actual file path
                         let content = Self::path_content(&path).await;
                         match content {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -218,10 +218,6 @@ impl Input {
     /// This can be used for retrieving all inputs which lychee would check for
     /// links.
     ///
-    /// # Parameters
-    ///
-    /// * `file_extensions` - The file extensions to filter on
-    ///
     /// # Returns
     ///
     /// Returns a stream of `Result<PathBuf>` for all matching file paths.

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -212,7 +212,7 @@ impl Input {
 
     /// Get all input sources for content processing.
     ///
-    /// This method returns a stream of input sources from the input source, taking into
+    /// This method returns a stream of input sources for the given input, taking into
     /// account the matching file extensions and respecting exclusions.
     ///
     /// This can be used for retrieving all inputs which lychee would check for

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -435,7 +435,7 @@ impl Input {
         file_extensions: FileExtensions,
         skip_hidden: bool,
         skip_gitignored: bool,
-        excluded_paths: PathExcludes,
+        excluded_paths: &PathExcludes,
     ) -> impl Stream<Item = Result<String>> {
         try_stream! {
             match self.source {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -391,8 +391,7 @@ impl Input {
                                 yield content;
                             },
                             InputSource::FsGlob { .. } => {
-                                // This shouldn't happen as get_file_paths expands globs
-                                continue;
+                                // This shouldn't happen as `get_input_sources` expands the glob patterns
                             }
                         }
                     },

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -262,7 +262,6 @@ impl Input {
                             }
                             Err(e) => {
                                 eprintln!("Error in glob pattern: {e:?}");
-                                continue;
                             }
                         }
                     }
@@ -391,7 +390,7 @@ impl Input {
                         // Process the actual file path
                         let content = Self::path_content(&path).await;
                         match content {
-                            Err(_) if skip_missing => continue,
+                            Err(_) if skip_missing => (),
                             Err(e) => Err(e)?,
                             Ok(content) => yield content,
                         }
@@ -491,7 +490,8 @@ impl TryFrom<&str> for Input {
 /// Helper function to check if a file path matches any of the given extensions
 fn file_extensions_match(path: &Path, extensions: &FileExtensions) -> bool {
     // If the path has no extension, check if we accept plaintext files
-    // Note: We treat files without extensions as plaintext
+    // NOTE: We treat files without extensions as plaintext, which might be problematic
+    // and is therefore subject to change
     if path.extension().is_none() {
         return extensions.contains("txt") || extensions.contains("");
     }

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -270,16 +270,8 @@ impl Input {
                     if path.is_dir() {
 
                         for entry in WalkBuilder::new(path)
-                            // Enable or disable standard filters based on skip_gitignored parameter.
-                            // This controls:
-                            // - Hidden files/directories (skip files starting with '.')
-                            // - Parent directory gitignore rules
-                            // - .ignore files
-                            // - .gitignore files
-                            // - Global git ignore files
-                            // - .git/info/exclude files
-                            // When skip_gitignored is true, these filters are enabled (files will be skipped).
-                            // When skip_gitignored is false, these filters are disabled (all files will be included).
+                            // Enable standard filters if skip_gitignored is true.
+                            // This will skip files ignored by .gitignore and other VCS ignore files.
                             .standard_filters(skip_gitignored)
 
                             // Override hidden file behavior to be controlled by the separate skip_hidden parameter

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -450,7 +450,7 @@ impl Input {
                     for entry in glob_with(&glob_expanded, match_opts)? {
                         match entry {
                             Ok(path) => {
-                                if !Self::is_excluded_path(&path, &excluded_paths) {
+                                if !Self::is_excluded_path(&path, excluded_paths) {
                                     yield path.to_string_lossy().to_string();
                                 }
                             },
@@ -467,14 +467,14 @@ impl Input {
                             skip_gitignored,
                         )? {
                             let entry = entry?;
-                            if !Self::is_excluded_path(entry.path(), &excluded_paths) {
+                            if !Self::is_excluded_path(entry.path(), excluded_paths) {
                                 // Only yield files, not directories
                                 if entry.file_type().is_some_and(|ft| ft.is_file()) {
                                     yield entry.path().to_string_lossy().to_string();
                                 }
                             }
                         }
-                    } else if !Self::is_excluded_path(path, &excluded_paths) {
+                    } else if !Self::is_excluded_path(path, excluded_paths) {
                         yield path.to_string_lossy().to_string();
                     }
                 }

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -391,7 +391,7 @@ impl Input {
                                 yield content;
                             },
                             InputSource::FsGlob { .. } => {
-                                // This shouldn't happen as `get_input_sources` expands the glob patterns
+                                unreachable!("This shouldn't happen as `get_input_sources` expands the glob patterns");
                             }
                         }
                     },

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -210,9 +210,9 @@ impl Input {
         }
     }
 
-    /// Get all file paths matching this input source.
+    /// Get all input sources for content processing.
     ///
-    /// This method returns a stream of paths from the input source, taking into
+    /// This method returns a stream of input sources from the input source, taking into
     /// account the matching file extensions and respecting exclusions.
     ///
     /// This can be used for retrieving all inputs which lychee would check for
@@ -220,12 +220,12 @@ impl Input {
     ///
     /// # Returns
     ///
-    /// Returns a stream of `Result<PathBuf>` for all matching file paths.
+    /// Returns a stream of `Result<InputSource>` for all matching input sources.
     ///
     /// # Errors
     ///
     /// Will return errors for file system operations or glob pattern issues
-    pub fn get_file_paths<'a>(
+    pub fn get_input_sources<'a>(
         &'a self,
         file_extensions: FileExtensions,
         skip_hidden: bool,
@@ -357,9 +357,9 @@ impl Input {
             }
 
             // Handle FsPath and FsGlob sources
-            // We can use `get_file_paths` to get the input sources, which will handle
+            // We can use `get_input_sources` to get the input sources, which will handle
             // filtering by file extensions and exclusions
-            let mut sources_stream = Box::pin(self.get_file_paths(file_extensions, skip_hidden, skip_gitignored, &excluded_paths));
+            let mut sources_stream = Box::pin(self.get_input_sources(file_extensions, skip_hidden, skip_gitignored, &excluded_paths));
 
             while let Some(source_result) = sources_stream.next().await {
                 match source_result {

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -268,10 +268,7 @@ impl Input {
                 },
                 InputSource::FsPath(path) => {
                     if path.is_dir() {
-                        // For directories, we walk through and yield matching files
-                        println!("Walking through directory: {}", path.display());
 
-                        // In the get_file_paths method:
                         for entry in WalkBuilder::new(path)
                             // Enable or disable standard filters based on skip_gitignored parameter.
                             // This controls:


### PR DESCRIPTION
Refactor the `dump-inputs` functionality to print all files checked for links and implement file path retrieval with extension filtering in the `Input` module.

I added this because it was hard to troubleshoot the extension changes, but I figured it would also be helpful to people who want to see which files would be checked when they write `lychee .`.

As an added benefit, `dump-inputs` now behaves more like the `check` command and properly ignores hidden files etc.

This is a follow-up to #1559.
Closes #1767.