### PR TITLE
feat: add 'user-content-' prefix to support github markdown fragment

### DIFF
--- a/fixtures/fragments/file.html
+++ b/fixtures/fragments/file.html
@@ -24,7 +24,7 @@
       <a href="#in-the-end">doesn't exist</a><br>
       <a href="#">To the top</a><br>
       <a href="#top">To the top alt</a><br>
-      <a href="https://github.com/lycheeverse/lychee#user-content-table-of-contents">To the lychee readme license fragment.</a>
+      <a href="https://github.com/lycheeverse/lychee#table-of-contents">To the lychee readme license fragment.</a>
     </section>
   </body>
 </html>

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1871,7 +1871,7 @@ mod cli {
             .stderr(contains("fixtures/fragments/file.html#top"))
             .stderr(contains("fixtures/fragments/file2.md#top"))
             .stderr(contains(
-                "https://github.com/lycheeverse/lychee#user-content-table-of-contents",
+                "https://github.com/lycheeverse/lychee#table-of-contents",
             ))
             .stderr(contains(
                 "https://github.com/lycheeverse/lychee#non-existent-anchor",


### PR DESCRIPTION
What can be handled:

- GitHub default README + Gist fragment (by adding the `user-content-` prefix)
- GitHub PR discussion (by nature)
- Gist files (by nature)

What cannot be handled:

- GitHub markdown files on any specific path
  - includes `blob/master/README.md`
- issue comments
  - like `https://github.com/PyO3/pyo3/issues/1800#issuecomment-906786649`

We have to simulate with a headless browser library to support these cases.
