### PR TITLE
Always check files explicitly if specified by user or matched by user glob

### DIFF
--- a/fixtures/example_dir/example.html
+++ b/fixtures/example_dir/example.html
@@ -1,0 +1,1 @@
+<a href="https://example.com/example_dir/html">This is an HTML file to test glob patterns in lychee.</a>

--- a/fixtures/example_dir/example.md
+++ b/fixtures/example_dir/example.md
@@ -1,0 +1,3 @@
+# Example Markdown file to test glob patterns in lychee.
+
+It contains a link: https://example.com/example_dir/md

--- a/fixtures/example_dir/example.ts
+++ b/fixtures/example_dir/example.ts
@@ -1,0 +1,2 @@
+// This is a TypeScript file to test glob patterns in lychee.
+// It contains a link: https://example.com/example_dir/ts

--- a/fixtures/example_dir/example.tsx
+++ b/fixtures/example_dir/example.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Example: React.FC = () => {
+    return (
+        <div>
+            <h1>Example Page</h1>
+            <a href="https://example.com/example_dir/tsx" target="_blank" rel="noopener noreferrer">
+                Visit Example.com
+            </a>
+        </div>
+    );
+};
+
+export default Example;

--- a/fixtures/glob_dir/example.html
+++ b/fixtures/glob_dir/example.html
@@ -1,0 +1,1 @@
+<a href="https://example.com/glob_dir/html">This is an HTML file to test glob patterns in lychee.</a>

--- a/fixtures/glob_dir/example.md
+++ b/fixtures/glob_dir/example.md
@@ -1,0 +1,3 @@
+# Example Markdown file to test glob patterns in lychee.
+
+It contains a link: https://example.com/glob_dir/md

--- a/fixtures/glob_dir/example.ts
+++ b/fixtures/glob_dir/example.ts
@@ -1,0 +1,2 @@
+// This is a TypeScript file to test glob patterns in lychee.
+// It contains a link: https://example.com/glob_dir/ts

--- a/fixtures/glob_dir/example.tsx
+++ b/fixtures/glob_dir/example.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const Example: React.FC = () => {
+    return (
+        <div>
+            <h1>Example Page</h1>
+            <a href="https://example.com/glob_dir/tsx" target="_blank" rel="noopener noreferrer">
+                Visit Example.com
+            </a>
+        </div>
+    );
+};
+
+export default Example;

--- a/lychee-bin/src/commands/dump_inputs.rs
+++ b/lychee-bin/src/commands/dump_inputs.rs
@@ -16,7 +16,7 @@ pub(crate) async fn dump_inputs(
     inputs: HashSet<Input>,
     output: Option<&PathBuf>,
     excluded_paths: &[String],
-    valid_extensions: &FileExtensions,
+    file_extensions: &FileExtensions,
     skip_hidden: bool,
     skip_gitignored: bool,
 ) -> Result<ExitCode> {
@@ -34,7 +34,7 @@ pub(crate) async fn dump_inputs(
 
     for input in inputs {
         let sources_stream = input.get_sources(
-            valid_extensions.clone(),
+            file_extensions.clone(),
             skip_hidden,
             skip_gitignored,
             &excluded_path_filter,

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -2664,6 +2664,7 @@ mod cli {
             .assert()
             .failure()
             .stdout(contains("2 Total"))
+            // Note: The space is intentional to avoid matching tsx.
             .stderr(contains("https://example.com/glob_dir/ts "))
             // TSX files are ignored because we did not specify
             // that extension. So `https://example.com/tsx"` should be missing from the output.
@@ -2700,5 +2701,25 @@ mod cli {
             .stderr(contains("https://example.com/example_dir/ts ").not())
             // TSX files in examle_dir are ignored because we did not specify that extension.
             .stderr(contains("https://example.com/example_dir/tsx").not());
+    }
+
+    /// Individual files should always be checked, even if their
+    /// extension does not match the given extensions.
+    #[test]
+    fn test_file_inputs_always_get_checked_no_matter_their_extension() {
+        let ts_input_file = fixtures_path().join("glob_dir/example.ts");
+        let md_input_file = fixtures_path().join("glob_dir/example.md");
+
+        main_command()
+            .arg("--verbose")
+            .arg("--dump")
+            .arg("--extensions=html,md")
+            .arg(ts_input_file)
+            .arg(md_input_file)
+            .assert()
+            .success()
+            .stderr("") // Ensure stderr is empty
+            .stdout(contains("https://example.com/glob_dir/ts"))
+            .stdout(contains("https://example.com/glob_dir/md"));
     }
 }

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -301,8 +301,12 @@ impl Input {
                             yield InputSource::FsPath(entry.path().to_path_buf());
                         }
                     } else {
-                        // For individual files, yield if not excluded and matches extensions
-                        if !Self::is_excluded_path(path, excluded_paths) && file_extensions_match(path, &file_extensions) {
+                        // For individual files, yield if not excluded.
+                        // We do not filter by extension here, as individual files
+                        // should always be checked, no matter if their extension matches or not.
+                        // This follows the principle of least surprise because the user
+                        // explicitly specified the file.
+                        if !Self::is_excluded_path(path, excluded_paths) {
                             yield InputSource::FsPath(path.clone());
                         }
                     }
@@ -547,21 +551,6 @@ impl TryFrom<&str> for Input {
     fn try_from(value: &str) -> std::result::Result<Self, Self::Error> {
         Self::from_value(value)
     }
-}
-
-/// Helper function to check if a file path matches any of the given extensions
-fn file_extensions_match(path: &Path, extensions: &FileExtensions) -> bool {
-    // If the path has no extension, check if we accept plaintext files
-    // NOTE: We treat files without extensions as plaintext, which might be problematic
-    // and is therefore subject to change
-    if path.extension().is_none() {
-        return extensions.contains("txt") || extensions.contains("");
-    }
-
-    // Otherwise, check if the extension is in our allowed list
-    path.extension()
-        .and_then(|ext| ext.to_str())
-        .is_some_and(|ext| extensions.contains(ext.to_lowercase()))
 }
 
 #[cfg(test)]

--- a/lychee-lib/src/types/input.rs
+++ b/lychee-lib/src/types/input.rs
@@ -264,10 +264,10 @@ impl Input {
                                     continue;
                                 }
 
-                                // Check if it matches one of our file extensions
-                                if file_extensions_match(&path, &file_extensions) {
-                                    yield InputSource::FsPath(path);
-                                }
+                                // Ignore extensions here. Instead, always check
+                                // files captured by the glob pattern, as the
+                                // user explicitly specified them.
+                                yield InputSource::FsPath(path);
                             }
                             Err(e) => {
                                 eprintln!("Error in glob pattern: {e:?}");


### PR DESCRIPTION
Ensure that files specified via glob patterns are always checked, regardless of their extensions. This change addresses the issue where no links were found due to configuration errors. Additional tests have been added to verify glob pattern handling and extension checks.

Fixes lycheeverse/lychee-action#305