### PR TITLE
refactor: remove unimportant public library function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2562,7 +2562,6 @@ dependencies = [
  "cached",
  "check-if-email-exists",
  "cookie_store 0.22.0",
- "dashmap 6.1.0",
  "doc-comment",
  "email_address",
  "futures",

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -18,7 +18,6 @@ async-trait = "0.1.88"
 cached = "0.56.0"
 check-if-email-exists = { version = "0.9.1", optional = true }
 cookie_store = "0.22.0"
-dashmap = { version = "6.1.0", features = ["serde"] }
 email_address = "0.2.9"
 futures = "0.3.31"
 glob = "0.3.3"


### PR DESCRIPTION
I noticed the public library function `collect_sources_with_file_types` which is not used by lychee-bin. There could be library users depending on this function but IMO this is unlikely. The reason I would like to remove this function is because it's not used by ourselves and I think it is not very useful, it's not a feature that library users of a link checker would expect.

Note that all the function does, is collect the provided inputs, convert them into the path string representation. If library users really need to do this they are still able to so on their own when we remove the function.