### PR TITLE
Use 'match' for version pattern matching and not 'pattern'

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,8 +38,8 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=lychee-{{version}},value=${{ github.ref_name }}
-            type=semver,pattern=lychee-{{major}}.{{minor}},value=${{ github.ref_name }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }},match=lychee-v(\d.\d.\d)$
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }},match=lychee-v(\d.\d.\d)$
             type=sha
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}
@@ -59,8 +59,8 @@ jobs:
             type=schedule
             type=ref,event=branch
             type=ref,event=pr
-            type=semver,pattern=lychee-{{version}},value=${{ github.ref_name }}
-            type=semver,pattern=lychee-{{major}}.{{minor}},value=${{ github.ref_name }}
+            type=semver,pattern={{version}},value=${{ github.ref_name }},match=lychee-v(\d.\d.\d)$
+            type=semver,pattern={{major}}.{{minor}},value=${{ github.ref_name }},match=lychee-v(\d.\d.\d)$
             type=sha
             # set latest tag for default branch
             type=raw,value=latest,enable={{is_default_branch}}


### PR DESCRIPTION
This issue: https://github.com/lycheeverse/lychee/issues/1833 wasn't solved by: https://github.com/lycheeverse/lychee/pull/1834.

I think it's because the action was trying to pattern match the version with the wrong setting.

After reviewing: https://github.com/docker/metadata-action/issues/56, I think the action needs to use `match`, rather than `pattern`.