### PR TITLE
Specify that Scoop installation is for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ nix-env -iA nixos.lychee
 pkg install lychee
 ```
 
-### Scoop
+### Scoop (Windows)
 
 ```sh
 scoop install lychee


### PR DESCRIPTION
To be consistent with other entries such as WinGet or Chocolatey