### PR TITLE
Fix broken path in the extract example

### DIFF
--- a/examples/extract/extract.rs
+++ b/examples/extract/extract.rs
@@ -5,7 +5,7 @@ use std::fs;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let input = fs::read_to_string("fixtures/elvis.html").unwrap();
+    let input = fs::read_to_string("fixtures/bench/elvis.html").unwrap();
     let extractor = Extractor::default();
     let links = extractor.extract(&InputContent::from_string(&input, FileType::Html));
     println!("{links:#?}");


### PR DESCRIPTION
Awesome repo that really helped me learn idiomatic Rust. I look forward to contributing more.

This PR fixes this command:

```
cargo run --example extract
```

It was broken on master.