### PR TITLE
Add support for 64-bit ARM binary

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -47,6 +47,7 @@ jobs:
           - arm-unknown-linux-musleabi
           - arm-unknown-linux-musleabihf
           - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
           # See https://github.com/briansmith/ring/issues/562
           # - mips-unknown-linux-musl
           # - mipsel-unknown-linux-musl

--- a/Dockerfile-CI.alpine.Dockerfile
+++ b/Dockerfile-CI.alpine.Dockerfile
@@ -5,15 +5,15 @@ ARG LYCHEE_VERSION="latest"
 
 RUN apk add --no-cache ca-certificates jq wget \
     && ARCH=$(case $(arch) in \
-        "x86_64") echo "x86_64-unknown-linux-musl";; \
-        "aarch64") echo "arm-unknown-linux-musleabihf";; \
+        "amd64") echo "x86_64";; \
+        "arm64") echo "aarch64";; \
         *) echo "Unsupported architecture" && exit 1;; \
         esac) \
     && BASE_URL=$(case $LYCHEE_VERSION in \
         "latest" | "nightly") echo "https://github.com/lycheeverse/lychee/releases/latest/download";; \
         *) echo "https://github.com/lycheeverse/lychee/releases/download/$LYCHEE_VERSION";; \
         esac) \
-    && wget -4 -q -O - "$BASE_URL/lychee-$ARCH.tar.gz" | tar -xz lychee \
+    && wget -q -O - "$BASE_URL/lychee-$ARCH-unknown-linux-musl.tar.gz" | tar -xz lychee \
     && chmod +x lychee
 
 FROM alpine:latest


### PR DESCRIPTION
Add support for 64-bit ARM binary and use in Alpine Linux-based Docker images.

Fixes: https://github.com/lycheeverse/lychee/issues/1745.