### PR TITLE
Add possible values for minimum TLS version in help message

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,8 @@ Options:
       --min-tls <MIN_TLS>
           Minimum accepted TLS Version
 
+          [possible values: TLSv1_0, TLSv1_1, TLSv1_2, TLSv1_3]
+
       --max-concurrency <MAX_CONCURRENCY>
           Maximum number of concurrent network requests
 

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -47,7 +47,7 @@ const HELP_MSG_CONFIG_FILE: &str = formatcp!(
 const TIMEOUT_STR: &str = concatcp!(DEFAULT_TIMEOUT_SECS);
 const RETRY_WAIT_TIME_STR: &str = concatcp!(DEFAULT_RETRY_WAIT_TIME_SECS);
 
-#[derive(Debug, Display, Deserialize, Default, Clone, EnumString)]
+#[derive(Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString, VariantNames)]
 #[non_exhaustive]
 pub(crate) enum TlsVersion {
     #[serde(rename = "TLSv1_0")]
@@ -349,7 +349,7 @@ and 501."
     pub(crate) max_retries: u64,
 
     /// Minimum accepted TLS Version
-    #[arg(long)]
+    #[arg(long, value_parser = PossibleValuesParser::new(TlsVersion::VARIANTS).map(|s| s.parse::<TlsVersion>().unwrap()))]
     #[serde(default)]
     pub(crate) min_tls: Option<TlsVersion>,
 


### PR DESCRIPTION
This makes the output a bit nicer by providing a list of possible values:

```sh
❯❯❯ lychee --min-tls=TLSv1_4 
error: invalid value 'TLSv1_4' for '--min-tls <MIN_TLS>'
  [possible values: TLSv1_0, TLSv1_1, TLSv1_2, TLSv1_3]

  tip: a similar value exists: 'TLSv1_3'

For more information, try '--help'.
```

Follow up of https://github.com/lycheeverse/lychee/pull/1655