### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -43,47 +43,36 @@ jobs:
     strategy:
       matrix:
         include:
-          - build: linux
-            os: ubuntu-latest
-            rust: nightly
+          - build: x86_64-gnu
+            target: x86_64-unknown-linux-gnu
+            strip: x86_64-linux-gnu-strip
+          - build: x86_64-musl
             target: x86_64-unknown-linux-musl
             strip: x86_64-linux-musl-strip
-          - build: stable-x86
-            os: ubuntu-latest
-            rust: stable
-            target: i686-unknown-linux-gnu
-            strip: x86_64-linux-gnu-strip
-            qemu: i386
-          - build: stable-aarch64
-            os: ubuntu-latest
-            rust: stable
-            target: aarch64-unknown-linux-gnu
-            strip: aarch64-linux-gnu-strip
-            qemu: qemu-aarch64
-          - build: stable-arm-gnueabihf
-            os: ubuntu-latest
-            rust: stable
+          - build: arm-gnueabihf
             target: armv7-unknown-linux-gnueabihf
             strip: arm-linux-gnueabihf-strip
             qemu: qemu-arm
-          - build: stable-arm-musleabihf
-            os: ubuntu-latest
-            rust: stable
-            target: armv7-unknown-linux-musleabihf
-            strip: arm-linux-musleabihf-strip
-            qemu: qemu-arm
-          - build: stable-arm-musleabi
-            os: ubuntu-latest
-            rust: stable
-            target: armv7-unknown-linux-musleabi
+          - build: arm-musleabi
+            target: arm-unknown-linux-musleabi
             strip: arm-linux-musleabi-strip
             qemu: qemu-arm
-          - build: stable-s390x
-            os: ubuntu-latest
-            rust: stable
-            target: s390x-unknown-linux-gnu
-            strip: s390x-linux-gnu-strip
-            qemu: qemu-s390x
+          - build: arm-musleabihf
+            target: arm-unknown-linux-musleabihf
+            strip: arm-linux-musleabihf-strip
+            qemu: qemu-arm
+          - build: aarch64-gnu
+            target: aarch64-unknown-linux-gnu
+            strip: aarch64-linux-gnu-strip
+            qemu: qemu-aarch64
+          - build: aarch64-musl
+            target: aarch64-unknown-linux-musl
+            strip: aarch64-linux-musl-strip
+            qemu: qemu-aarch64
+          - build: i686-gnu
+            target: i686-unknown-linux-gnu
+            strip: x86_64-linux-gnu-strip
+            qemu: i386
       fail-fast: false
     steps:
       - name: Install musl tools


### PR DESCRIPTION
With 9f23103 I unfortunately broke the release-binary.yml workflow. Because we now want to generate the man pages in CI we need to run lychee itself, which in turn requires qemu. This PR is heavily inspired by [ripgrep's release workflow](https://github.com/BurntSushi/ripgrep/blob/master/.github/workflows/release.yml).

The qemu invocations with docker are actually really fast, which surprised me. They take about one second to run.
You see that I also update the target matrix, which for now I've cloned from ripgrep. Would you like to keep the original matrix? Having this one seems to be fine to me, since ripgrep has probably a much broader user base it should cover enough users.

I've notice that Windows and macOS are completely separated in this workflow. IMO it makes sense to streamline the release for all three targets, as is done in by ripgrep. I've opened #1875 for that.

See https://github.com/thomas-zahner/lychee/actions/runs/18653717357 for a workflow run.