### PR TITLE
Fix possible outputs of 'arch' command in Alpine Linux-based Dockerfile

### DIFF
--- a/Dockerfile-CI.alpine.Dockerfile
+++ b/Dockerfile-CI.alpine.Dockerfile
@@ -5,8 +5,8 @@ ARG LYCHEE_VERSION="latest"
 
 RUN apk add --no-cache ca-certificates jq wget \
     && ARCH=$(case $(arch) in \
-        "amd64") echo "x86_64";; \
-        "arm64") echo "aarch64";; \
+        "x86_64") echo "x86_64";; \
+        "aarch64") echo "aarch64";; \
         *) echo "Unsupported architecture" && exit 1;; \
         esac) \
     && BASE_URL=$(case $LYCHEE_VERSION in \


### PR DESCRIPTION
A follow up to: https://github.com/lycheeverse/lychee/pull/1774.

That pull request seemed to correctly provide a new `lychee-aarch64-unknown-linux-musl.tar.gz` build (see nightly: https://github.com/lycheeverse/lychee/releases/tag/nightly), but incorrectly changed what the expected output from Alpine Linux's `arch` command was.

This pull request restores the original parsing of the output, but retains the new format of what is set in `$ARCH` for use later. It might be possible to further refine the Dockerfile, but the intention here is to make as few changes as possible each time.