### PR TITLE
 chore(file checker): separate resolving and checking for easier testing

### DIFF
--- a/lychee-lib/src/checker/file.rs
+++ b/lychee-lib/src/checker/file.rs
@@ -156,12 +156,10 @@ impl FileChecker {
         //
         // (currently, this case is only reachable if `.` is in the index_files list.)
         match path {
-            Ok(dir_path) if dir_path.is_dir() => {
-                match self.apply_fallback_extensions(&dir_path, uri) {
-                    Ok(fallback_path) => Ok(Cow::Owned(fallback_path)),
-                    Err(_) => Ok(dir_path),
-                }
-            }
+            Ok(dir_path) if dir_path.is_dir() => self
+                .apply_fallback_extensions(&dir_path, uri)
+                .map(Cow::Owned)
+                .or(Ok(dir_path)),
             Ok(path) => Ok(path),
             Err(err) => Err(err),
         }


### PR DESCRIPTION
  this does a simple refactor to break up the `check_path` function.   previously, this had the responsibility of resolving index   files/fallback extensions _and_ checking fragments. this was done in one   step which made it hard to test - in order to test the resolving, we had  to test it indirectly by checking fragments in certain files.
  
  this introduces a new `resolve_local_path` function which only applies  the index file + extensions, so we can use this in unit tests and make  assertions about the resolved path.
  
  this should have no changes to any behaviour.

~please note perf bug.~ also, idk if I go overboard with the macros ;-;
