### PR TITLE
 refactor: use log::Level's deserialiser, and link example TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2485,7 +2485,6 @@ version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 dependencies = [
- "serde",
  "value-bag",
 ]
 

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -34,7 +34,7 @@ humantime = "2.3.0"
 humantime-serde = "1.1.1"
 numeric-sort = "0.1.5"
 indicatif = "0.18.1"
-log = { version = "0.4.28", features = ["serde"] }
+log = "0.4.28"
 openssl-sys = { version = "0.9.110", optional = true }
 pad = "0.1.6"
 regex = "1.12.2"

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -30,7 +30,7 @@ hyper = "1.6.0"
 ignore = "0.4.24"
 ip_network = "0.4.1"
 linkify = "0.10.0"
-log = { version = "0.4.28", features = ["serde"] }
+log = "0.4.28"
 octocrab = "0.47.0"
 openssl-sys = { version = "0.9.110", optional = true }
 path-clean = "1.0.1"


### PR DESCRIPTION
use the serde functionality of the log crate. this will make the error
message print the accepted strings if an incorrect string is provided.

    unknown variant `asd`, expected one of `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`

however, if you use a wrong type (like bool), it will just say
"wanted string or table".

to try and direct to docs, we link to the example toml in github.
alternatively, this could link to https://lychee.cli.rs/guides/config/
instead?

the table format from log::Level is a bit mysterious and could be
a source for confusion, but idk how to prevent mentioning - can you somehow
assert that what is being deserialised is a string?

related to https://github.com/lycheeverse/lychee/issues/1903