### PR TITLE
Fix docker tagging for release versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,16 +1,11 @@
 name: Docker
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: 
-      - "Release Binary"
-    types:
-      - completed
-    branches:
-      - master
   push:
     branches:
       - master
+    tags:
+      - 'lychee-v*'
   pull_request:
     branches:
       - master


### PR DESCRIPTION
I hope will resolve #1628

This is the relevant part of the workflow to understand what's going on:

https://github.com/lycheeverse/lychee/blob/3592972d6462ceb6081c3945cc43121bc3ce2039/.github/workflows/docker.yml#L46-L48

This is configuring `docker/metadata-action`.

And [`type=semver`](https://github.com/docker/metadata-action#typesemver)

> Will be used on a [push tag event](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push) and requires a valid [semver](https://semver.org/) Git tag

Even if docker/metadata-action is being used on branch push, I think that [`${{ github.ref_name }}`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context) is the branch name when the workflow is triggered by a branch push (and the tag name when the workflow is triggered by a tag push).