### PR TITLE
fix: do not reuse excluded status from cache

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -246,7 +246,11 @@ fn load_cache(cfg: &Config) -> Option<Cache> {
         }
     }
 
-    let cache = Cache::load(LYCHEE_CACHE_FILE, cfg.max_cache_age.as_secs());
+    let cache = Cache::load(
+        LYCHEE_CACHE_FILE,
+        cfg.max_cache_age.as_secs(),
+        &cfg.cache_exclude_status,
+    );
     match cache {
         Ok(cache) => Some(cache),
         Err(e) => {


### PR DESCRIPTION
Ensures that Uris in the cache whose status has in the meantime been excluded will not be reused.

If any more skips end up in `Cache::load`, it would probably make sense to pass the entire config to it, rather than bits and pieces.

Fixes: #1770 