### PR TITLE
refactor: add exhaustivity check for `fold_in!` macro

### DIFF
--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -201,7 +201,7 @@ default_function! {
 macro_rules! fold_in {
     ($cli:ident , $toml:ident ; $ty:ident { $(..$ignore:ident,)* $( $key:ident : $default:expr, )* } ) => {
         if (false) {
-            #[allow(dead_code, unused)]
+            #[allow(dead_code, unused, clippy::diverging_sub_expression)]
             let _check_fold_in_exhaustivity = $ty {
                 $($key: unreachable!(), )*
                 $($ignore: unreachable!(), )*


### PR DESCRIPTION
now, if a field is missing:
```rust
error[E0063]: missing field `header` in initializer of `Config`
   --> lychee-bin/src/options.rs:205:47
    |
205 |               let _check_fold_in_exhaustivity = $ty {
    |                                                 ^^^ missing `header`
...
858 | /         fold_in! {
859 | |             // Destination and source configs
860 | |             self, toml;
...   |
919 | |         }
    | |_________- in this macro invocation
```
and if a field is repeated:
```rust
error[E0062]: field `github_token` specified more than once
   --> lychee-bin/src/options.rs:865:19
    |
206 |                 $($key: unreachable!(), )*
    |                   -------------------- first use of `github_token`
...
865 |                 ..github_token,
    |                   ^^^^^^^^^^^^ used more than once
```

this works by trying to construct a struct literal using the listed fields. the error messages are accurate, but the source code snippets might be confusing. 

this changes the macro syntax slightly to look superficially similar to a struct literal.
```rust
        fold_in! {
            // Destination and source configs
            self, toml;

            Config {
                // Keys which are handled outside of fold_in
                ..header,
                ..github_token,

                // Keys with defaults to assign
                accept: StatusCodeSelector::default(),
                ...
```
but maybe this is more confusing, because this is not literally a struct syntax. for instance, the spread `..` is applied to individual fields rather than a struct variable.

todo:
- maybe, add all the fields to smoketest.toml and add a comment that if you change this macro, then you should change the toml too.

follow up to https://github.com/lycheeverse/lychee/pull/1843.

edit: also, I should add that the macro logic is slightly flawed. it assumes that if the CLI has a default value for an argument, then that can be overridden. but that's not necessarily correct, because the user may have manually specified a CLI argument that happens to be the same as the default. in these cases, the CLI value should have precedence.