### PR TITLE
chore: release v0.19.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2490,7 +2490,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2538,7 +2538,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches"]
 resolver = "2"
 
 [workspace.package]
-version = "0.19.0"
+version = "0.19.1"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1](https://github.com/lycheeverse/lychee/compare/lychee-v0.19.0...lychee-v0.19.1) - 2025-06-16
+
+### Other
+
+- Don't echo potentially sensitive header data ([#1728](https://github.com/lycheeverse/lychee/pull/1728))
+- Update changelog
+
 ## [0.19.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.18.1...lychee-v0.19.0) - 2025-06-11
 
 Most notably with this release the deprecated `--exclude-mail` flag was removed and the behavior of the `--accept` flag was updated. Previously, status codes such as `200 OK` were always accepted. Now they are only accepted by default. This means providing the argument `--accept 201` now rejects status code `200 OK`.

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.19.0", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.19.1", default-features = false }
 
 anyhow = "1.0.98"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.19.0...lychee-lib-v0.19.1) - 2025-06-16
+
+### Fixed
+
+- skip the fragment check if the uri doesn't contain fragment ([#1730](https://github.com/lycheeverse/lychee/pull/1730))
+
+### Other
+
+- Update changelog
+
 ## [0.19.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.18.1...lychee-lib-v0.19.0) - 2025-06-11
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.19.0 -> 0.19.1 (✓ API compatible changes)
* `lychee`: 0.19.0 -> 0.19.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.19.1](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.19.0...lychee-lib-v0.19.1) - 2025-06-16

### Fixed

- skip the fragment check if the uri doesn't contain fragment ([#1730](https://github.com/lycheeverse/lychee/pull/1730))

### Other

- Update changelog
</blockquote>

## `lychee`

<blockquote>

## [0.19.1](https://github.com/lycheeverse/lychee/compare/lychee-v0.19.0...lychee-v0.19.1) - 2025-06-16

### Other

- Don't echo potentially sensitive header data ([#1728](https://github.com/lycheeverse/lychee/pull/1728))
- Update changelog
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).