### PR TITLE
Clippy 1.88

### DIFF
--- a/examples/archive/archive.rs
+++ b/examples/archive/archive.rs
@@ -11,7 +11,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .await?;
 
     if let Some(replacement) = result {
-        println!("Good news! {} can be replaced with {}", url, replacement);
+        println!("Good news! {url} can be replaced with {replacement}");
     }
 
     Ok(())

--- a/examples/chain/chain.rs
+++ b/examples/chain/chain.rs
@@ -28,7 +28,7 @@ async fn main() -> Result<()> {
         .client()?;
 
     let result = client.check("https://wikipedia.org/home").await;
-    println!("{:?}", result);
+    println!("{result:?}");
 
     Ok(())
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748370509,
-        "narHash": "sha256-QlL8slIgc16W5UaI3w7xHQEP+Qmv/6vSNTpoZrrSlbk=",
+        "lastModified": 1750776420,
+        "narHash": "sha256-/CG+w0o0oJ5itVklOoLbdn2dGB0wbZVOoDm4np6w09A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4faa5f5321320e49a78ae7848582f684d64783e9",
+        "rev": "30a61f056ac492e3b7cdcb69c1e6abdcf00e39cf",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1748486227,
-        "narHash": "sha256-veMuFa9cq/XgUXp1S57oC8K0TIw3XyZWL2jIyGWlW0c=",
+        "lastModified": 1750991972,
+        "narHash": "sha256-jzadGZL1MtqmHb5AZcjZhHpNulOdMZPxf8Wifg8e5VA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4bf1892eb81113e868efe67982b64f1da15c8c5a",
+        "rev": "b6509555d8ffaa0727f998af6ace901c5b78dc26",
         "type": "github"
       },
       "original": {

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -998,7 +998,7 @@ mod cli {
 
         // Ensure clean state
         if cache_file.exists() {
-            println!("Removing cache file before test: {:?}", cache_file);
+            println!("Removing cache file before test: {cache_file:?}");
             fs::remove_file(&cache_file)?;
             tokio::time::sleep(Duration::from_millis(500)).await;
         }
@@ -1041,7 +1041,7 @@ mod cli {
 
         // Check cache contents
         let data = fs::read_to_string(&cache_file)?;
-        println!("Cache file contents: {}", data);
+        println!("Cache file contents: {data}");
 
         assert!(
             data.contains(&format!("{}/,200", mock_server_ok.uri())),

--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -148,12 +148,12 @@ mod tests {
         Ok(())
     }
 
-    #[ignore]
+    #[ignore = "
+        It is flaky because the API does not reliably return snapshots,
+        i.e. the `archived_snapshots` field is unreliable.
+        That's why the test is ignored. For development and documentation this test is still useful."]
     #[tokio::test]
     /// This tests the real Wayback API without any mocks.
-    /// It is flaky because the API does not reliably return snapshots,
-    /// i.e. the `archived_snapshots` field is unreliable.
-    /// That's why the test is ignored. For development and documentation this test is still useful.
     async fn wayback_suggestion_real() -> Result<(), Box<dyn StdError>> {
         let url = &"https://example.com".try_into()?;
         let response = get_archive_snapshot(url, TIMEOUT).await?;

--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -464,12 +464,7 @@ mod tests {
         assert_eq!(uris, expected);
     }
 
-    // TODO: This test is currently failing because we don't handle nested
-    // verbatim elements of the same type correctly. The first closing tag will
-    // lift the verbatim flag. This is a known issue and could be handled by
-    // keeping a stack of verbatim flags.
     #[test]
-    #[ignore]
     fn test_include_verbatim_nested_identical() {
         const HTML_INPUT: &str = r#"
         <pre>

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -314,7 +314,6 @@ or inline like `https://bar.org` for instance.
     }
 
     #[test]
-    #[ignore]
     fn test_skip_verbatim_html() {
         let input = "
 <code>


### PR DESCRIPTION
Pipeline fails because of Rust 1.88 was released yesterday with new clippy suggestions.

The most interesting part of this PR is that I removed `#[ignore]` from two tests as I noticed that they are actually passing. I assume it's because the issues were addressed in the meantime. Or is there a reason we should still ignore them?