### PR TITLE
snap: enable proper permissions

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,3 +30,6 @@ parts:
 apps:
   lychee:
     command: lychee
+    plugs:
+      - home
+      - network


### PR DESCRIPTION
Allows the packaged app to access files and the network.