### PR TITLE
Fix source code formatting in ErrorKind::details()

### DIFF
--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -8,7 +8,7 @@ use tokio::task::JoinError;
 
 use super::InputContent;
 use crate::types::StatusCodeSelectorError;
-use crate::{basic_auth::BasicAuthExtractorError, utils, Uri};
+use crate::{Uri, basic_auth::BasicAuthExtractorError, utils};
 
 /// Kinds of status errors
 /// Note: The error messages can change over time, so don't match on the output
@@ -310,10 +310,10 @@ impl ErrorKind {
             ErrorKind::InvalidGlobPattern(pattern_error) => Some(format!(
                 "Invalid glob pattern: {pattern_error}. Check pattern syntax",
             )),
-            ErrorKind::MissingGitHubToken => Some(
+            ErrorKind::MissingGitHubToken => Some(format!(
                 "GitHub token required. {}",
-                "Use --github-token flag or GITHUB_TOKEN environment variable".to_string(),
-            ),
+                "Use --github-token flag or GITHUB_TOKEN environment variable",
+            )),
             ErrorKind::InsecureURL(uri) => Some(format!(
                 "Insecure HTTP URL detected: use '{}' instead of HTTP",
                 uri.as_str().replace("http://", "https://")


### PR DESCRIPTION
Fixes https://github.com/lycheeverse/lychee/issues/1992. Doesn't change anything aside from formatting.

It looks like rustfmt gives up on a function if it has strings which exceed the max_width, because rustfmt doesn't make any changes to string literals.

After some long strings are manually broken up, rustfmt can format the rest of the function.

Example of manual change, old:
```
            ErrorKind::MissingGitHubToken => Some(
                "GitHub token required. Use --github-token flag or GITHUB_TOKEN environment variable".to_string()
            ),
```
new:
```
            ErrorKind::MissingGitHubToken => Some(format!(
                "GitHub token required. {}",
                "Use --github-token flag or GITHUB_TOKEN environment variable",
            )),
```

Unfortunately, this PR doesn't do anything to prevent this happening again. Some options I looked into:
- The rustfmt options error_on_line_overflow and error_on_unformatted seemed promising. However, I tried both and they do  not report the long strings as problems, but they _do_ report different unrelated errors across the codebase.
- Enable rustfmt option format_strings. Does fix the problem, but sometimes introduces `\` inside string literals. Also, the option is unstable and has some known bugs. Could be chosen as a trade-off.