### PR TITLE
Add xml schema found in xsd files to list of exclusions

### DIFF
--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -41,15 +41,15 @@ static UNSUPPORTED_DOMAINS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
 
 /// Pre-defined exclusions for known false-positives
 const FALSE_POSITIVE_PAT: &[&str] = &[
-    r"^https?://schemas.openxmlformats.org",
-    r"^https?://schemas.zune.net",
-    r"^https?://www.w3.org/1999/xhtml",
-    r"^https?://www.w3.org/1999/xlink",
-    r"^https?://www.w3.org/2000/svg",
-    r"^https?://www.w3.org/2001/XMLSchema-instance",
-    r"^https?://ogp.me/ns#",
-    r"^https?://schemas.microsoft.com",
-    r"^https?://(.*)/xmlrpc.php$",
+    r"^https?://schemas\.openxmlformats\.org",
+    r"^https?://schemas\.microsoft\.com",
+    r"^https?://schemas\.zune\.net",
+    r"^https?://www\.w3\.org/1999/xhtml",
+    r"^https?://www\.w3\.org/1999/xlink",
+    r"^https?://www\.w3\.org/2000/svg",
+    r"^https?://www\.w3\.org/2001/XMLSchema-instance",
+    r"^https?://ogp\.me/ns#",
+    r"^https?://(.*)/xmlrpc\.php$",
 ];
 
 static FALSE_POSITIVE_SET: LazyLock<RegexSet> =


### PR DESCRIPTION
- Adding xml schema found in XSD files, see e.g. https://www.w3schools.com/xml/schema_intro.asp
- Escape `.`'s in URLs
- Reorder one entry for better readability

Linking https://github.com/lycheeverse/lychee-action/issues/297

<br>

~~Should the dots in the regex be escaped to match explicitly? @mre~~ Done, https://github.com/lycheeverse/lychee/pull/1735/commits/93090c30b9cfa76257702fd182f8e8943eac26ac