### PR TITLE
Fix parsing larger HTML blocks in MDX files

### DIFF
--- a/fixtures/mdx/test.mdx
+++ b/fixtures/mdx/test.mdx
@@ -1,0 +1,8 @@
+<CardGroup cols={1}>
+  <Card
+    title="Example"
+    href="https://example.com"
+  >
+    Some text
+  </Card>
+</CardGroup>

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -3103,4 +3103,15 @@ The config file should contain every possible key for documentation purposes."
                 script.as_os_str().to_str().unwrap()
             )));
     }
+
+    #[test]
+    fn test_mdx_file() {
+        let file = fixtures_path!().join("mdx").join("test.mdx");
+        cargo_bin_cmd!()
+            .arg("--dump")
+            .arg(&file)
+            .assert()
+            .success()
+            .stdout(contains("https://example.com"));
+    }
 }


### PR DESCRIPTION
Previously, each HTML line inside a Markdown file would be parsed independently. This worked reasonably well, but in the case where individual lines are not valid HTML, we would skip link checking.

The fix is to accumulate an HTML block until it gets closed and only _then_ parsing it.

Fixes #1923