### PR TITLE
fix comment for `ErrorKind::InvalidFragment`

### DIFF
--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -66,7 +66,7 @@ pub enum ErrorKind {
     #[error("Cannot find file")]
     InvalidFilePath(Uri),
 
-    /// The given URI cannot be converted to a file path
+    /// The given URI's fragment could not be found within the page content
     #[error("Cannot find fragment")]
     InvalidFragment(Uri),
 


### PR DESCRIPTION
the comment doesn't make sense and it is identical to InvalidFilePath which is right above it, so I reason this was a copy/paste mistake.