### PR TITLE
Replace unmaintained human-sort with numeric-sort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1907,12 +1907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "human-sort"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "140a09c9305e6d5e557e2ed7cbc68e05765a7d4213975b87cb04920689cc6219"
-
-[[package]]
 name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,12 +2500,12 @@ dependencies = [
  "headers",
  "http 1.3.1",
  "http-serde",
- "human-sort",
  "humantime",
  "humantime-serde",
  "indicatif",
  "log",
  "lychee-lib",
+ "numeric-sort",
  "openssl-sys",
  "pad",
  "predicates",
@@ -2785,6 +2779,12 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "numeric-sort"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2dcb6053ab98da45585315f79932c5c9821fab8efa4301c0d7b637c91630eb7"
 
 [[package]]
 name = "object"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -31,7 +31,7 @@ http = "1.3.1"
 http-serde = "2.1.1"
 humantime = "2.2.0"
 humantime-serde = "1.1.1"
-human-sort = "0.2.2"
+numeric-sort = "0.1.5"
 indicatif = "0.17.11"
 log = "0.4.27"
 openssl-sys = { version = "0.9.108", optional = true }

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -11,8 +11,6 @@ use crate::{formatters::get_response_formatter, options, stats::ResponseStats};
 
 use super::StatsFormatter;
 
-use numeric_sort::cmp;
-
 struct CompactResponseStats {
     stats: ResponseStats,
     mode: options::OutputMode,
@@ -54,7 +52,7 @@ impl Display for CompactResponseStats {
                 let mut sorted_suggestions: Vec<_> = suggestions.iter().collect();
                 sorted_suggestions.sort_by(|a, b| {
                     let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-                    cmp(&a, &b)
+                    numeric_sort::cmp(&a, &b)
                 });
 
                 writeln!(f, "\n\u{2139} Suggestions")?;

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -11,6 +11,8 @@ use crate::{formatters::get_response_formatter, options, stats::ResponseStats};
 
 use super::StatsFormatter;
 
+use numeric_sort::cmp;
+
 struct CompactResponseStats {
     stats: ResponseStats,
     mode: options::OutputMode,
@@ -52,7 +54,7 @@ impl Display for CompactResponseStats {
                 let mut sorted_suggestions: Vec<_> = suggestions.iter().collect();
                 sorted_suggestions.sort_by(|a, b| {
                     let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-                    human_sort::compare(&a, &b)
+                    cmp(&a, &b)
                 });
 
                 writeln!(f, "\n\u{2139} Suggestions")?;

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -2,9 +2,9 @@ use super::StatsFormatter;
 use crate::{formatters::get_response_formatter, options, stats::ResponseStats};
 
 use anyhow::Result;
+use numeric_sort::cmp;
 use pad::{Alignment, PadStr};
 use std::fmt::{self, Display};
-use numeric_sort::cmp;
 // Maximum padding for each entry in the final statistics output
 const MAX_PADDING: usize = 20;
 

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -4,7 +4,7 @@ use crate::{formatters::get_response_formatter, options, stats::ResponseStats};
 use anyhow::Result;
 use pad::{Alignment, PadStr};
 use std::fmt::{self, Display};
-
+use numeric_sort::cmp;
 // Maximum padding for each entry in the final statistics output
 const MAX_PADDING: usize = 20;
 
@@ -68,7 +68,7 @@ impl Display for DetailedResponseStats {
                 let mut sorted_suggestions: Vec<_> = suggestions.iter().collect();
                 sorted_suggestions.sort_by(|a, b| {
                     let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-                    human_sort::compare(&a, &b)
+                    cmp(&a, &b)
                 });
 
                 writeln!(f, "\nSuggestions in {source}")?;

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -2,7 +2,6 @@ use super::StatsFormatter;
 use crate::{formatters::get_response_formatter, options, stats::ResponseStats};
 
 use anyhow::Result;
-use numeric_sort::cmp;
 use pad::{Alignment, PadStr};
 use std::fmt::{self, Display};
 // Maximum padding for each entry in the final statistics output
@@ -68,7 +67,7 @@ impl Display for DetailedResponseStats {
                 let mut sorted_suggestions: Vec<_> = suggestions.iter().collect();
                 sorted_suggestions.sort_by(|a, b| {
                     let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-                    cmp(&a, &b)
+                    numeric_sort::cmp(&a, &b)
                 });
 
                 writeln!(f, "\nSuggestions in {source}")?;

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -19,6 +19,8 @@ use crate::stats::ResponseStats;
 use anyhow::Result;
 use lychee_lib::InputSource;
 
+use numeric_sort::cmp;
+
 pub(crate) trait StatsFormatter {
     /// Format the stats of all responses and write them to stdout
     fn format(&self, stats: ResponseStats) -> Result<Option<String>>;
@@ -36,7 +38,7 @@ where
             let mut sorted_responses: Vec<&T> = responses.iter().collect();
             sorted_responses.sort_by(|a, b| {
                 let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-                human_sort::compare(&a, &b)
+                cmp(&a, &b)
             });
 
             (source, sorted_responses)
@@ -45,7 +47,7 @@ where
 
     entries.sort_by(|(a, _), (b, _)| {
         let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-        human_sort::compare(&a, &b)
+        cmp(&a, &b)
     });
 
     entries

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -19,8 +19,6 @@ use crate::stats::ResponseStats;
 use anyhow::Result;
 use lychee_lib::InputSource;
 
-use numeric_sort::cmp;
-
 pub(crate) trait StatsFormatter {
     /// Format the stats of all responses and write them to stdout
     fn format(&self, stats: ResponseStats) -> Result<Option<String>>;
@@ -38,7 +36,7 @@ where
             let mut sorted_responses: Vec<&T> = responses.iter().collect();
             sorted_responses.sort_by(|a, b| {
                 let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-                cmp(&a, &b)
+                numeric_sort::cmp(&a, &b)
             });
 
             (source, sorted_responses)
@@ -47,7 +45,7 @@ where
 
     entries.sort_by(|(a, _), (b, _)| {
         let (a, b) = (a.to_string().to_lowercase(), b.to_string().to_lowercase());
-        cmp(&a, &b)
+        numeric_sort::cmp(&a, &b)
     });
 
     entries


### PR DESCRIPTION
## Description
Fixes #1758

Replaces the unmaintained `human-sort` crate with `numeric-sort` to fix panic issues in recent Rust versions.

## Problem
- `human-sort` is unmaintained
- Causes "user-provided comparison function does not correctly implement a total order" panic in recent Rust versions

## Solution
- Replace `human-sort` (0.2.2) with `numeric-sort` (0.1.5)
- Update all usages of `human_sort::compare` to `numeric_sort::cmp`
- The new crate provides the same natural/human sorting behavior

## Changes
- Updated `Cargo.toml` dependency
- Modified sorting logic in:
  - `lychee-bin/src/formatters/stats/mod.rs`
  - `lychee-bin/src/formatters/stats/compact.rs`
  - `lychee-bin/src/formatters/stats/detailed.rs`

## Testing
- [x] `cargo build` passes without errors
- [x] `cargo test` passes
- [x] No more panic when running lychee
- [x] Sorting behavior remains consistent with natural ordering