### PR TITLE
Hide progress bar if input is `stdin` only

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -59,7 +59,7 @@ where
         accept,
     ));
 
-    let hide_bar = params.cfg.no_progress || params.stdin_input;
+    let hide_bar = params.cfg.no_progress || params.is_stdin_input;
     let level = params.cfg.verbose().log_level();
 
     let progress = Progress::new("Extracting links", hide_bar, level, &params.cfg.mode());

--- a/lychee-bin/src/commands/mod.rs
+++ b/lychee-bin/src/commands/mod.rs
@@ -22,7 +22,7 @@ pub(crate) struct CommandParams<S: futures::Stream<Item = Result<Request, Reques
     pub(crate) cache: Cache,
     pub(crate) requests: S,
     pub(crate) cfg: Config,
-    pub(crate) stdin_input: bool,
+    pub(crate) is_stdin_input: bool,
 }
 
 /// Creates a writer that outputs to a file or stdout.

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -59,7 +59,7 @@
 #![deny(missing_docs)]
 
 use std::fs::{self, File};
-use std::io::{self, BufRead, BufReader, ErrorKind, IsTerminal};
+use std::io::{self, BufRead, BufReader, ErrorKind, IsTerminal, stdin};
 use std::path::PathBuf;
 
 use anyhow::{Context, Error, Result};
@@ -311,11 +311,11 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
     //
     // When stdin is piped (`cat links.txt | lychee -`), `is_terminal()` returns
     // false, so the progress bar is shown normally.
-    let stdin_input = inputs.len() == 1
+    let is_stdin_input = inputs.len() == 1
         && inputs
             .iter()
             .any(|input| matches!(input.source, lychee_lib::InputSource::Stdin))
-        && std::io::stdin().is_terminal();
+        && stdin().is_terminal();
 
     // TODO: Remove this section after `--base` got removed with 1.0
     let base = match (opts.config.base.clone(), opts.config.base_url.clone()) {
@@ -384,7 +384,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         cache,
         requests,
         cfg: opts.config.clone(),
-        stdin_input,
+        is_stdin_input,
     };
 
     let exit_code = if opts.config.dump {

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -13,6 +13,7 @@ use crate::{ErrorKind, LycheeResult};
 use async_stream::try_stream;
 use futures::stream::{Stream, StreamExt};
 use log::debug;
+use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use tokio::io::{AsyncReadExt, stdin};
 
@@ -271,7 +272,10 @@ impl Input {
         let mut content = String::new();
         let mut stdin = stdin();
 
-        debug!("Reading content from stdin"); // useful info when nothing piped and process blocks
+        if std::io::stdin().is_terminal() {
+            // useful info when nothing piped and process blocks
+            debug!("Reading content from stdin");
+        }
         stdin.read_to_string(&mut content).await?;
 
         let input_content = InputContent {


### PR DESCRIPTION
In https://github.com/lycheeverse/lychee/pull/1914, work was done to hide the progress bar on `stdin`. The simple solution of removing enable_steady_tick for the progress bar. This worked well for avoiding cluttering the output while the user typed their input.

However, the initial progress bar still gets shown, which is not ideal. This commit slightly imporves the behavior by waiting for all inputs before showing the progress bar. We do this by iterating over the inputs and checking if any of them is `stdin`.

This way, the progress bar does no longer get shown. To start the processing, the user has to press Ctrl^D, which is customs for other Unix tools as well. Other behavior remains unchanged.