### PR TITLE
chore: release v0.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2789,7 +2789,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4788,7 +4788,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.21.0"
+version = "0.22.0"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.22.0"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.21.0...lychee-v0.22.0) - 2025-12-05
+
+### Added
+
+- support relative --root-dir ([#1912](https://github.com/lycheeverse/lychee/pull/1912))
+- propagate input loading/collecting errors to top level  ([#1864](https://github.com/lycheeverse/lychee/pull/1864))
+- file preprocessing ([#1891](https://github.com/lycheeverse/lychee/pull/1891))
+
+### Fixed
+
+- make file matcher respect the hidden option ([#1936](https://github.com/lycheeverse/lychee/pull/1936))
+- inverted gitignore behaviour for --dump-inputs  ([#1882](https://github.com/lycheeverse/lychee/pull/1882))
+
+### Other
+
+- *(deps)* bump the dependencies group with 5 updates ([#1944](https://github.com/lycheeverse/lychee/pull/1944))
+- progress bar ([#1914](https://github.com/lycheeverse/lychee/pull/1914))
+- Bump the dependencies group with 3 updates ([#1933](https://github.com/lycheeverse/lychee/pull/1933))
+- Fix parsing larger HTML blocks in MDX files ([#1924](https://github.com/lycheeverse/lychee/pull/1924))
+- use markdown formatting for files-from help text ([#1917](https://github.com/lycheeverse/lychee/pull/1917))
+- Bump the dependencies group across 1 directory with 8 updates ([#1916](https://github.com/lycheeverse/lychee/pull/1916))
+- use log::Level's deserialiser, and link example TOML ([#1907](https://github.com/lycheeverse/lychee/pull/1907))
+- Config file up to date ([#1906](https://github.com/lycheeverse/lychee/pull/1906))
+- check glob validity when parsing input source arguments ([#1869](https://github.com/lycheeverse/lychee/pull/1869))
+- Fix typos, and configure the typos tool ([#1895](https://github.com/lycheeverse/lychee/pull/1895))
+- Address new clippy lints with version 1.91
+- Bump MSRV
+- Bump the dependencies group across 1 directory with 7 updates
+
 ## [0.21.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.20.1...lychee-v0.21.0) - 2025-10-23
 
 ### Added

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.21.0", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.22.0", default-features = false }
 
 anyhow = "1.0.100"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.21.0...lychee-lib-v0.22.0) - 2025-12-05
+
+### Added
+
+- add github markdown fragment quirk ([#1940](https://github.com/lycheeverse/lychee/pull/1940))
+- support relative --root-dir ([#1912](https://github.com/lycheeverse/lychee/pull/1912))
+- propagate input loading/collecting errors to top level  ([#1864](https://github.com/lycheeverse/lychee/pull/1864))
+- file preprocessing ([#1891](https://github.com/lycheeverse/lychee/pull/1891))
+
+### Fixed
+
+- make file matcher respect the hidden option ([#1936](https://github.com/lycheeverse/lychee/pull/1936))
+- parsing of srcset URLs after the first URL ([#1890](https://github.com/lycheeverse/lychee/pull/1890))
+
+### Other
+
+- *(deps)* bump the dependencies group with 5 updates ([#1944](https://github.com/lycheeverse/lychee/pull/1944))
+- progress bar ([#1914](https://github.com/lycheeverse/lychee/pull/1914))
+- Bump the dependencies group with 3 updates ([#1933](https://github.com/lycheeverse/lychee/pull/1933))
+- Provide a more helpful error message in case of TLS protocol issues ([#1927](https://github.com/lycheeverse/lychee/pull/1927))
+- Fix parsing larger HTML blocks in MDX files ([#1924](https://github.com/lycheeverse/lychee/pull/1924))
+- Bump the dependencies group with 3 updates ([#1921](https://github.com/lycheeverse/lychee/pull/1921))
+- Fix outdated reference to pre
+- Make use of more explicit LazyLock::force
+- use markdown formatting for files-from help text ([#1917](https://github.com/lycheeverse/lychee/pull/1917))
+- Bump the dependencies group across 1 directory with 8 updates ([#1916](https://github.com/lycheeverse/lychee/pull/1916))
+- use InputResolver to implement Input::get_sources  ([#1880](https://github.com/lycheeverse/lychee/pull/1880))
+- Fix extracting links after `<pre><code></code></pre>` ([#1911](https://github.com/lycheeverse/lychee/pull/1911))
+- check glob validity when parsing input source arguments ([#1869](https://github.com/lycheeverse/lychee/pull/1869))
+- remove unimportant public library function ([#1893](https://github.com/lycheeverse/lychee/pull/1893))
+- Fix typos, and configure the typos tool ([#1895](https://github.com/lycheeverse/lychee/pull/1895))
+- Remove an unneeded clone ([#1897](https://github.com/lycheeverse/lychee/pull/1897))
+- Address new clippy lints with version 1.91
+- clippy --fix
+- Bump MSRV
+- Bump the dependencies group across 1 directory with 7 updates
+
 ## [0.21.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.20.1...lychee-lib-v0.21.0) - 2025-10-23
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.21.0 -> 0.22.0 (⚠ API breaking changes)
* `lychee`: 0.21.0 -> 0.22.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant Status:RequestError in /tmp/.tmpp4BQbL/lychee/lychee-lib/src/types/status.rs:30

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ErrorKind::RootDirMustBeAbsolute, previously in file /tmp/.tmpFOSjX0/lychee-lib/src/types/error.rs:105
  variant ErrorKind::TestError, previously in file /tmp/.tmpFOSjX0/lychee-lib/src/types/error.rs:177

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  Collector::collect_sources, previously in file /tmp/.tmpFOSjX0/lychee-lib/src/collector.rs:173
  Collector::collect_sources_with_file_types, previously in file /tmp/.tmpFOSjX0/lychee-lib/src/collector.rs:178
  Collector::collect_sources, previously in file /tmp/.tmpFOSjX0/lychee-lib/src/collector.rs:173
  Collector::collect_sources_with_file_types, previously in file /tmp/.tmpFOSjX0/lychee-lib/src/collector.rs:178

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lychee_lib::Input::get_contents now takes 8 parameters instead of 7, in /tmp/.tmpp4BQbL/lychee/lychee-lib/src/types/input/input.rs:90
  lychee_lib::Input::path_content now takes 2 parameters instead of 1, in /tmp/.tmpp4BQbL/lychee/lychee-lib/src/types/input/input.rs:251
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.22.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.21.0...lychee-lib-v0.22.0) - 2025-12-05

### Added

- add github markdown fragment quirk ([#1940](https://github.com/lycheeverse/lychee/pull/1940))
- support relative --root-dir ([#1912](https://github.com/lycheeverse/lychee/pull/1912))
- propagate input loading/collecting errors to top level  ([#1864](https://github.com/lycheeverse/lychee/pull/1864))
- file preprocessing ([#1891](https://github.com/lycheeverse/lychee/pull/1891))

### Fixed

- make file matcher respect the hidden option ([#1936](https://github.com/lycheeverse/lychee/pull/1936))
- parsing of srcset URLs after the first URL ([#1890](https://github.com/lycheeverse/lychee/pull/1890))

### Other

- *(deps)* bump the dependencies group with 5 updates ([#1944](https://github.com/lycheeverse/lychee/pull/1944))
- progress bar ([#1914](https://github.com/lycheeverse/lychee/pull/1914))
- Bump the dependencies group with 3 updates ([#1933](https://github.com/lycheeverse/lychee/pull/1933))
- Provide a more helpful error message in case of TLS protocol issues ([#1927](https://github.com/lycheeverse/lychee/pull/1927))
- Fix parsing larger HTML blocks in MDX files ([#1924](https://github.com/lycheeverse/lychee/pull/1924))
- Bump the dependencies group with 3 updates ([#1921](https://github.com/lycheeverse/lychee/pull/1921))
- Fix outdated reference to pre
- Make use of more explicit LazyLock::force
- use markdown formatting for files-from help text ([#1917](https://github.com/lycheeverse/lychee/pull/1917))
- Bump the dependencies group across 1 directory with 8 updates ([#1916](https://github.com/lycheeverse/lychee/pull/1916))
- use InputResolver to implement Input::get_sources  ([#1880](https://github.com/lycheeverse/lychee/pull/1880))
- Fix extracting links after `<pre><code></code></pre>` ([#1911](https://github.com/lycheeverse/lychee/pull/1911))
- check glob validity when parsing input source arguments ([#1869](https://github.com/lycheeverse/lychee/pull/1869))
- remove unimportant public library function ([#1893](https://github.com/lycheeverse/lychee/pull/1893))
- Fix typos, and configure the typos tool ([#1895](https://github.com/lycheeverse/lychee/pull/1895))
- Remove an unneeded clone ([#1897](https://github.com/lycheeverse/lychee/pull/1897))
- Address new clippy lints with version 1.91
- clippy --fix
- Bump MSRV
- Bump the dependencies group across 1 directory with 7 updates
</blockquote>

## `lychee`

<blockquote>

## [0.22.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.21.0...lychee-v0.22.0) - 2025-12-05

### Added

- support relative --root-dir ([#1912](https://github.com/lycheeverse/lychee/pull/1912))
- propagate input loading/collecting errors to top level  ([#1864](https://github.com/lycheeverse/lychee/pull/1864))
- file preprocessing ([#1891](https://github.com/lycheeverse/lychee/pull/1891))

### Fixed

- make file matcher respect the hidden option ([#1936](https://github.com/lycheeverse/lychee/pull/1936))
- inverted gitignore behaviour for --dump-inputs  ([#1882](https://github.com/lycheeverse/lychee/pull/1882))

### Other

- *(deps)* bump the dependencies group with 5 updates ([#1944](https://github.com/lycheeverse/lychee/pull/1944))
- progress bar ([#1914](https://github.com/lycheeverse/lychee/pull/1914))
- Bump the dependencies group with 3 updates ([#1933](https://github.com/lycheeverse/lychee/pull/1933))
- Fix parsing larger HTML blocks in MDX files ([#1924](https://github.com/lycheeverse/lychee/pull/1924))
- use markdown formatting for files-from help text ([#1917](https://github.com/lycheeverse/lychee/pull/1917))
- Bump the dependencies group across 1 directory with 8 updates ([#1916](https://github.com/lycheeverse/lychee/pull/1916))
- use log::Level's deserialiser, and link example TOML ([#1907](https://github.com/lycheeverse/lychee/pull/1907))
- Config file up to date ([#1906](https://github.com/lycheeverse/lychee/pull/1906))
- check glob validity when parsing input source arguments ([#1869](https://github.com/lycheeverse/lychee/pull/1869))
- Fix typos, and configure the typos tool ([#1895](https://github.com/lycheeverse/lychee/pull/1895))
- Address new clippy lints with version 1.91
- Bump MSRV
- Bump the dependencies group across 1 directory with 7 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).