### PR TITLE
Fix local directory checking

### DIFF
--- a/fixtures/TEST_LOCAL_DIRECTORIES.md
+++ b/fixtures/TEST_LOCAL_DIRECTORIES.md
@@ -1,0 +1,6 @@
+The following links should all be valid and be detected as such by lychee.
+
+[link to root dir](file:///)
+[link to /dev](file:///dev/)
+[link to current dir](.)
+[relative link to docs](../docs/)

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -281,6 +281,18 @@ mod cli {
     }
 
     #[test]
+    fn test_local_directories() -> Result<()> {
+        test_json_output!(
+            "TEST_LOCAL_DIRECTORIES.md",
+            MockResponseStats {
+                total: 4,
+                successful: 4,
+                ..MockResponseStats::default()
+            }
+        )
+    }
+
+    #[test]
     fn test_email() -> Result<()> {
         test_json_output!(
             "TEST_EMAIL.md",

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1928,9 +1928,9 @@ mod cli {
                 "https://raw.githubusercontent.com/lycheeverse/lychee/master/fixtures/fragments/zero.bin#fragment",
             ))
             .stdout(contains("42 Total"))
-            .stdout(contains("30 OK"))
+            .stdout(contains("31 OK"))
             // Failures because of missing fragments or failed binary body scan
-            .stdout(contains("12 Errors"));
+            .stdout(contains("11 Errors"));
     }
 
     #[test]

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -104,7 +104,7 @@ mod cli {
             let test_path = fixtures_path().join($test_file);
             let outfile = format!("{}.json", uuid::Uuid::new_v4());
 
-            cmd$(.arg($arg))*.arg("--output").arg(&outfile).arg("--format").arg("json").arg(test_path).assert().success();
+            let result = cmd$(.arg($arg))*.arg("--output").arg(&outfile).arg("--format").arg("json").arg(test_path).assert();
 
             let output = std::fs::read_to_string(&outfile)?;
             std::fs::remove_file(outfile)?;
@@ -112,6 +112,7 @@ mod cli {
             let actual: Value = serde_json::from_str(&output)?;
             let expected: Value = serde_json::to_value(&$expected)?;
 
+            result.success();
             assert_json_include!(actual: actual, expected: expected);
             Ok(())
         }};

--- a/lychee-lib/src/checker/file.rs
+++ b/lychee-lib/src/checker/file.rs
@@ -106,10 +106,16 @@ impl FileChecker {
     /// Returns a `Status` indicating the result of the check.
     async fn check_path(&self, path: &Path, uri: &Uri) -> Status {
         let file_path = self.resolve_file_path(path);
+        let has_fragment = uri.url.fragment().is_some_and(|x| !x.is_empty());
 
         // If file_path exists, check this file
         if file_path.is_some() {
             return self.check_file(&file_path.unwrap(), uri).await;
+        }
+        // If path is a directory, and we cannot find an index file inside it,
+        // and we don't have a fragment, just return success.
+        else if path.is_dir() && !has_fragment {
+            return Status::Ok(StatusCode::OK);
         }
 
         ErrorKind::InvalidFilePath(uri.clone()).into()


### PR DESCRIPTION
81f2605 introduced a new bug. The bug is now described in `test_local_directories`. I've reverted the few lines in file.rs that introduced the bug.

So previously we had:

`[ERROR] file:///home/thomas/Projects/lychee/fixtures/fragments/empty_dir | Cannot find file`


now we're back at:

`[200] file:///home/thomas/Projects/lychee/fixtures/fragments/empty_dir`

This bug was introduced in https://github.com/lycheeverse/lychee/pull/1756. The tests form this PR make sense and can be left unchanged apart from this one difference mentioned above. (which results in the 30/31 OK and 12/11 Errors difference)

 @ocavue @mre @katrinafyi Can you explain the reasoning behind removing the `else if`? If there really is a reason behind skipping that check we could introduce a new feature flag for that but I don't understand the idea yet.