### PR TITLE
Remove an unneeded clone

### DIFF
--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -468,7 +468,7 @@ impl Hash for ErrorKind {
             }
             Self::Regex(e) => e.to_string().hash(state),
             Self::BasicAuthExtractorError(e) => e.to_string().hash(state),
-            Self::Cookies(e) => e.clone().hash(state),
+            Self::Cookies(e) => e.hash(state),
             Self::StatusCodeSelectorError(e) => e.to_string().hash(state),
         }
     }


### PR DESCRIPTION
In 8cc0cf0c7e78a8c07f8b62995ad3873011e79f6d, clippy suggested to replace a `String::to_string()` with a `Clone::clone()`, without noticing that the value was passed to `Hash::hash()` anyway which borrows the value.