### PR TITLE
test: require exact version number in README's --help output

### DIFF
--- a/lychee-bin/tests/usage.rs
+++ b/lychee-bin/tests/usage.rs
@@ -10,15 +10,6 @@ mod readme {
         Command::cargo_bin(env!("CARGO_PKG_NAME")).expect("Couldn't get cargo package name")
     }
 
-    /// Remove line `[default: lychee/x.y.z]` from the string
-    fn remove_lychee_version_line(string: &str) -> String {
-        string
-            .lines()
-            .filter(|line| !line.contains("[default: lychee/"))
-            .collect::<Vec<_>>()
-            .join("\n")
-    }
-
     fn trim_empty_lines(str: &str) -> String {
         str.lines()
             .map(|line| if line.trim().is_empty() { "" } else { line })
@@ -40,14 +31,13 @@ mod readme {
         let help_cmd = cmd.env_clear().arg("--help").assert().success();
         let usage_in_help = std::str::from_utf8(&help_cmd.get_output().stdout)?;
 
-        let usage_in_help = trim_empty_lines(&remove_lychee_version_line(usage_in_help));
+        let usage_in_help = trim_empty_lines(usage_in_help);
         let readme = load_readme_text!();
         let usage_start = readme.find(BEGIN).ok_or("Usage not found in README")? + BEGIN.len();
         let usage_end = readme[usage_start..]
             .find("\n```")
             .ok_or("End of usage not found in README")?;
         let usage_in_readme = &readme[usage_start..usage_start + usage_end];
-        let usage_in_readme = remove_lychee_version_line(usage_in_readme);
 
         assert_eq!(usage_in_readme, usage_in_help);
         Ok(())


### PR DESCRIPTION
previously, the README test would ignore any line with `lychee/` so that the README's lychee/x.y.z could still match the lychee --help output of lychee/0.21.0 (or similar).

however, this scrubbing is too coarse, because it also passes the test when the README contains a line which is lychee/0.99.0 (or any other version number). this has a *very small* possibility of confusing users and is a minor inaccuracy.

this PR is one fix to this problem, by requiring that the README contain the exact version number.

an alternative fix would be to keep `remove_lychee_version_line` but change it to require `x.y.z` on the README side. this would assert that the README text uses the `lychee/x.y.z` form.