### PR TITLE
Redirect reporting

### DIFF
--- a/ideas.md
+++ b/ideas.md
@@ -1,0 +1,33 @@
+# Summary bug
+
+Redirects are currently never counted, even though there is a category for that.
+
+echo "https://httpstat.us/301" | cargo run - -vv --format detailed
+
+📝 Summary
+---------------------
+🔍 Total............1
+✅ Successful.......1
+⏳ Timeouts.........0
+🔀 Redirected.......0
+👻 Excluded.........0
+❓ Unknown..........0
+🚫 Errors...........0
+
+-> fixed in bf9b2bf
+
+# Only show 200 OK links in -vv output. (TBD)
+
+-> Create separate issue
+
+# Redirection tracking
+
+- Option 1: Keep using `redirect` from `reqwest` Client (introduces state and complexity)
+- Option 2: Remove `reqwest`'s `redirect` method, instead introduce a new `Chain` element which handles redirections
+
+# UX
+
+- This redirection tracking/reporting should be independent of `--suggest` (granularity). It probably should always happen.
+- When to show redirects? Always or only when explicitly wanted by user?
+- Keep debugging statement (`[DEBUG] Redirecting`)
+- Add separate section at the end, as with `--suggest`

--- a/lychee-bin/src/formatters/response/color.rs
+++ b/lychee-bin/src/formatters/response/color.rs
@@ -19,7 +19,11 @@ impl ColorFormatter {
             Status::Excluded
             | Status::Unsupported(_)
             | Status::Cached(CacheStatus::Excluded | CacheStatus::Unsupported) => &DIM,
-            Status::Redirected(_) => &NORMAL,
+            Status::Redirected {
+                original: _,
+                resolved: _,
+                code: _,
+            } => &NORMAL,
             Status::UnknownStatusCode(_) | Status::Timeout(_) => &YELLOW,
             Status::Error(_) | Status::Cached(CacheStatus::Error(_)) => &PINK,
         }

--- a/lychee-bin/src/formatters/response/emoji.rs
+++ b/lychee-bin/src/formatters/response/emoji.rs
@@ -17,7 +17,11 @@ impl EmojiFormatter {
             Status::Excluded
             | Status::Unsupported(_)
             | Status::Cached(CacheStatus::Excluded | CacheStatus::Unsupported) => "🚫",
-            Status::Redirected(_) => "↪️",
+            Status::Redirected {
+                original: _,
+                resolved: _,
+                code: _,
+            } => "↪️",
             Status::UnknownStatusCode(_) | Status::Timeout(_) => "⚠️",
             Status::Error(_) | Status::Cached(CacheStatus::Error(_)) => "❌",
         }

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -72,7 +72,11 @@ impl ResponseStats {
             Status::Error(_) => self.errors += 1,
             Status::UnknownStatusCode(_) => self.unknown += 1,
             Status::Timeout(_) => self.timeouts += 1,
-            Status::Redirected(_) => self.redirects += 1,
+            Status::Redirected {
+                original: _,
+                resolved: _,
+                code: _,
+            } => self.redirects += 1,
             Status::Excluded => self.excludes += 1,
             Status::Unsupported(_) => self.unsupported += 1,
             Status::Cached(cache_status) => {

--- a/lychee-bin/src/stats.rs
+++ b/lychee-bin/src/stats.rs
@@ -89,6 +89,7 @@ impl ResponseStats {
 
     /// Add a response status to the appropriate map (success, fail, excluded)
     fn add_response_status(&mut self, response: Response) {
+        // TODO: redirect map?
         let status = response.status();
         let source = response.source().clone();
         let status_map_entry = match status {

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -116,8 +116,15 @@ impl WebsiteChecker {
                 if self.include_fragments && status.is_success() && method == Method::GET {
                     return self.check_html_fragment(status, response).await;
                 }
-                if let Some(redirection) = self.redirect_map.lock().unwrap().get(&url) {
-                    todo!("Redirected from {} to {}", url, redirection)
+
+                if let Some(code) = status.code() {
+                    if let Some(resolved) = self.redirect_map.lock().unwrap().get(&url).cloned() {
+                        return Status::Redirected {
+                            original: url,
+                            resolved,
+                            code,
+                        };
+                    }
                 }
 
                 status

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -95,10 +95,6 @@ impl WebsiteChecker {
         let mut status = self.check_default(clone_unwrap(&request)).await;
         while retries < self.max_retries {
             if status.is_success() || !status.should_retry() {
-                if let Some(url) = self.redirect_map.lock().unwrap().get(dbg!(request.url())) {
-                    todo!("Redirected: {}", url)
-                }
-
                 return status;
             }
             retries += 1;
@@ -113,14 +109,18 @@ impl WebsiteChecker {
     /// Check a URI using [reqwest](https://github.com/seanmonstar/reqwest).
     async fn check_default(&self, request: Request) -> Status {
         let method = request.method().clone();
+        let url = request.url().clone();
         match self.reqwest_client.execute(request).await {
             Ok(response) => {
                 let status = Status::new(&response, &self.accepted);
                 if self.include_fragments && status.is_success() && method == Method::GET {
-                    self.check_html_fragment(status, response).await
-                } else {
-                    status
+                    return self.check_html_fragment(status, response).await;
                 }
+                if let Some(redirection) = self.redirect_map.lock().unwrap().get(&url) {
+                    todo!("Redirected from {} to {}", url, redirection)
+                }
+
+                status
             }
             Err(e) => e.into(),
         }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -335,7 +335,7 @@ impl ClientBuilder {
         let max_redirects = self.max_redirects;
         let redirect_policy = redirect::Policy::custom(move |attempt| {
             if attempt.previous().len() > max_redirects {
-                attempt.error("too many redirects")
+                attempt.stop()
             } else {
                 debug!("Redirecting to {}", attempt.url());
                 attempt.follow()

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -335,7 +335,7 @@ impl ClientBuilder {
             HeaderValue::from_static("chunked"),
         );
 
-        let mut redirect_map = Arc::new(Mutex::new(HashMap::new()));
+        let redirect_map = Arc::new(Mutex::new(HashMap::new()));
 
         let mut builder = reqwest::ClientBuilder::new()
             .gzip(true)
@@ -423,8 +423,6 @@ fn redirect_policy(
                 .unwrap()
                 .insert(first.clone(), attempt.url().clone());
         }
-
-        dbg!(&redirect_map); // todo
 
         if attempt.previous().len() > max_redirects {
             attempt.stop()

--- a/lychee-lib/src/retry.rs
+++ b/lychee-lib/src/retry.rs
@@ -122,7 +122,11 @@ impl RetryExt for Status {
             Status::Ok(_) => false,
             Status::Error(err) => err.should_retry(),
             Status::Timeout(_) => true,
-            Status::Redirected(_) => false,
+            Status::Redirected {
+                original: _,
+                resolved: _,
+                code: _,
+            } => false,
             Status::UnknownStatusCode(_) => false,
             Status::Excluded => false,
             Status::Unsupported(_) => false,

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -73,7 +73,11 @@ impl From<&Status> for CacheStatus {
             Status::Ok(code) | Status::UnknownStatusCode(code) => Self::Ok(code.as_u16()),
             Status::Excluded => Self::Excluded,
             Status::Unsupported(_) => Self::Unsupported,
-            Status::Redirected(code) => Self::Error(Some(code.as_u16())),
+            Status::Redirected {
+                original: _,
+                resolved: _,
+                code,
+            } => Self::Error(Some(code.as_u16())),
             Status::Timeout(code) => Self::Error(code.map(|code| code.as_u16())),
             Status::Error(e) => match e {
                 ErrorKind::RejectedStatusCode(code) => Self::Error(Some(code.as_u16())),


### PR DESCRIPTION
We want to report redirects at the end of the link check process, the same way we do for example with `--suggest`. The output format `markdown` for example should then also contain a section with all listed redirects.

**Summary bug**

There is a category `Redirected` in the summary. However, redirects were never counted. This is fixed with 6b28e2b.
This means `echo "https://http.codes/301 " | cargo run - --format detailed` yielded

```
📝 Summary
---------------------
🔍 Total............1
✅ Successful.......1
⏳ Timeouts.........0
🔀 Redirected.......0
👻 Excluded.........0
❓ Unknown..........0
🚫 Errors...........0
```

now it yields

```
📝 Summary
---------------------
🔍 Total............1
✅ Successful.......0
⏳ Timeouts.........0
🔀 Redirected.......1
👻 Excluded.........0
❓ Unknown..........0
🚫 Errors...........0
```

## Questions

1. I think it makes sense to show a `Redirects` section in the end just as we currently do with `Suggestions`. But I think we should show them by default without introducing a new feature/flag. Tying the feature to `--suggest` wouldn't make sense in my opinion. Do you agree?
2. As you can see in this PR I introduced a `redirect_map`. It is used to keep track of the redirects that lychee followed. This allows us to create the new summary section. (not yet implemented) The map is wrapped in an `Arc<Mutex<_>>`. Do you think this is okay? I probably could try to use channels instead. The reason for the `Arc<Mutex<_>>` is that `redirect::Policy::custom` takes `Fn(Attempt) -> Action + Send + Sync + 'static` as argument, so we can't mutate data in there. I also briefly considered using getting rid of `redirect::Policy::custom` and implement our own mechanism. But that turns out to be way more effort then necessary.