### PR TITLE
fix: move log level padding outside brackets

### DIFF
--- a/lychee-bin/src/formatters/log.rs
+++ b/lychee-bin/src/formatters/log.rs
@@ -62,7 +62,7 @@ pub(crate) fn init_logging(verbose: &Verbosity, mode: &OutputMode) {
             let level_text = format!("{level}");
             let padding = (MAX_RESPONSE_OUTPUT_WIDTH.saturating_sub(max_level_text_width)).max(0);
             let level_padding = max_level_text_width.saturating_sub(level_text.len() + 2);
-            let prefix = format!("[{level_text}]{:<width$}", "", width = level_padding);
+            let prefix = format!("{:>width$}[{level_text}]", "", width = level_padding);
             let color = formatters::color::color_for_level(level);
             let colored_level = color.apply_to(&prefix);
             writeln!(


### PR DESCRIPTION
## Summary

Move log level padding from inside brackets to outside brackets for better visual appearance.

**Before:**
```bash
[WARN ] Test
[ERROR] Test
```

**After:**
```bash
[WARN]  Test
[ERROR] Test
```

## Changes
Modified `lychee-bin/src/formatters/log.rs` to place padding after brackets instead of inside

## Related Issue
Fixes #1868