### PR TITLE
Fix CI lint by adding rustfmt in the the toolchain components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,7 @@ jobs:
       - name: Run cargo fmt (check if all code is rustfmt-ed)
         run: cargo fmt --all --check
       - name: Run cargo clippy (deny warnings)
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features -- -D warnings
       - uses: cargo-bins/cargo-binstall@main
       - name: Install cargo-msrv
         run: cargo binstall --no-confirm --force cargo-msrv
@@ -58,16 +55,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: cargo fetch
-        uses: actions-rs/cargo@v1
-        with:
-          command: fetch
+        run: cargo fetch
       - name: cargo publish lychee-lib
-        uses: actions-rs/cargo@v1
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        with:
-          command: publish
-          args: --dry-run --manifest-path lychee-lib/Cargo.toml
+        run: cargo publish --dry-run --manifest-path lychee-lib/Cargo.toml
 
       # Can't check lychee binary as it depends on the lib above
       # and `--dry-run` doesn't allow unpublished crates yet.
@@ -95,17 +87,8 @@ jobs:
       - name: Check that rustls-tls feature doesn't depend on OpenSSL
         run: test -z "$( cargo tree --package lychee --no-default-features --features rustls-tls --prefix none | sed -n '/^openssl-sys /p' )"
       - name: Run cargo check with default features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets
+        run: cargo check --workspace --all-targets
       - name: Run cargo check with all features
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets --all-features
+        run: cargo check --workspace --all-targets --all-features
       - name: Run cargo check with rustls-tls feature
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --workspace --all-targets --no-default-features --features rustls-tls
+        run: cargo check --workspace --all-targets --no-default-features --features rustls-tls

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,10 +39,7 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Run cargo fmt (check if all code is rustfmt-ed)
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all --check
       - name: Run cargo clippy (deny warnings)
         uses: actions-rs/cargo@v1
         with:


### PR DESCRIPTION
CI is currently failing with this error:
`'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.`

adding rustfmt as a toolchain component fixes is