### PR TITLE
fix: ignore gitlab table of content in wikilinks

### DIFF
--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -429,8 +429,7 @@ $$
     #[test]
     fn test_ignore_gitlab_toc() {
         let markdown = r"[[_TOC_]][TOC]";
-        let expected = vec![];
         let uris = extract_markdown(markdown, true);
-        assert_eq!(uris, expected);
+        assert!(uris.is_empty());
     }
 }

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -65,6 +65,10 @@ pub(crate) fn extract_markdown(input: &str, include_verbatim: bool) -> Vec<RawUr
                     // Wiki URL (`[[http://example.com]]`)
                     LinkType::WikiLink { has_pothole: _ } => {
                         inside_link_block = true;
+                        //Ignore gitlab toc notation: https://docs.gitlab.com/user/markdown/#table-of-contents
+                        if ["_TOC_".to_string(), "TOC".to_string()].contains(&dest_url.to_string()) {
+                            return None;
+                        }
                         Some(vec![RawUri {
                             text: dest_url.to_string(),
                             element: Some("a".to_string()),
@@ -418,6 +422,14 @@ $$
                 attribute: Some("href".to_string()),
             },
         ];
+        let uris = extract_markdown(markdown, true);
+        assert_eq!(uris, expected);
+    }
+
+    #[test]
+    fn test_ignore_gitlab_toc() {
+        let markdown = r"[[_TOC_]][TOC]";
+        let expected = vec![];
         let uris = extract_markdown(markdown, true);
         assert_eq!(uris, expected);
     }


### PR DESCRIPTION
fixes #1708