### PR TITLE
README: Cleanup input example

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ lychee ~/projects/*/README.md
 lychee "~/projects/big_project/**/README.*"
 
 # ignore case when globbing and check result for each link:
-lychee --glob-ignore-case --verbose "~/projects/**/[r]eadme.*"
+lychee --glob-ignore-case "~/projects/**/[r]eadme.*"
 
 # check links from epub file (requires atool: https://www.nongnu.org/atool)
 acat -F zip {file.epub} "*.xhtml" "*.html" | lychee -


### PR DESCRIPTION
`--verbose` command in one of the examples on input options looks like a leftover