### PR TITLE
add cargo-msrv to the devshell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
               pkgs.openssl
               rust
               pkgs.cargo-nextest
+              pkgs.cargo-msrv
             ];
           };
         }


### PR DESCRIPTION
Just noticed that this was missing and `make verify` is therefore not available ootb.