### PR TITLE
clarify `--base-url` and `--root-dir` and their interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,8 +533,9 @@ Options:
           `/root/dir`, a link to `/page.html` would be resolved to `/root/dir/page.html`.
 
           This option can be specified alongside `--base-url`. If both are given, an
-          absolute link is resolved as: the domain name of the base URL, then the root
-          dir path, then the absolute link's path.
+          absolute link is resolved by constructing a URL from three parts: the domain
+          name specified in `--base-url`, followed by the `--root-dir` directory path,
+          followed by the absolute link's own path.
 
       --basic-auth <BASIC_AUTH>
           Basic authentication support. E.g. `http://example.com username:password`

--- a/README.md
+++ b/README.md
@@ -524,7 +524,7 @@ Options:
           at the given base URL address.
 
       --root-dir <ROOT_DIR>
-          Root path to use when checking absolute links in local files. This option is
+          Root directory to use when checking absolute links in local files. This option is
           required if absolute links appear in local files, otherwise those links will be
           flagged as errors. This must be an absolute path (i.e., one beginning with `/`).
 

--- a/README.md
+++ b/README.md
@@ -506,10 +506,35 @@ Options:
           Deprecated; use `--base-url` instead
 
   -b, --base-url <BASE_URL>
-          Base URL used to resolve relative URLs during link checking Example: <https://example.com>
+          Base URL to use when resolving relative URLs in local files. If specified,
+          relative links in local files are interpreted as being relative to the given
+          base URL.
+
+          For example, given a base URL of `https://example.com/dir/page`, the link `a`
+          would resolve to `https://example.com/dir/a` and the link `/b` would resolve
+          to `https://example.com/b`. This behavior is not affected by the filesystem
+          path of the file containing these links.
+
+          Note that relative URLs without a leading slash become siblings of the base
+          URL. If, instead, the base URL ended in a slash, the link would become a child
+          of the base URL. For example, a base URL of `https://example.com/dir/page/` and
+          a link of `a` would resolve to `https://example.com/dir/page/a`.
+
+          Basically, the base URL option resolves links as if the local files were hosted
+          at the given base URL address.
 
       --root-dir <ROOT_DIR>
-          Root path to use when checking absolute local links, must be an absolute path
+          Root path to use when checking absolute links in local files. This option is
+          required if absolute links appear in local files, otherwise those links will be
+          flagged as errors. This must be an absolute path (i.e., one beginning with `/`).
+
+          If specified, absolute links in local files are resolved by prefixing the given
+          root directory to the requested absolute link. For example, with a root-dir of
+          `/root/dir`, a link to `/page.html` would be resolved to `/root/dir/page.html`.
+
+          This option can be specified alongside `--base-url`. If both are given, an
+          absolute link is resolved as: the domain name of the base URL, then the root
+          dir path, then the absolute link's path.
 
       --basic-auth <BASIC_AUTH>
           Basic authentication support. E.g. `http://example.com username:password`

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -667,8 +667,9 @@ root directory to the requested absolute link. For example, with a root-dir of
 `/root/dir`, a link to `/page.html` would be resolved to `/root/dir/page.html`.
 
 This option can be specified alongside `--base-url`. If both are given, an
-absolute link is resolved as: the domain name of the base URL, then the root
-dir path, then the absolute link's path."
+absolute link is resolved by constructing a URL from three parts: the domain
+name specified in `--base-url`, followed by the `--root-dir` directory path,
+followed by the absolute link's own path."
     )]
     #[serde(default)]
     pub(crate) root_dir: Option<PathBuf>,

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -628,15 +628,48 @@ separated list of accepted status codes. This example will accept 200, 201,
     #[serde(skip)]
     pub(crate) base: Option<Base>,
 
-    /// Base URL used to resolve relative URLs during link checking
+    /// Base URL used to resolve relative URLs in local files.
     /// Example: <https://example.com>
-    #[arg(short, long, value_parser= parse_base)]
+    #[arg(
+        short,
+        long,
+        value_parser = parse_base,
+        long_help = "Base URL to use when resolving relative URLs in local files. If specified,
+relative links in local files are interpreted as being relative to the given
+base URL.
+
+For example, given a base URL of `https://example.com/dir/page`, the link `a`
+would resolve to `https://example.com/dir/a` and the link `/b` would resolve
+to `https://example.com/b`. This behavior is not affected by the filesystem
+path of the file containing these links.
+
+Note that relative URLs without a leading slash become siblings of the base
+URL. If, instead, the base URL ended in a slash, the link would become a child
+of the base URL. For example, a base URL of `https://example.com/dir/page/` and
+a link of `a` would resolve to `https://example.com/dir/page/a`.
+
+Basically, the base URL option resolves links as if the local files were hosted
+at the given base URL address."
+    )]
     #[serde(default)]
     pub(crate) base_url: Option<Base>,
 
-    /// Root path to use when checking absolute local links,
-    /// must be an absolute path
-    #[arg(long)]
+    /// Root path to use when checking absolute links in local files.
+    /// Must be an absolute path.
+    #[arg(
+        long,
+        long_help = "Root path to use when checking absolute links in local files. This option is
+required if absolute links appear in local files, otherwise those links will be
+flagged as errors. This must be an absolute path (i.e., one beginning with `/`).
+
+If specified, absolute links in local files are resolved by prefixing the given
+root directory to the requested absolute link. For example, with a root-dir of
+`/root/dir`, a link to `/page.html` would be resolved to `/root/dir/page.html`.
+
+This option can be specified alongside `--base-url`. If both are given, an
+absolute link is resolved as: the domain name of the base URL, then the root
+dir path, then the absolute link's path."
+    )]
     #[serde(default)]
     pub(crate) root_dir: Option<PathBuf>,
 

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -654,11 +654,11 @@ at the given base URL address."
     #[serde(default)]
     pub(crate) base_url: Option<Base>,
 
-    /// Root path to use when checking absolute links in local files.
+    /// Root directory to use when checking absolute links in local files.
     /// Must be an absolute path.
     #[arg(
         long,
-        long_help = "Root path to use when checking absolute links in local files. This option is
+        long_help = "Root directory to use when checking absolute links in local files. This option is
 required if absolute links appear in local files, otherwise those links will be
 flagged as errors. This must be an absolute path (i.e., one beginning with `/`).
 


### PR DESCRIPTION
this more clearly documents the behaviour of these flags. this makes no changes to behavior. as always, this documents the usage as i observe right now and does not presume that this behaviour is good or correct.

i also hope to clarify some more subtle points:
- the base-url is uniformly applied to every local file being checked, regardless of the filesystem path of each local file. this means that a relative link `a/b` resolves to exactly the same URL no matter which local file it appears in.
- base-url is affected by trailing slashes.
- define behavior when root-dir and base-url are both specified. namely, root-dir becomes a subpath of the base-url's domain.

honestly, the more i think about it, the more i think this behavior is wrong or has diverged from its original intention. for instance, let's look at [the docs recipe about `--root-dir`][1]:

[1]: https://lychee.cli.rs/recipes/root-dir/#using-both-together

> Sometimes you need both:
>
> ```bash
> lychee \
>   --root-dir "$(pwd)/public" \
>   --base-url https://example.com/ \
>   "public/**/*.html"
> ```
>
> This tells lychee:
>
> 1. Look for `/`-prefixed files in `./public/`
> 2. Resolve relative links against https://example.com/

with the above points in mind, this example is nonsensical. firstly, the root-dir will make absolute links become something like `https://example.com/path/to/pwd/public/absolute-link` which is unlikely to exist on the remote host. this is in contradiction with point (1) in the quote. secondly, /every/ relative link is resolved against exactly `https://example.com/`, without considering its position relative to root-dir. this seems wrong too.

but in any case, this PR clarifies the behavior as it is right now. this PR is mostly just my findings from https://github.com/lycheeverse/lychee/issues/1718#issuecomment-3142606156