### PR TITLE
README: Order argument options alphabetically

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Options:
           Equivalent to using `--exclude-private --exclude-link-local --exclude-loopback` combined.
 
       --exclude-file <EXCLUDE_FILE>
-          Deprecated; use `--exclude-path` instead
+          Deprecated since v0.15.1; use `--exclude-path` instead
 
       --exclude-link-local
           Exclude link-local IP address range from checking


### PR DESCRIPTION
Linked to #1789

Changes:
- Reorder alphabetically (by long names)
- Added the version number next to the deprecation note of `--bump` and `--exclude-file`
- Made the lines more narrow and reduce/prevent scrolling in the code block to read all information
- More uniform representation of examples or available options
- Few wording changes

I like that this also highlights now that casing matters for `-v`/`-V`, `-t`/`-T` or `-h`/`-H`.

**Please check and review!**
See it here: https://github.com/tooomm/lychee/tree/patch-2?tab=readme-ov-file#commandline-parameters

<br>

Questions:
~~1) Since which lychee version is `--exclude-file` deprecated?~~
2) What is the default for `--cache-exclude-status`?
  The list shows "[default: ]", does that mean there is no default?
3) Should we add an example on when to separate inputs from options with "--"?
4) For `--github-token`, how to understand the `[env: GITHUB_TOKEN]` note?
5) For `--help`, the explanation reads `Print help (see a summary with '-h')`.
  Isn't `-h` the same as `--help`? So I do not really get the comment in brackets.
6) How many levels of quiet and verbose are there? -qq << -q << none >> -v >> -vv ?
  How do they interact/relate, I assume they are mutually exclusive?
7) How to interpret the `...` behind a few options?

Notes:
- `-X`/`--method` has not a short form derived from its long form
- I could imagine something like `--dump-options`, `--dump-args`, or `--dump-params` could be helpful.
  The idea would be to not only list the provided options, but also list out default values otherwise hidden
- Following the logic in other places, shouldn't `--hidden` be named something like the many other includes,
  e.g. `--include-hidden`
- https://github.com/lycheeverse/lychee/issues/1789#issuecomment-3193390510_

<br>

Edit:
Looks like the output of `--help` is out of sync with this README change, but is expected to match (See test). Can look at that after the rest is clarified.