### PR TITLE
Explicitly add `rustfmt` component to toolchain config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy
+          components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       - name: Run cargo fmt (check if all code is rustfmt-ed)
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Looks like they changed something in the Rust toolchain recently, which causes CI breakage.

Related: 
- Comment by @katrinafyi: https://github.com/lycheeverse/lychee/pull/1857#issuecomment-3344741362
- Failing pipeline example: https://github.com/lycheeverse/lychee/actions/runs/18085016162/job/51454625324?pr=1857
