### PR TITLE
docs: add `fallback_extensions` to example config file

### DIFF
--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -74,6 +74,10 @@ header = { "accept" = "text/html", "x-custom-header" = "value" }
 # Remap URI matching pattern to different URI.
 remap = ["https://example.com http://example.invalid"]
 
+# Fallback extensions to apply when a URL does not specify one.
+# This is common in documentation tools that cross-reference files without extensions.
+fallback_extensions = ["md", "html"]
+
 # Base URL or website root directory to check relative URLs.
 base_url = "https://example.com"
 


### PR DESCRIPTION
This is very common for documentation tools like vitepress, astro, etc.