### PR TITLE
fix: only check the fragment when it's a file

### DIFF
--- a/fixtures/fragments/file1.md
+++ b/fixtures/fragments/file1.md
@@ -65,3 +65,5 @@ without related HTML element. Browser will scroll to the top of the page.
 ##### Lets wear a hat: être
 
 A link to the non-existing fragment: [try](https://github.com/lycheeverse/lychee#non-existent-anchor).
+
+Skip the fragment check for directories like: [empty](empty_dir/).

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1843,8 +1843,8 @@ mod cli {
             .stderr(contains(
                 "https://github.com/lycheeverse/lychee#non-existent-anchor",
             ))
-            .stdout(contains("27 Total"))
-            .stdout(contains("22 OK"))
+            .stdout(contains("28 Total"))
+            .stdout(contains("23 OK"))
             // 4 failures because of missing fragments
             .stdout(contains("5 Errors"));
     }

--- a/lychee-lib/src/checker/file.rs
+++ b/lychee-lib/src/checker/file.rs
@@ -123,7 +123,8 @@ impl FileChecker {
     ///
     /// Returns a `Status` indicating the result of the check.
     async fn check_existing_path(&self, path: &Path, uri: &Uri) -> Status {
-        if self.include_fragments {
+        // only files can contain content with fragments
+        if self.include_fragments && path.is_file() {
             self.check_fragment(path, uri).await
         } else {
             Status::Ok(StatusCode::OK)
@@ -175,12 +176,12 @@ impl FileChecker {
                 Ok(true) => Status::Ok(StatusCode::OK),
                 Ok(false) => ErrorKind::InvalidFragment(uri.clone()).into(),
                 Err(err) => {
-                    warn!("Skipping fragment check due to the following error: {err}");
+                    warn!("Skipping fragment check for {uri} due to the following error: {err}");
                     Status::Ok(StatusCode::OK)
                 }
             },
             Err(err) => {
-                warn!("Skipping fragment check due to the following error: {err}");
+                warn!("Skipping fragment check for {uri} due to the following error: {err}");
                 Status::Ok(StatusCode::OK)
             }
         }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -543,12 +543,12 @@ impl Client {
                 Ok(true) => Status::Ok(StatusCode::OK),
                 Ok(false) => ErrorKind::InvalidFragment(uri.clone()).into(),
                 Err(err) => {
-                    warn!("Skipping fragment check due to the following error: {err}");
+                    warn!("Skipping fragment check for {uri} due to the following error: {err}");
                     Status::Ok(StatusCode::OK)
                 }
             },
             Err(err) => {
-                warn!("Skipping fragment check due to the following error: {err}");
+                warn!("Skipping fragment check for {uri} due to the following error: {err}");
                 Status::Ok(StatusCode::OK)
             }
         }

--- a/lychee-lib/src/utils/fragment_checker.rs
+++ b/lychee-lib/src/utils/fragment_checker.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::{
     extract::{html::html5gum::extract_html_fragments, markdown::extract_markdown_fragments},
-    types::FileType,
+    types::{ErrorKind, FileType},
     Result,
 };
 use percent_encoding::percent_decode_str;
@@ -21,7 +21,9 @@ pub(crate) struct FragmentInput {
 
 impl FragmentInput {
     pub(crate) async fn from_path(path: &Path) -> Result<Self> {
-        let content = fs::read_to_string(path).await?;
+        let content = fs::read_to_string(path)
+            .await
+            .map_err(|err| ErrorKind::ReadFileInput(err, path.to_path_buf()))?;
         let file_type = FileType::from(path);
         Ok(Self { content, file_type })
     }


### PR DESCRIPTION
- related to https://github.com/lycheeverse/lychee/issues/1709

What's in this PR:

- only check fragments for files
- better err type
- more info in err msg

BTW, I'm not sure if the `Client.check_fragment` is used by any caller. cc @mre 