### PR TITLE
feat: improve InvalidIndexFile error to mention index file names

### DIFF
--- a/lychee-bin/src/client.rs
+++ b/lychee-bin/src/client.rs
@@ -28,13 +28,6 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
 
     let headers = HeaderMap::from_header_pairs(&cfg.header)?;
 
-    // Drop empty index file names. These will never be accepted as valid
-    // index files, and doing this makes cleaner error reporting.
-    let index_files = cfg.index_files.clone().map(|mut names| {
-        names.retain(|x| !x.is_empty());
-        names
-    });
-
     ClientBuilder::builder()
         .remaps(remaps)
         .base(cfg.base_url.clone())
@@ -61,7 +54,7 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
         .min_tls_version(cfg.min_tls.clone().map(Into::into))
         .include_fragments(cfg.include_fragments)
         .fallback_extensions(cfg.fallback_extensions.clone())
-        .index_files(index_files)
+        .index_files(cfg.index_files.clone())
         .build()
         .client()
         .context("Failed to create request client")

--- a/lychee-bin/src/client.rs
+++ b/lychee-bin/src/client.rs
@@ -28,6 +28,13 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
 
     let headers = HeaderMap::from_header_pairs(&cfg.header)?;
 
+    // Drop empty index file names. These will never be accepted as valid
+    // index files, and doing this makes cleaner error reporting.
+    let index_files = cfg.index_files.clone().map(|mut names| {
+        names.retain(|x| !x.is_empty());
+        names
+    });
+
     ClientBuilder::builder()
         .remaps(remaps)
         .base(cfg.base_url.clone())
@@ -54,7 +61,7 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
         .min_tls_version(cfg.min_tls.clone().map(Into::into))
         .include_fragments(cfg.include_fragments)
         .fallback_extensions(cfg.fallback_extensions.clone())
-        .index_files(cfg.index_files.clone())
+        .index_files(index_files)
         .build()
         .client()
         .context("Failed to create request client")

--- a/lychee-lib/src/checker/file.rs
+++ b/lychee-lib/src/checker/file.rs
@@ -242,7 +242,7 @@ impl FileChecker {
                 let path = dir_path.join(filename);
                 exists(&path).then_some(path)
             })
-            .ok_or_else(|| ErrorKind::InvalidIndexFile(dir_path.to_path_buf()))
+            .ok_or_else(|| ErrorKind::InvalidIndexFile(index_names_to_try.to_vec()))
     }
 
     /// Checks a resolved file, optionally verifying fragments for HTML files.

--- a/lychee-lib/src/checker/file.rs
+++ b/lychee-lib/src/checker/file.rs
@@ -240,7 +240,7 @@ impl FileChecker {
 
         index_names_to_try
             .iter()
-            .find_map(|ref filename| {
+            .find_map(|filename| {
                 // for some special index file names, we accept directories as well
                 // as files.
                 let exists = match filename.as_str() {

--- a/lychee-lib/src/checker/file.rs
+++ b/lychee-lib/src/checker/file.rs
@@ -229,9 +229,18 @@ impl FileChecker {
             None => &[".".to_owned()],
         };
 
+        let invalid_index_error = || {
+            // Drop empty index file names. These will never be accepted as valid
+            // index files, and doing this makes cleaner error reporting.
+            let mut names = index_names_to_try.to_vec();
+            names.retain(|x| !x.is_empty());
+
+            ErrorKind::InvalidIndexFile(names)
+        };
+
         index_names_to_try
             .iter()
-            .find_map(|filename| {
+            .find_map(|ref filename| {
                 // for some special index file names, we accept directories as well
                 // as files.
                 let exists = match filename.as_str() {
@@ -242,7 +251,7 @@ impl FileChecker {
                 let path = dir_path.join(filename);
                 exists(&path).then_some(path)
             })
-            .ok_or_else(|| ErrorKind::InvalidIndexFile(index_names_to_try.to_vec()))
+            .ok_or_else(invalid_index_error)
     }
 
     /// Checks a resolved file, optionally verifying fragments for HTML files.

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -70,9 +70,9 @@ pub enum ErrorKind {
     #[error("Cannot find fragment")]
     InvalidFragment(Uri),
 
-    /// The given directory is missing a required index file
+    /// Cannot resolve local directory link using the configured index files
     #[error("Cannot find index file within directory")]
-    InvalidIndexFile(PathBuf),
+    InvalidIndexFile(Vec<String>),
 
     /// The given path cannot be converted to a URI
     #[error("Invalid path to URL conversion: {0}")]
@@ -330,9 +330,11 @@ impl ErrorKind {
             ErrorKind::StatusCodeSelectorError(status_code_selector_error) => Some(format!(
                 "Status code selector error: {status_code_selector_error}. Check accept configuration",
             )),
-            ErrorKind::InvalidIndexFile(_path) => Some(
-                "Index file not found in directory. Check if index.html or other index files exist".to_string()
-            ),
+            ErrorKind::InvalidIndexFile(index_files) => match &index_files[..] {
+                [] => "No directory links are allowed because index_files is defined and empty".to_string(),
+                [name] => format!("An index file ({name}) is required"),
+                [init @ .., tail] => format!("An index file ({}, or {}) is required", init.join(", "), tail),
+            }.into()
         }
     }
 


### PR DESCRIPTION
this makes it clearer which files are causing the link check to fail. it also lets us customise the message in the special case of `--index-files ''`, which could otherwise be confusing with a generic message.

the messages are:
```
[ERROR] file:///h | Cannot find index file within directory: An index file (index.html) is required
[ERROR] file:///h | Cannot find index file within directory: An index file (index.html, or index.htm) is required
[ERROR] file:///h | Cannot find index file within directory: An index file (index.html, index.htm, or index.md) is required
```

and for the `--index-files ''` case:
```
[ERROR] file:///h | Cannot find index file within directory: No directory links are allowed because index_files is defined and empty
```

i do wonder if this last error message is still confusing because of the "Cannot find index file within directory" text. maybe it should be changed to a more general "Cannot resolve link to local directory" or "Invalid local directory link"?

for comparison, the old message was this:
```
[ERROR] file:///h | Cannot find index file within directory: Index file not found in directory. Check if index.html or other index files exist
```
and it was constant and never changed.