### PR TITLE
Fix extracting links after `<pre><code></code></pre>`

### DIFF
--- a/lychee-lib/src/extract/html/html5ever.rs
+++ b/lychee-lib/src/extract/html/html5ever.rs
@@ -583,4 +583,40 @@ mod tests {
         let uris = extract_html(input, false);
         assert!(uris.is_empty());
     }
+
+    #[test]
+    fn test_extract_links_after_empty_verbatim_block() {
+        // Test that links are correctly extracted after empty <pre><code> blocks
+        let input = r#"
+        <body>
+            <div>
+                See <a href="https://example.com/1">First</a>
+            </div>
+            <pre>
+                <code></code>
+            </pre>
+            <div>
+                See <a href="https://example.com/2">Second</a>
+            </div>
+        </body>
+        "#;
+
+        let expected = vec![
+            RawUri {
+                text: "https://example.com/1".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+                span: span_line(4),
+            },
+            RawUri {
+                text: "https://example.com/2".to_string(),
+                element: Some("a".to_string()),
+                attribute: Some("href".to_string()),
+                span: span_line(10),
+            },
+        ];
+
+        let uris = extract_html(input, false);
+        assert_eq!(uris, expected);
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/lycheeverse/lychee/issues/1905

The problem was that the EndTag event handler was checking if `last_verbatim == &self.current_element`, but `self.current_element` was never updated during EndTag events - it only got set during OpenStartTag events. This meant when `</code>` was processed, it couldn't match against the verbatim stack to pop it, leaving the verbatim flag incorrectly active for subsequent content.