### PR TITLE
fix: add support for name attributes in HTML fragment extraction

### DIFF
--- a/lychee-lib/src/extract/html/html5gum.rs
+++ b/lychee-lib/src/extract/html/html5gum.rs
@@ -235,6 +235,12 @@ impl LinkExtractor {
             self.fragments.insert(id.to_string());
         }
 
+        // Also check for 'name' attributes for backward compatibility with older HTML
+        // standards and JavaDoc-generated HTML which uses <a name="anchor"> instead of id
+        if let Some(name) = self.current_attributes.get("name") {
+            self.fragments.insert(name.to_string());
+        }
+
         self.current_attributes.clear();
     }
 }
@@ -704,5 +710,37 @@ mod tests {
 
         let uris = extract_html(input, false);
         assert!(uris.is_empty());
+    }
+
+    #[test]
+    fn test_extract_fragments_with_name_attributes() {
+        // Test for JavaDoc-style name attributes used for anchors
+        let input = r#"
+        <html>
+        <body>
+            <h1 id="title">Title</h1>
+            <a name="skip.navbar.top"></a>
+            <a name="method.summary"></a>
+            <div>
+                <a name="clear--"></a>
+                <h2 id="section">Section</h2>
+                <a name="method.detail"></a>
+            </div>
+            <a name="skip.navbar.bottom"></a>
+        </body>
+        </html>
+        "#;
+
+        let expected = HashSet::from([
+            "title".to_string(),
+            "section".to_string(),
+            "skip.navbar.top".to_string(),
+            "method.summary".to_string(),
+            "clear--".to_string(),
+            "method.detail".to_string(),
+            "skip.navbar.bottom".to_string(),
+        ]);
+        let actual = extract_html_fragments(input);
+        assert_eq!(actual, expected);
     }
 }


### PR DESCRIPTION
Fixes fragment checking for JavaDoc-generated HTML which uses <a name="anchor"> instead of id attributes for anchors.

This resolves a regression where lychee v0.20.1 was failing to find fragments that worked in v0.18.1, particularly for JavaDoc URLs like:
- https://example.com/javadoc/Class.html#method--
- https://example.com/javadoc/Class.html#skip.navbar.top

The fix maintains backward compatibility by checking both 'id' and 'name' attributes when extracting fragments from HTML documents.

Resolves #1838