### PR TITLE
Fix locating of version when tagging Docker images on Git tag push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,9 +38,8 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ github.ref_name }},prefix=lychee-
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }},prefix=lychee-
-            type=semver,pattern={{major}},value=${{ github.ref_name }},prefix=lychee-
+            type=semver,pattern=lychee-{{version}},value=${{ github.ref_name }}
+            type=semver,pattern=lychee-{{major}}.{{minor}},value=${{ github.ref_name }}
             type=sha
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
@@ -60,9 +59,8 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern={{version}},value=${{ github.ref_name }},prefix=lychee-
-            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }},prefix=lychee-
-            type=semver,pattern={{major}},value=${{ github.ref_name }},prefix=lychee-
+            type=semver,pattern=lychee-{{version}},value=${{ github.ref_name }}
+            type=semver,pattern=lychee-{{major}}.{{minor}},value=${{ github.ref_name }}
             type=sha
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
To contribute to https://github.com/lycheeverse/lychee/issues/1833

Fix locating of version when tagging Docker images on Git tag push and also remove tagging major version only, because it would resolve to 'version 0' at the moment.