### PR TITLE
Fix pre-commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,18 +1,30 @@
 - id: lychee
   name: lychee
-  description: "Run 'lychee' for fast, async, stream-based link checking"
+  description: "Run 'lychee' for fast, async, stream-based link checking (auto-installs)"
+  entry: scripts/lychee_pre_commit.sh
+  language: script
+  args: ["--no-progress"]
+  types: [text]
+  pass_filenames: true
+  require_serial: true
+  minimum_pre_commit_version: "2.9.2"
+- id: lychee-system
+  name: lychee-system
+  description: "Run 'lychee' using system installation (requires: cargo install lychee)"
   entry: lychee
   language: system
   args: ["--no-progress"]
   types: [text]
   pass_filenames: true
   require_serial: true
+  minimum_pre_commit_version: "2.9.2"
 - id: lychee-docker
-  name: lychee
-  description: "Run 'lychee' docker image for fast, async, stream-based link checking"
-  entry: lycheeverse/lychee:0.14
+  name: lychee-docker  
+  description: "Run 'lychee' docker image for fast, async, stream-based link checking (auto-installs)"
+  entry: lycheeverse/lychee:0.20.1
   language: docker_image
   args: ["--no-progress"]
   types: [text]
   pass_filenames: true
   require_serial: true
+  minimum_pre_commit_version: "2.9.2"

--- a/PRE_COMMIT.md
+++ b/PRE_COMMIT.md
@@ -1,0 +1,78 @@
+# Lychee Pre-commit Hooks
+
+This repository provides three pre-commit hook options for lychee link checking:
+
+## Quick Start
+
+Add this to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+  - repo: https://github.com/lycheeverse/lychee
+    rev: lychee-v0.20.1  # Use latest lychee-v* tag
+    hooks:
+      - id: lychee  # Auto-installs lychee
+```
+
+## Hook Options
+
+### 1. `lychee` (Recommended)
+
+- **Auto-installs** lychee using cargo-binstall (fast) or cargo install (fallback)
+- **Best user experience** - no manual setup required
+- **Fast** - uses pre-built binaries when available
+
+```yaml
+- id: lychee
+  args: ["--no-progress", "--exclude", "file://"]
+```
+
+### 2. `lychee-system` 
+
+- **Requires manual installation**: `cargo install lychee`
+- **Fastest** - no installation overhead
+- **For users who already have lychee installed**
+
+```yaml
+- id: lychee-system
+  args: ["--no-progress", "--exclude", "file://"]
+```
+
+### 3. `lychee-docker`
+
+- **Auto-installs** via Docker image
+- **Slower** - pulls Docker image
+- **For environments where cargo is not available**
+
+```yaml
+- id: lychee-docker
+  args: ["--no-progress", "--exclude", "file://"]
+```
+
+## Version Format
+
+⚠️ **Important**: Use `lychee-v*` format for tags (e.g., `lychee-v0.20.1`), not `v*` format.
+
+The tag format changed after v0.15.1 to support cargo-binstall URL patterns:
+- ❌ `rev: v0.20.1` (doesn't exist)  
+- ✅ `rev: lychee-v0.20.1` (correct format)
+
+## Common Configuration
+
+```yaml
+repos:
+  - repo: https://github.com/lycheeverse/lychee
+    rev: lychee-v0.20.1
+    hooks:
+      - id: lychee
+        args: 
+          - --no-progress
+          - --exclude=file://
+          - --exclude=mailto:
+```
+
+## Troubleshooting
+
+**"Executable `lychee` not found"**: Use the default `lychee` hook (not `lychee-system`) for auto-installation.
+
+**Tag format issues**: Ensure you're using `lychee-v*` format, not `v*` format for versions after 0.15.1.

--- a/scripts/lychee_pre_commit.sh
+++ b/scripts/lychee_pre_commit.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# Auto-install lychee if not found
+if ! command -v lychee &> /dev/null; then
+    echo "Installing lychee..."
+    
+    # Try cargo-binstall first (faster - uses pre-built binaries)
+    if command -v cargo-binstall &> /dev/null; then
+        echo "Using cargo-binstall for faster installation..."
+        cargo binstall lychee --no-confirm
+    else
+        # Fall back to cargo install (slower - compiles from source)
+        echo "Using cargo install (this may take a few minutes)..."
+        cargo install lychee
+    fi
+fi
+
+# Run lychee with all passed arguments
+exec lychee "$@"


### PR DESCRIPTION
So I was thinking about the pre-commit hooks again. At the moment, the installation fails because lychee is a workspace and AFAICT, there is no way to say to the pre-commit project to install the Rust *binary* in the project (correct me if I'm wrong). 

The workaround is to provide a script which installs lychee. This has the advantage that we can use `cargo binstall`, if available`, to speed up the installation process. If it is not available, we fall back to a normal installation. The installation should happen automatically if users use the default `lychee` hook.

I also considered using our pre-built lychee binaries instead, but this would require us to check the platform we're on before fetching the correct binary. That would be additional work, but may worth it? 🤔 I could change that part, but I would like to hear if this is a thing that is typically done. I haven't checked if there's an example for that binary installation process anywhere. Either way, we could also do that in a separate PR. This PR should at least unblock most users for now (?).

Feedback welcome! 

## Implementation Details

- Add auto-installing lychee hook using script that tries cargo-binstall then cargo install
- Add lychee-system hook for users with existing installations
- Update docker hook to use current version (0.20.1)
- Add `PRE_COMMIT.md` documentation which explains hook options and version format
- Fix version tag format usage (lychee-v* instead of v*)

Closes: #1635