### PR TITLE
Fix: outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -754,7 +754,7 @@ If you are using lychee for your project, **please add it here**.
 ## Credits
 
 The first prototype of lychee was built in [episode 10 of Hello
-Rust](https://hello-rust.show/10/). Thanks to all GitHub and Patreon sponsors
+Rust](https://hello-rust.github.io/10/). Thanks to all GitHub and Patreon sponsors
 for supporting the development since the beginning. Also, thanks to all the
 great contributors who have since made this project more mature.
 


### PR DESCRIPTION
This PR updates the URL from https://hello-rust.show/10/ to https://hello-rust.github.io/10/ 
The `hello-rust.show` domain is no longer valid. 