### PR TITLE
chore: release v0.23.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2326,7 +2326,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2375,7 +2375,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.22.0"
+version = "0.23.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4206,7 +4206,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.22.0"
+version = "0.23.0"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.22.0"
+version = "0.23.0"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.22.0...lychee-v0.23.0) - 2026-02-13
+
+### Added
+
+- per-host caching ([#1974](https://github.com/lycheeverse/lychee/pull/1974))
+- implement per-host rate limiting and statistics ([#1929](https://github.com/lycheeverse/lychee/pull/1929))
+
+### Fixed
+
+- CacheableResponse should only download file when needed ([#2035](https://github.com/lycheeverse/lychee/pull/2035))
+- Combine host stats with response stats ([#1975](https://github.com/lycheeverse/lychee/pull/1975))
+
+### Other
+
+- delete leftover openssl sentence in readme
+- Speed up slow tests ([#2019](https://github.com/lycheeverse/lychee/pull/2019))
+- *(deps)* bump the dependencies group with 2 updates
+- Improve README.md UX ([#2029](https://github.com/lycheeverse/lychee/pull/2029))
+- Replace OpenSSL with rustls  ([#1928](https://github.com/lycheeverse/lychee/pull/1928))
+- Replace check-if-email-exists with mailify ([#1985](https://github.com/lycheeverse/lychee/pull/1985))
+- Redirect hint ([#2020](https://github.com/lycheeverse/lychee/pull/2020))
+- Update to reqwest 0.13.1 & cargo update
+- *(deps)* bump the dependencies group across 1 directory with 4 updates
+- Use absolute instead of canonicalize for relative root-dir ([#2008](https://github.com/lycheeverse/lychee/pull/2008))
+- Log successful responses only for Debug and Trace
+- Only show redirect details in verbose mode
+- Show status code in redirect list
+- Use u8 instead of i8 for log level values
+- Update comparison table ([#1997](https://github.com/lycheeverse/lychee/pull/1997))
+- Rejected urls ([#1990](https://github.com/lycheeverse/lychee/pull/1990))
+- Accept ranges ([#1989](https://github.com/lycheeverse/lychee/pull/1989))
+- *(deps)* bump the dependencies group with 5 updates ([#1988](https://github.com/lycheeverse/lychee/pull/1988))
+- *(deps)* bump the dependencies group with 4 updates ([#1978](https://github.com/lycheeverse/lychee/pull/1978))
+- *(deps)* bump the dependencies group with 4 updates ([#1973](https://github.com/lycheeverse/lychee/pull/1973))
+- *(docs)* update TOC
+- Improve wikilink parsing and checking ([#1799](https://github.com/lycheeverse/lychee/pull/1799))
+- Specify that Scoop installation is for Windows ([#1969](https://github.com/lycheeverse/lychee/pull/1969))
+- Extract record_cache_event & skip mail caching
+- Add tldr-pages link to README ([#1963](https://github.com/lycheeverse/lychee/pull/1963))
+- *(deps)* bump the dependencies group across 1 directory with 3 updates ([#1961](https://github.com/lycheeverse/lychee/pull/1961))
+- Extract URLs from CSS ([#1956](https://github.com/lycheeverse/lychee/pull/1956))
+
 ## [0.22.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.21.0...lychee-v0.22.0) - 2025-12-05
 
 ### Added

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.22.0", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.23.0", default-features = false }
 
 anyhow = "1.0.101"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.22.0...lychee-lib-v0.23.0) - 2026-02-13
+
+### Added
+
+- per-host caching ([#1974](https://github.com/lycheeverse/lychee/pull/1974))
+- implement per-host rate limiting and statistics ([#1929](https://github.com/lycheeverse/lychee/pull/1929))
+
+### Fixed
+
+- CacheableResponse should only download file when needed ([#2035](https://github.com/lycheeverse/lychee/pull/2035))
+- GITHUB_TOKEN should not cause rustls CryptoProvider panic ([#2036](https://github.com/lycheeverse/lychee/pull/2036))
+- Combine host stats with response stats ([#1975](https://github.com/lycheeverse/lychee/pull/1975))
+
+### Other
+
+- delete leftover openssl sentence in readme
+- Speed up slow tests ([#2019](https://github.com/lycheeverse/lychee/pull/2019))
+- *(deps)* bump the dependencies group with 2 updates
+- Fix overflow when handling rate limit headers
+- Improve README.md UX ([#2029](https://github.com/lycheeverse/lychee/pull/2029))
+- Replace OpenSSL with rustls  ([#1928](https://github.com/lycheeverse/lychee/pull/1928))
+- Replace check-if-email-exists with mailify ([#1985](https://github.com/lycheeverse/lychee/pull/1985))
+- Redirect hint ([#2020](https://github.com/lycheeverse/lychee/pull/2020))
+- Try to fix rustls setup after recent reqwest change ([#2016](https://github.com/lycheeverse/lychee/pull/2016))
+- Update to reqwest 0.13.1 & cargo update
+- *(deps)* bump the dependencies group across 1 directory with 4 updates
+- Use absolute instead of canonicalize for relative root-dir ([#2008](https://github.com/lycheeverse/lychee/pull/2008))
+- Show status code in redirect list
+- Update comparison table ([#1997](https://github.com/lycheeverse/lychee/pull/1997))
+- Rejected urls ([#1990](https://github.com/lycheeverse/lychee/pull/1990))
+- Fix source code formatting in ErrorKind::details() ([#1993](https://github.com/lycheeverse/lychee/pull/1993))
+- Accept ranges ([#1989](https://github.com/lycheeverse/lychee/pull/1989))
+- *(deps)* bump the dependencies group with 5 updates ([#1988](https://github.com/lycheeverse/lychee/pull/1988))
+- *(deps)* bump the dependencies group with 4 updates ([#1978](https://github.com/lycheeverse/lychee/pull/1978))
+- *(deps)* bump the dependencies group with 4 updates ([#1973](https://github.com/lycheeverse/lychee/pull/1973))
+- *(docs)* update TOC
+- Improve wikilink parsing and checking ([#1799](https://github.com/lycheeverse/lychee/pull/1799))
+- *(deps)* bump the dependencies group with 2 updates ([#1967](https://github.com/lycheeverse/lychee/pull/1967))
+- Specify that Scoop installation is for Windows ([#1969](https://github.com/lycheeverse/lychee/pull/1969))
+- Extract record_cache_event & skip mail caching
+- Improve logging
+- Add tldr-pages link to README ([#1963](https://github.com/lycheeverse/lychee/pull/1963))
+- *(deps)* bump the dependencies group across 1 directory with 3 updates ([#1961](https://github.com/lycheeverse/lychee/pull/1961))
+- Extract URLs from CSS ([#1956](https://github.com/lycheeverse/lychee/pull/1956))
+- *(deps)* bump the dependencies group with 2 updates ([#1948](https://github.com/lycheeverse/lychee/pull/1948))
+
 ## [0.22.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.21.0...lychee-lib-v0.22.0) - 2025-12-05
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.22.0 -> 0.23.0 (⚠ API breaking changes)
* `lychee`: 0.22.0 -> 0.23.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum lychee_lib::AcceptRangeError, previously in file /tmp/.tmpXCubol/lychee-lib/src/types/accept/range.rs:12

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant FileType::Plaintext 2 -> 3 in /tmp/.tmpR9F4bT/lychee/lychee-lib/src/types/file.rs:123

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Status:UnknownMailStatus in /tmp/.tmpR9F4bT/lychee/lychee-lib/src/types/status.rs:40
  variant FileType:Css in /tmp/.tmpR9F4bT/lychee/lychee-lib/src/types/file.rs:120

--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature native-tls in the package's Cargo.toml
  feature check-if-email-exists in the package's Cargo.toml
  feature rustls-tls in the package's Cargo.toml
  feature openssl-sys in the package's Cargo.toml
  feature vendored-openssl in the package's Cargo.toml

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  StatusCodeSelector::new, previously in file /tmp/.tmpXCubol/lychee-lib/src/types/status_code/selector.rs:70
  Redirects::none, previously in file /tmp/.tmpXCubol/lychee-lib/src/types/redirect_history.rs:44
  Status::new, previously in file /tmp/.tmpXCubol/lychee-lib/src/types/status.rs:95

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct lychee_lib::AcceptRange, previously in file /tmp/.tmpXCubol/lychee-lib/src/types/accept/range.rs:29
  struct lychee_lib::StatusCodeExcluder, previously in file /tmp/.tmpXCubol/lychee-lib/src/types/status_code/excluder.rs:16
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.23.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.22.0...lychee-lib-v0.23.0) - 2026-02-13

### Added

- per-host caching ([#1974](https://github.com/lycheeverse/lychee/pull/1974))
- implement per-host rate limiting and statistics ([#1929](https://github.com/lycheeverse/lychee/pull/1929))

### Fixed

- CacheableResponse should only download file when needed ([#2035](https://github.com/lycheeverse/lychee/pull/2035))
- GITHUB_TOKEN should not cause rustls CryptoProvider panic ([#2036](https://github.com/lycheeverse/lychee/pull/2036))
- Combine host stats with response stats ([#1975](https://github.com/lycheeverse/lychee/pull/1975))

### Other

- delete leftover openssl sentence in readme
- Speed up slow tests ([#2019](https://github.com/lycheeverse/lychee/pull/2019))
- *(deps)* bump the dependencies group with 2 updates
- Fix overflow when handling rate limit headers
- Improve README.md UX ([#2029](https://github.com/lycheeverse/lychee/pull/2029))
- Replace OpenSSL with rustls  ([#1928](https://github.com/lycheeverse/lychee/pull/1928))
- Replace check-if-email-exists with mailify ([#1985](https://github.com/lycheeverse/lychee/pull/1985))
- Redirect hint ([#2020](https://github.com/lycheeverse/lychee/pull/2020))
- Try to fix rustls setup after recent reqwest change ([#2016](https://github.com/lycheeverse/lychee/pull/2016))
- Update to reqwest 0.13.1 & cargo update
- *(deps)* bump the dependencies group across 1 directory with 4 updates
- Use absolute instead of canonicalize for relative root-dir ([#2008](https://github.com/lycheeverse/lychee/pull/2008))
- Show status code in redirect list
- Update comparison table ([#1997](https://github.com/lycheeverse/lychee/pull/1997))
- Rejected urls ([#1990](https://github.com/lycheeverse/lychee/pull/1990))
- Fix source code formatting in ErrorKind::details() ([#1993](https://github.com/lycheeverse/lychee/pull/1993))
- Accept ranges ([#1989](https://github.com/lycheeverse/lychee/pull/1989))
- *(deps)* bump the dependencies group with 5 updates ([#1988](https://github.com/lycheeverse/lychee/pull/1988))
- *(deps)* bump the dependencies group with 4 updates ([#1978](https://github.com/lycheeverse/lychee/pull/1978))
- *(deps)* bump the dependencies group with 4 updates ([#1973](https://github.com/lycheeverse/lychee/pull/1973))
- *(docs)* update TOC
- Improve wikilink parsing and checking ([#1799](https://github.com/lycheeverse/lychee/pull/1799))
- *(deps)* bump the dependencies group with 2 updates ([#1967](https://github.com/lycheeverse/lychee/pull/1967))
- Specify that Scoop installation is for Windows ([#1969](https://github.com/lycheeverse/lychee/pull/1969))
- Extract record_cache_event & skip mail caching
- Improve logging
- Add tldr-pages link to README ([#1963](https://github.com/lycheeverse/lychee/pull/1963))
- *(deps)* bump the dependencies group across 1 directory with 3 updates ([#1961](https://github.com/lycheeverse/lychee/pull/1961))
- Extract URLs from CSS ([#1956](https://github.com/lycheeverse/lychee/pull/1956))
- *(deps)* bump the dependencies group with 2 updates ([#1948](https://github.com/lycheeverse/lychee/pull/1948))
</blockquote>

## `lychee`

<blockquote>

## [0.23.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.22.0...lychee-v0.23.0) - 2026-02-13

### Added

- per-host caching ([#1974](https://github.com/lycheeverse/lychee/pull/1974))
- implement per-host rate limiting and statistics ([#1929](https://github.com/lycheeverse/lychee/pull/1929))

### Fixed

- CacheableResponse should only download file when needed ([#2035](https://github.com/lycheeverse/lychee/pull/2035))
- Combine host stats with response stats ([#1975](https://github.com/lycheeverse/lychee/pull/1975))

### Other

- delete leftover openssl sentence in readme
- Speed up slow tests ([#2019](https://github.com/lycheeverse/lychee/pull/2019))
- *(deps)* bump the dependencies group with 2 updates
- Improve README.md UX ([#2029](https://github.com/lycheeverse/lychee/pull/2029))
- Replace OpenSSL with rustls  ([#1928](https://github.com/lycheeverse/lychee/pull/1928))
- Replace check-if-email-exists with mailify ([#1985](https://github.com/lycheeverse/lychee/pull/1985))
- Redirect hint ([#2020](https://github.com/lycheeverse/lychee/pull/2020))
- Update to reqwest 0.13.1 & cargo update
- *(deps)* bump the dependencies group across 1 directory with 4 updates
- Use absolute instead of canonicalize for relative root-dir ([#2008](https://github.com/lycheeverse/lychee/pull/2008))
- Log successful responses only for Debug and Trace
- Only show redirect details in verbose mode
- Show status code in redirect list
- Use u8 instead of i8 for log level values
- Update comparison table ([#1997](https://github.com/lycheeverse/lychee/pull/1997))
- Rejected urls ([#1990](https://github.com/lycheeverse/lychee/pull/1990))
- Accept ranges ([#1989](https://github.com/lycheeverse/lychee/pull/1989))
- *(deps)* bump the dependencies group with 5 updates ([#1988](https://github.com/lycheeverse/lychee/pull/1988))
- *(deps)* bump the dependencies group with 4 updates ([#1978](https://github.com/lycheeverse/lychee/pull/1978))
- *(deps)* bump the dependencies group with 4 updates ([#1973](https://github.com/lycheeverse/lychee/pull/1973))
- *(docs)* update TOC
- Improve wikilink parsing and checking ([#1799](https://github.com/lycheeverse/lychee/pull/1799))
- Specify that Scoop installation is for Windows ([#1969](https://github.com/lycheeverse/lychee/pull/1969))
- Extract record_cache_event & skip mail caching
- Add tldr-pages link to README ([#1963](https://github.com/lycheeverse/lychee/pull/1963))
- *(deps)* bump the dependencies group across 1 directory with 3 updates ([#1961](https://github.com/lycheeverse/lychee/pull/1961))
- Extract URLs from CSS ([#1956](https://github.com/lycheeverse/lychee/pull/1956))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).