### PR TITLE
chore: release v0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,7 +2490,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.18.1"
+version = "0.19.0"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches"]
 resolver = "2"
 
 [workspace.package]
-version = "0.18.1"
+version = "0.19.0"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.1...lychee-v0.19.0) - 2025-06-11
+
+### Added
+
+- raise error when the default config file is invalid ([#1715](https://github.com/lycheeverse/lychee/pull/1715))
+- detect website fragments ([#1675](https://github.com/lycheeverse/lychee/pull/1675))
+
+### Fixed
+
+- only check the fragment when it's a file ([#1713](https://github.com/lycheeverse/lychee/pull/1713))
+
+### Other
+
+- Add cli test
+- Use StatusCodeSelector default as default accepted StatusCodes
+- Update tests
+- Remove duplicated information from output
+- Update test
+- Update test
+- Move archive functionality to library ([#1720](https://github.com/lycheeverse/lychee/pull/1720))
+- Bump the dependencies group across 1 directory with 3 updates ([#1714](https://github.com/lycheeverse/lychee/pull/1714))
+- Upgrade to 2024 edition ([#1711](https://github.com/lycheeverse/lychee/pull/1711))
+- Fix `test_exclude_example_domains` ([#1712](https://github.com/lycheeverse/lychee/pull/1712))
+- Add support for custom headers in input processing ([#1561](https://github.com/lycheeverse/lychee/pull/1561))
+- Fix lints ([#1705](https://github.com/lycheeverse/lychee/pull/1705))
+- Remove flag
+- Bump the dependencies group with 2 updates
+- Add possible values for minimum TLS version in help message ([#1693](https://github.com/lycheeverse/lychee/pull/1693))
+- Add TLS version option ([#1655](https://github.com/lycheeverse/lychee/pull/1655))
+- Bump the dependencies group across 1 directory with 11 updates ([#1692](https://github.com/lycheeverse/lychee/pull/1692))
+- Specify MSRV ([#1676](https://github.com/lycheeverse/lychee/pull/1676))
+- Fix outdated link
+- Remove once_cell as direct dependency
+- Make clippy happy ([#1681](https://github.com/lycheeverse/lychee/pull/1681))
+- Bump the dependencies group with 3 updates ([#1670](https://github.com/lycheeverse/lychee/pull/1670))
+- Fix accept/exclude range syntax and docs ([#1668](https://github.com/lycheeverse/lychee/pull/1668))
+- Add FreeBSD-Ask to users ([#1662](https://github.com/lycheeverse/lychee/pull/1662))
+- Bump the dependencies group with 4 updates ([#1664](https://github.com/lycheeverse/lychee/pull/1664))
+- Allow header values that contain equal signs ([#1647](https://github.com/lycheeverse/lychee/pull/1647))
+- Bump the dependencies group with 11 updates ([#1656](https://github.com/lycheeverse/lychee/pull/1656))
+- Bump the dependencies group across 1 directory with 14 updates ([#1653](https://github.com/lycheeverse/lychee/pull/1653))
+- Add support for custom file extensions in link checking. ([#1559](https://github.com/lycheeverse/lychee/pull/1559))
+- Format Markdown URLs with `<>` instead of `[]()` ([#1638](https://github.com/lycheeverse/lychee/pull/1638))
+- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
+- add tests for URL extraction ending with a period ([#1641](https://github.com/lycheeverse/lychee/pull/1641))
+- renamed `base` to `base_url` (fixes #1607) ([#1629](https://github.com/lycheeverse/lychee/pull/1629))
+- Sort compact/detailed/markdown error output by file path ([#1622](https://github.com/lycheeverse/lychee/pull/1622))
+
 ## [0.18.1](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.0...lychee-v0.18.1) - 2025-02-06
 
 ### Fixed

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.18.1", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.19.0", default-features = false }
 
 anyhow = "1.0.98"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.1...lychee-lib-v0.19.0) - 2025-06-11
+
+### Added
+
+- respect the `disabled` property for stylesheet links ([#1716](https://github.com/lycheeverse/lychee/pull/1716))
+- detect website fragments ([#1675](https://github.com/lycheeverse/lychee/pull/1675))
+
+### Fixed
+
+- only check the fragment when it's a file ([#1713](https://github.com/lycheeverse/lychee/pull/1713))
+- ignore gitlab table of content in wikilinks ([#1710](https://github.com/lycheeverse/lychee/pull/1710))
+
+### Other
+
+- Add explanation
+- Fix grammar
+- Update docs
+- Extract DEFAULT_ACCEPTED_STATUS_CODES & apply clippy's suggestions
+- Use StatusCodeSelector default as default accepted StatusCodes
+- Tiny improvements
+- Remove dbg macro
+- Pass accepted values by reference
+- Make accepted codes non-optional
+- Handle rejected TOO_MANY_REQUESTS
+- Update Status::code
+- Remove duplicated information from output
+- Change usage of ErrorKind::NetworkRequest, as it no longer represents rejected status codes
+- Update doc comment
+- Make error message more user-friendly
+- Remove hardcoded rule for handling erroneous status codes differently
+- Move archive functionality to library ([#1720](https://github.com/lycheeverse/lychee/pull/1720))
+- Bump the dependencies group across 1 directory with 3 updates ([#1714](https://github.com/lycheeverse/lychee/pull/1714))
+- Upgrade to 2024 edition ([#1711](https://github.com/lycheeverse/lychee/pull/1711))
+- Add support for custom headers in input processing ([#1561](https://github.com/lycheeverse/lychee/pull/1561))
+- Fix lints ([#1705](https://github.com/lycheeverse/lychee/pull/1705))
+- Remove flag
+- detect wikilinks, prevent plaintext extraction from links #1650 ([#1679](https://github.com/lycheeverse/lychee/pull/1679))
+- Bump the dependencies group with 2 updates
+- Add possible values for minimum TLS version in help message ([#1693](https://github.com/lycheeverse/lychee/pull/1693))
+- Add TLS version option ([#1655](https://github.com/lycheeverse/lychee/pull/1655))
+- Bump the dependencies group across 1 directory with 11 updates ([#1692](https://github.com/lycheeverse/lychee/pull/1692))
+- Specify MSRV ([#1676](https://github.com/lycheeverse/lychee/pull/1676))
+- Fix outdated link
+- Remove once_cell as direct dependency
+- Make clippy happy ([#1681](https://github.com/lycheeverse/lychee/pull/1681))
+- Bump the dependencies group with 3 updates ([#1670](https://github.com/lycheeverse/lychee/pull/1670))
+- Fix accept/exclude range syntax and docs ([#1668](https://github.com/lycheeverse/lychee/pull/1668))
+- Add FreeBSD-Ask to users ([#1662](https://github.com/lycheeverse/lychee/pull/1662))
+- Bump the dependencies group with 4 updates ([#1664](https://github.com/lycheeverse/lychee/pull/1664))
+- Bump the dependencies group with 11 updates ([#1656](https://github.com/lycheeverse/lychee/pull/1656))
+- Bump the dependencies group across 1 directory with 14 updates ([#1653](https://github.com/lycheeverse/lychee/pull/1653))
+- Add support for custom file extensions in link checking. ([#1559](https://github.com/lycheeverse/lychee/pull/1559))
+- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
+- renamed `base` to `base_url` (fixes #1607) ([#1629](https://github.com/lycheeverse/lychee/pull/1629))
+
 ## [0.18.1](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.0...lychee-lib-v0.18.1) - 2025-02-06
 
 ### Fixed


### PR DESCRIPTION

## 🤖 New release

* `lychee-lib`: 0.18.1 -> 0.19.0 (⚠ API breaking changes)
* `lychee`: 0.18.1 -> 0.19.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Input.headers in /tmp/.tmpuG4vCC/lychee/lychee-lib/src/types/input.rs:114

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type Input no longer derives Hash, in /tmp/.tmpuG4vCC/lychee/lychee-lib/src/types/input.rs:106

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/inherent_method_missing.ron

Failed in:
  StatusCodeSelector::into_set, previously in file /tmp/.tmpvLAXCA/lychee-lib/src/types/status_code/selector.rs:104
  Client::check_fragment, previously in file /tmp/.tmpvLAXCA/lychee-lib/src/client.rs:534

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lychee_lib::Input::new now takes 5 parameters instead of 4, in /tmp/.tmpuG4vCC/lychee/lychee-lib/src/types/input.rs:126
  lychee_lib::Input::get_contents now takes 5 parameters instead of 4, in /tmp/.tmpuG4vCC/lychee/lychee-lib/src/types/input.rs:221
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.19.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.1...lychee-lib-v0.19.0) - 2025-06-11

### Added

- respect the `disabled` property for stylesheet links ([#1716](https://github.com/lycheeverse/lychee/pull/1716))
- detect website fragments ([#1675](https://github.com/lycheeverse/lychee/pull/1675))

### Fixed

- only check the fragment when it's a file ([#1713](https://github.com/lycheeverse/lychee/pull/1713))
- ignore gitlab table of content in wikilinks ([#1710](https://github.com/lycheeverse/lychee/pull/1710))

### Other

- Update --accept behaviour ([#1661](https://github.com/lycheeverse/lychee/issues/1661))
- Move archive functionality to library ([#1720](https://github.com/lycheeverse/lychee/pull/1720))
- Bump the dependencies group across 1 directory with 3 updates ([#1714](https://github.com/lycheeverse/lychee/pull/1714))
- Upgrade to 2024 edition ([#1711](https://github.com/lycheeverse/lychee/pull/1711))
- Add support for custom headers in input processing ([#1561](https://github.com/lycheeverse/lychee/pull/1561))
- Fix lints ([#1705](https://github.com/lycheeverse/lychee/pull/1705))
- Remove flag
- detect wikilinks, prevent plaintext extraction from links #1650 ([#1679](https://github.com/lycheeverse/lychee/pull/1679))
- Bump the dependencies group with 2 updates
- Add possible values for minimum TLS version in help message ([#1693](https://github.com/lycheeverse/lychee/pull/1693))
- Add TLS version option ([#1655](https://github.com/lycheeverse/lychee/pull/1655))
- Bump the dependencies group across 1 directory with 11 updates ([#1692](https://github.com/lycheeverse/lychee/pull/1692))
- Specify MSRV ([#1676](https://github.com/lycheeverse/lychee/pull/1676))
- Fix outdated link
- Remove once_cell as direct dependency
- Make clippy happy ([#1681](https://github.com/lycheeverse/lychee/pull/1681))
- Bump the dependencies group with 3 updates ([#1670](https://github.com/lycheeverse/lychee/pull/1670))
- Fix accept/exclude range syntax and docs ([#1668](https://github.com/lycheeverse/lychee/pull/1668))
- Add FreeBSD-Ask to users ([#1662](https://github.com/lycheeverse/lychee/pull/1662))
- Bump the dependencies group with 4 updates ([#1664](https://github.com/lycheeverse/lychee/pull/1664))
- Bump the dependencies group with 11 updates ([#1656](https://github.com/lycheeverse/lychee/pull/1656))
- Bump the dependencies group across 1 directory with 14 updates ([#1653](https://github.com/lycheeverse/lychee/pull/1653))
- Add support for custom file extensions in link checking. ([#1559](https://github.com/lycheeverse/lychee/pull/1559))
- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
- renamed `base` to `base_url` (fixes #1607) ([#1629](https://github.com/lycheeverse/lychee/pull/1629))
</blockquote>

## `lychee`

<blockquote>

## [0.19.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.1...lychee-v0.19.0) - 2025-06-11

### Added

- raise error when the default config file is invalid ([#1715](https://github.com/lycheeverse/lychee/pull/1715))
- detect website fragments ([#1675](https://github.com/lycheeverse/lychee/pull/1675))

### Fixed

- only check the fragment when it's a file ([#1713](https://github.com/lycheeverse/lychee/pull/1713))

### Other

- Move archive functionality to library ([#1720](https://github.com/lycheeverse/lychee/pull/1720))
- Bump the dependencies group across 1 directory with 3 updates ([#1714](https://github.com/lycheeverse/lychee/pull/1714))
- Upgrade to 2024 edition ([#1711](https://github.com/lycheeverse/lychee/pull/1711))
- Fix `test_exclude_example_domains` ([#1712](https://github.com/lycheeverse/lychee/pull/1712))
- Add support for custom headers in input processing ([#1561](https://github.com/lycheeverse/lychee/pull/1561))
- Fix lints ([#1705](https://github.com/lycheeverse/lychee/pull/1705))
- Remove flag
- Bump the dependencies group with 2 updates
- Add possible values for minimum TLS version in help message ([#1693](https://github.com/lycheeverse/lychee/pull/1693))
- Add TLS version option ([#1655](https://github.com/lycheeverse/lychee/pull/1655))
- Bump the dependencies group across 1 directory with 11 updates ([#1692](https://github.com/lycheeverse/lychee/pull/1692))
- Specify MSRV ([#1676](https://github.com/lycheeverse/lychee/pull/1676))
- Fix outdated link
- Remove once_cell as direct dependency
- Make clippy happy ([#1681](https://github.com/lycheeverse/lychee/pull/1681))
- Bump the dependencies group with 3 updates ([#1670](https://github.com/lycheeverse/lychee/pull/1670))
- Fix accept/exclude range syntax and docs ([#1668](https://github.com/lycheeverse/lychee/pull/1668))
- Add FreeBSD-Ask to users ([#1662](https://github.com/lycheeverse/lychee/pull/1662))
- Bump the dependencies group with 4 updates ([#1664](https://github.com/lycheeverse/lychee/pull/1664))
- Allow header values that contain equal signs ([#1647](https://github.com/lycheeverse/lychee/pull/1647))
- Bump the dependencies group with 11 updates ([#1656](https://github.com/lycheeverse/lychee/pull/1656))
- Bump the dependencies group across 1 directory with 14 updates ([#1653](https://github.com/lycheeverse/lychee/pull/1653))
- Add support for custom file extensions in link checking. ([#1559](https://github.com/lycheeverse/lychee/pull/1559))
- Format Markdown URLs with `<>` instead of `[]()` ([#1638](https://github.com/lycheeverse/lychee/pull/1638))
- Bump the dependencies group across 1 directory with 21 updates ([#1643](https://github.com/lycheeverse/lychee/pull/1643))
- add tests for URL extraction ending with a period ([#1641](https://github.com/lycheeverse/lychee/pull/1641))
- renamed `base` to `base_url` (fixes #1607) ([#1629](https://github.com/lycheeverse/lychee/pull/1629))
- Sort compact/detailed/markdown error output by file path ([#1622](https://github.com/lycheeverse/lychee/pull/1622))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).