### PR TITLE
Ensure lychee is installed and in PATH before running

### DIFF
--- a/scripts/lychee_pre_commit.sh
+++ b/scripts/lychee_pre_commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}"


### PR DESCRIPTION
The auto-install hook installs `lychee` via `cargo binstall` / `cargo install`, but the binary is not discoverable in pre-commit's isolated environment because Cargo's bin directory is not added to `PATH`.

This PR fixes the issue by explicitly exporting the Cargo bin path before execution. AFAIK it has no impact on global user environment as the hook gets executed in its own subshell.

@Borda FYI
