### PR TITLE
Fix missing identifier in snap build action; add snap install to readme

### DIFF
--- a/.github/workflows/snap.yml
+++ b/.github/workflows/snap.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: snapcore/action-build@v1
+        id: build
       - uses: snapcore/action-publish@v1
         env:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_LOGIN }}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ pacman -S lychee
 zypper in lychee
 ```
 
+### Ubuntu
+
+```sh
+snap install lychee
+```
+
 ### macOS
 
 Via [Homebrew](https://brew.sh):


### PR DESCRIPTION
Quick follow-up to #1786 since I saw the workflow isn't passing yet.