### PR TITLE
Update Ubuntu package list before installing tools

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -78,19 +78,19 @@ jobs:
     steps:
       - name: Install musl tools
         if: ${{ contains(matrix.target, 'musl') }}
-        run: sudo apt-get install -y musl-tools
+        run: apt-get update && apt-get install -y musl-tools
 
       - name: Install arm tools
         if: ${{ contains(matrix.target, 'arm') }}
         run: |
           echo "GNU_PREFIX=arm-linux-gnueabihf-" >> $GITHUB_ENV
-          sudo apt-get install -y binutils-arm-linux-gnueabihf
+          apt-get update && apt-get install -y binutils-arm-linux-gnueabihf
 
       - name: Install aarch64 tools
         if: ${{ contains(matrix.target, 'aarch64') }}
         run: |
           echo "GNU_PREFIX=aarch64-linux-gnu-" >> $GITHUB_ENV
-          sudo apt-get install -y binutils-aarch64-linux-gnu
+          apt-get update && apt-get install -y binutils-aarch64-linux-gnu
 
       - uses: actions/checkout@v5
 


### PR DESCRIPTION
Several jobs for nightly builds are failing because additional tooling can't be installed:

- <https://github.com/lycheeverse/lychee/actions/runs/19096465366/job/54557655997#step:3:22>
- <https://github.com/lycheeverse/lychee/actions/runs/19096465366/job/54557655999#step:3:22>
- <https://github.com/lycheeverse/lychee/actions/runs/19096465366/job/54557656055#step:3:22>
- <https://github.com/lycheeverse/lychee/actions/runs/19096465366/job/54557656047#step:4:22>
- <https://github.com/lycheeverse/lychee/actions/runs/19096465366/job/54557656019#step:4:22>

It looks like the package list that comes in the latest Ubuntu container image is out-of-date or non-existent.

At any rate, updating the package list before trying to install anything should fix the problem for these jobs.