### PR TITLE
chore: release v0.21.0

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -27,6 +27,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
+      - name: Debugging
+        if: ${{ github.repository }}
+        run: |
+          echo ${{github.repository}}
+          echo ${{github.ref}}
+          echo $GITHUB_REF
+          echo ${{ github.repository == 'lycheeverse/lychee' }}
+          echo ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
+          echo ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
+          echo ${{ github.repository == 'lycheeverse/lychee' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main') }}
+          exit 1
+
       - name: Get release
         id: get_release
         uses: bruceadams/get-release@v1.3.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2505,7 +2505,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2556,7 +2556,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.20.1"
+version = "0.21.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4385,7 +4385,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.20.1"
+version = "0.21.0"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.20.1"
+version = "0.21.0"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.20.1...lychee-v0.21.0) - 2025-10-21
+
+### Added
+
+- print warning if input source matches no files ([#1865](https://github.com/lycheeverse/lychee/pull/1865))
+- *(base-url)* [**breaking**] disallow relative local base to avoid confusion ([#1857](https://github.com/lycheeverse/lychee/pull/1857))
+- improve InvalidIndexFile error to mention index file names ([#1859](https://github.com/lycheeverse/lychee/pull/1859))
+
+### Fixed
+
+- move log level padding outside brackets ([#1871](https://github.com/lycheeverse/lychee/pull/1871))
+- do not reuse excluded status from cache ([#1850](https://github.com/lycheeverse/lychee/pull/1850))
+- fields missing from config.toml parsing logic ([#1843](https://github.com/lycheeverse/lychee/pull/1843))
+
+### Other
+
+- Do not require inputs with generate flag
+- Bump the dependencies group across 1 directory with 15 updates ([#1874](https://github.com/lycheeverse/lychee/pull/1874))
+- Inline formatting arguments for anyhow macros as per new lint
+- Man pages ([#1858](https://github.com/lycheeverse/lychee/pull/1858))
+- Add --default-extension argument to force file format ([#1842](https://github.com/lycheeverse/lychee/pull/1842))
+- hard wrap help text for options ([#1854](https://github.com/lycheeverse/lychee/pull/1854))
+- Bump the dependencies group with 6 updates ([#1855](https://github.com/lycheeverse/lychee/pull/1855))
+- add exhaustivity check for `fold_in!` macro ([#1848](https://github.com/lycheeverse/lychee/pull/1848))
+- Additional redirect reporting ([#1853](https://github.com/lycheeverse/lychee/pull/1853))
+- Redirect reporting ([#1725](https://github.com/lycheeverse/lychee/pull/1725))
+- Add WinGet installation instructions ([#1849](https://github.com/lycheeverse/lychee/pull/1849))
+- [**breaking**] use `ResolvedInputSource` downstream of `InputContent` ([#1840](https://github.com/lycheeverse/lychee/pull/1840))
+- Bump the dependencies group with 5 updates ([#1845](https://github.com/lycheeverse/lychee/pull/1845))
+- Implement `--files-from` Option ([#1836](https://github.com/lycheeverse/lychee/pull/1836))
+- apply fallback extensions if directory links resolve to a dir ([#1826](https://github.com/lycheeverse/lychee/pull/1826))
+- clarify `--base-url` and `--root-dir` and their interactions ([#1787](https://github.com/lycheeverse/lychee/pull/1787))
+- Add test for making sure URL inputs always get checked ([#1824](https://github.com/lycheeverse/lychee/pull/1824))
+- add conda install to readme ([#1822](https://github.com/lycheeverse/lychee/pull/1822))
+- Bump the dependencies group with 3 updates ([#1821](https://github.com/lycheeverse/lychee/pull/1821))
+- Refactor error reporting ([#1731](https://github.com/lycheeverse/lychee/pull/1731))
+
 ## [0.20.1](https://github.com/lycheeverse/lychee/compare/lychee-v0.20.0...lychee-v0.20.1) - 2025-08-25
 
 ### Other

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.85.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.20.1", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.21.0", default-features = false }
 
 anyhow = "1.0.100"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.20.1...lychee-lib-v0.21.0) - 2025-10-21
+
+### Added
+
+- print warning if input source matches no files ([#1865](https://github.com/lycheeverse/lychee/pull/1865))
+- *(base-url)* [**breaking**] disallow relative local base to avoid confusion ([#1857](https://github.com/lycheeverse/lychee/pull/1857))
+- improve InvalidIndexFile error to mention index file names ([#1859](https://github.com/lycheeverse/lychee/pull/1859))
+
+### Fixed
+
+- do not reuse excluded status from cache ([#1850](https://github.com/lycheeverse/lychee/pull/1850))
+- fields missing from config.toml parsing logic ([#1843](https://github.com/lycheeverse/lychee/pull/1843))
+- add support for name attributes in HTML fragment extraction ([#1839](https://github.com/lycheeverse/lychee/pull/1839))
+
+### Other
+
+- Bump the dependencies group across 1 directory with 15 updates ([#1874](https://github.com/lycheeverse/lychee/pull/1874))
+- Man pages ([#1858](https://github.com/lycheeverse/lychee/pull/1858))
+- Extract spans ([#1870](https://github.com/lycheeverse/lychee/pull/1870))
+- Remove truncate_source logic ([#1847](https://github.com/lycheeverse/lychee/pull/1847))
+- Add --default-extension argument to force file format ([#1842](https://github.com/lycheeverse/lychee/pull/1842))
+- hard wrap help text for options ([#1854](https://github.com/lycheeverse/lychee/pull/1854))
+- Bump the dependencies group with 6 updates ([#1855](https://github.com/lycheeverse/lychee/pull/1855))
+- Additional redirect reporting ([#1853](https://github.com/lycheeverse/lychee/pull/1853))
+- Fix extraction of reference links in Markdown ([#1841](https://github.com/lycheeverse/lychee/pull/1841))
+- Redirect reporting ([#1725](https://github.com/lycheeverse/lychee/pull/1725))
+- Add WinGet installation instructions ([#1849](https://github.com/lycheeverse/lychee/pull/1849))
+- [**breaking**] use `ResolvedInputSource` downstream of `InputContent` ([#1840](https://github.com/lycheeverse/lychee/pull/1840))
+- Bump the dependencies group with 5 updates ([#1845](https://github.com/lycheeverse/lychee/pull/1845))
+- Implement `--files-from` Option ([#1836](https://github.com/lycheeverse/lychee/pull/1836))
+- Optimize InputSource handling with Cow and add benchmarks ([#1832](https://github.com/lycheeverse/lychee/pull/1832))
+- Ignore Links in Markdown Link Text ([#1831](https://github.com/lycheeverse/lychee/pull/1831))
+- *(file checker)* separate resolving and checking for easier testing ([#1830](https://github.com/lycheeverse/lychee/pull/1830))
+- Refactor Input Handling ([#1827](https://github.com/lycheeverse/lychee/pull/1827))
+- Fix links in doc comments ([#1828](https://github.com/lycheeverse/lychee/pull/1828))
+- apply fallback extensions if directory links resolve to a dir ([#1826](https://github.com/lycheeverse/lychee/pull/1826))
+- clarify `--base-url` and `--root-dir` and their interactions ([#1787](https://github.com/lycheeverse/lychee/pull/1787))
+- Refactor collector and input ([#1823](https://github.com/lycheeverse/lychee/pull/1823))
+- add conda install to readme ([#1822](https://github.com/lycheeverse/lychee/pull/1822))
+- Bump the dependencies group with 3 updates ([#1821](https://github.com/lycheeverse/lychee/pull/1821))
+- Refactor error reporting ([#1731](https://github.com/lycheeverse/lychee/pull/1731))
+
 ## [0.20.1](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.20.0...lychee-lib-v0.20.1) - 2025-08-25
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.20.1 -> 0.21.0 (⚠ API breaking changes)
* `lychee`: 0.20.1 -> 0.21.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure enum_tuple_variant_field_added: pub enum tuple variant field added ---

Description:
An enum's exhaustive tuple variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_tuple_variant_field_added.ron

Failed in:
  field 1 of variant Status::Redirected in /tmp/.tmpya5ScC/lychee/lychee-lib/src/types/status.rs:31

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ErrorKind::TooManyRedirects, previously in file /tmp/.tmpx906U2/lychee-lib/src/types/error.rs:163

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.43.0/src/lints/inherent_method_missing.ron

Failed in:
  Input::get_input_sources, previously in file /tmp/.tmpx906U2/lychee-lib/src/types/input.rs:237
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.21.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.20.1...lychee-lib-v0.21.0) - 2025-10-21

### Added

- print warning if input source matches no files ([#1865](https://github.com/lycheeverse/lychee/pull/1865))
- *(base-url)* [**breaking**] disallow relative local base to avoid confusion ([#1857](https://github.com/lycheeverse/lychee/pull/1857))
- improve InvalidIndexFile error to mention index file names ([#1859](https://github.com/lycheeverse/lychee/pull/1859))

### Fixed

- do not reuse excluded status from cache ([#1850](https://github.com/lycheeverse/lychee/pull/1850))
- fields missing from config.toml parsing logic ([#1843](https://github.com/lycheeverse/lychee/pull/1843))
- add support for name attributes in HTML fragment extraction ([#1839](https://github.com/lycheeverse/lychee/pull/1839))

### Other

- Bump the dependencies group across 1 directory with 15 updates ([#1874](https://github.com/lycheeverse/lychee/pull/1874))
- Man pages ([#1858](https://github.com/lycheeverse/lychee/pull/1858))
- Extract spans ([#1870](https://github.com/lycheeverse/lychee/pull/1870))
- Remove truncate_source logic ([#1847](https://github.com/lycheeverse/lychee/pull/1847))
- Add --default-extension argument to force file format ([#1842](https://github.com/lycheeverse/lychee/pull/1842))
- hard wrap help text for options ([#1854](https://github.com/lycheeverse/lychee/pull/1854))
- Bump the dependencies group with 6 updates ([#1855](https://github.com/lycheeverse/lychee/pull/1855))
- Additional redirect reporting ([#1853](https://github.com/lycheeverse/lychee/pull/1853))
- Fix extraction of reference links in Markdown ([#1841](https://github.com/lycheeverse/lychee/pull/1841))
- Redirect reporting ([#1725](https://github.com/lycheeverse/lychee/pull/1725))
- Add WinGet installation instructions ([#1849](https://github.com/lycheeverse/lychee/pull/1849))
- [**breaking**] use `ResolvedInputSource` downstream of `InputContent` ([#1840](https://github.com/lycheeverse/lychee/pull/1840))
- Bump the dependencies group with 5 updates ([#1845](https://github.com/lycheeverse/lychee/pull/1845))
- Implement `--files-from` Option ([#1836](https://github.com/lycheeverse/lychee/pull/1836))
- Optimize InputSource handling with Cow and add benchmarks ([#1832](https://github.com/lycheeverse/lychee/pull/1832))
- Ignore Links in Markdown Link Text ([#1831](https://github.com/lycheeverse/lychee/pull/1831))
- *(file checker)* separate resolving and checking for easier testing ([#1830](https://github.com/lycheeverse/lychee/pull/1830))
- Refactor Input Handling ([#1827](https://github.com/lycheeverse/lychee/pull/1827))
- Fix links in doc comments ([#1828](https://github.com/lycheeverse/lychee/pull/1828))
- apply fallback extensions if directory links resolve to a dir ([#1826](https://github.com/lycheeverse/lychee/pull/1826))
- clarify `--base-url` and `--root-dir` and their interactions ([#1787](https://github.com/lycheeverse/lychee/pull/1787))
- Refactor collector and input ([#1823](https://github.com/lycheeverse/lychee/pull/1823))
- add conda install to readme ([#1822](https://github.com/lycheeverse/lychee/pull/1822))
- Bump the dependencies group with 3 updates ([#1821](https://github.com/lycheeverse/lychee/pull/1821))
- Refactor error reporting ([#1731](https://github.com/lycheeverse/lychee/pull/1731))
</blockquote>

## `lychee`

<blockquote>

## [0.21.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.20.1...lychee-v0.21.0) - 2025-10-21

### Added

- print warning if input source matches no files ([#1865](https://github.com/lycheeverse/lychee/pull/1865))
- *(base-url)* [**breaking**] disallow relative local base to avoid confusion ([#1857](https://github.com/lycheeverse/lychee/pull/1857))
- improve InvalidIndexFile error to mention index file names ([#1859](https://github.com/lycheeverse/lychee/pull/1859))

### Fixed

- move log level padding outside brackets ([#1871](https://github.com/lycheeverse/lychee/pull/1871))
- do not reuse excluded status from cache ([#1850](https://github.com/lycheeverse/lychee/pull/1850))
- fields missing from config.toml parsing logic ([#1843](https://github.com/lycheeverse/lychee/pull/1843))

### Other

- Do not require inputs with generate flag
- Bump the dependencies group across 1 directory with 15 updates ([#1874](https://github.com/lycheeverse/lychee/pull/1874))
- Inline formatting arguments for anyhow macros as per new lint
- Man pages ([#1858](https://github.com/lycheeverse/lychee/pull/1858))
- Add --default-extension argument to force file format ([#1842](https://github.com/lycheeverse/lychee/pull/1842))
- hard wrap help text for options ([#1854](https://github.com/lycheeverse/lychee/pull/1854))
- Bump the dependencies group with 6 updates ([#1855](https://github.com/lycheeverse/lychee/pull/1855))
- add exhaustivity check for `fold_in!` macro ([#1848](https://github.com/lycheeverse/lychee/pull/1848))
- Additional redirect reporting ([#1853](https://github.com/lycheeverse/lychee/pull/1853))
- Redirect reporting ([#1725](https://github.com/lycheeverse/lychee/pull/1725))
- Add WinGet installation instructions ([#1849](https://github.com/lycheeverse/lychee/pull/1849))
- [**breaking**] use `ResolvedInputSource` downstream of `InputContent` ([#1840](https://github.com/lycheeverse/lychee/pull/1840))
- Bump the dependencies group with 5 updates ([#1845](https://github.com/lycheeverse/lychee/pull/1845))
- Implement `--files-from` Option ([#1836](https://github.com/lycheeverse/lychee/pull/1836))
- apply fallback extensions if directory links resolve to a dir ([#1826](https://github.com/lycheeverse/lychee/pull/1826))
- clarify `--base-url` and `--root-dir` and their interactions ([#1787](https://github.com/lycheeverse/lychee/pull/1787))
- Add test for making sure URL inputs always get checked ([#1824](https://github.com/lycheeverse/lychee/pull/1824))
- add conda install to readme ([#1822](https://github.com/lycheeverse/lychee/pull/1822))
- Bump the dependencies group with 3 updates ([#1821](https://github.com/lycheeverse/lychee/pull/1821))
- Refactor error reporting ([#1731](https://github.com/lycheeverse/lychee/pull/1731))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).