### PR TITLE
chore: release v0.24.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2325,7 +2325,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4205,7 +4205,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.23.0"
+version = "0.24.0"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.23.0...lychee-v0.24.0) - 2026-04-24
+
+### Added
+
+- check text fragments ([#2138](https://github.com/lycheeverse/lychee/pull/2138))
+- allow bool flag merging ([#2137](https://github.com/lycheeverse/lychee/pull/2137))
+- show redirects & remaps ([#2094](https://github.com/lycheeverse/lychee/pull/2094))
+- hide progress bar if input is `stdin` only ([#1938](https://github.com/lycheeverse/lychee/pull/1938))
+- Support sitemap.xml ([#2071](https://github.com/lycheeverse/lychee/pull/2071))
+- allow accepting timeouts ([#2063](https://github.com/lycheeverse/lychee/pull/2063))
+- Support multiple config files ([#2007](https://github.com/lycheeverse/lychee/pull/2007))
+
+### Fixed
+
+- prevent 0 value for max-concurrency and threads ([#2145](https://github.com/lycheeverse/lychee/pull/2145))
+- use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/pull/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
+- *(cli)* bump open files limit on macOS and Linux ([#2106](https://github.com/lycheeverse/lychee/pull/2106))
+
+### Other
+
+- Unify Releases Across Operating Systems ([#1957](https://github.com/lycheeverse/lychee/pull/1957))
+- make website checker return Status always, rather than Result ([#2140](https://github.com/lycheeverse/lychee/pull/2140))
+- Fix matching logic for glob hidden files ([#2130](https://github.com/lycheeverse/lychee/pull/2130))
+- Remove the `Redirect` and `Remapped` wrapper variants from the `Status` enum. ([#2129](https://github.com/lycheeverse/lychee/pull/2129))
+- Fix output path not validated before the run ([#2148](https://github.com/lycheeverse/lychee/pull/2148))
+- Always show full config parse errors with full details in output ([#2149](https://github.com/lycheeverse/lychee/pull/2149))
+- allow root-dir that doesn't exist ([#2127](https://github.com/lycheeverse/lychee/pull/2127))
+- Add tests for the current state of "Checking a Local Folder with URL Remapping" ([#1965](https://github.com/lycheeverse/lychee/pull/1965))
+- *(deps)* bump the dependencies group with 3 updates
+- Simplify match as suggested by @mre
+- move caching logic to cache ([#2123](https://github.com/lycheeverse/lychee/pull/2123))
+- *(deps)* bump the dependencies group with 3 updates
+- Respect HTTP error codes in CLI inputs ([#2101](https://github.com/lycheeverse/lychee/pull/2101))
+- Support multiple config file formats and refactor config module ([#2104](https://github.com/lycheeverse/lychee/pull/2104))
+- Fix double count ([#2088](https://github.com/lycheeverse/lychee/pull/2088))
+- *(deps)* bump the dependencies group with 5 updates
+- Never cache errors on disk
+- Unify input URL fetching with the link-checker's HostPool ([#2100](https://github.com/lycheeverse/lychee/pull/2100))
+- Merge pull request #2098 from lycheeverse/dependabot/cargo/dependencies-94675db464
+- Fix Windows Absolute Path Parsing and Remove HTTP Assumption ([#1837](https://github.com/lycheeverse/lychee/pull/1837))
+- Adds shell completions for lychee ([#1972](https://github.com/lycheeverse/lychee/pull/1972))
+- Increase value for --max-redirects ([#2087](https://github.com/lycheeverse/lychee/pull/2087))
+- Remove raw mode ([#2086](https://github.com/lycheeverse/lychee/pull/2086))
+- Report input source errors rather than tokio panics ([#2074](https://github.com/lycheeverse/lychee/pull/2074))
+- *(deps)* bump the dependencies group with 3 updates
+- Add Tor Project's support website
+- Add JUnit format ([#2066](https://github.com/lycheeverse/lychee/pull/2066))
+- Prevent duplicate requests to the same URLs ([#2067](https://github.com/lycheeverse/lychee/pull/2067))
+- *(deps)* bump the dependencies group with 3 updates
+- add WaitGroup for waiting for a dynamic set of tasks  ([#2046](https://github.com/lycheeverse/lychee/pull/2046))
+- Show line & column numbers ([#2056](https://github.com/lycheeverse/lychee/pull/2056))
+- *(deps)* bump the dependencies group with 6 updates
+- Fix toc action ([#2055](https://github.com/lycheeverse/lychee/pull/2055))
+- [**breaking**] add BaseInfo for resolving links, delete Base, cleanup utils ([#2005](https://github.com/lycheeverse/lychee/pull/2005))
+- Document file format support ([#2052](https://github.com/lycheeverse/lychee/pull/2052))
+- Improve help message as proposed by @katrinafyi
+- *(deps)* bump the dependencies group with 8 updates
+- Update changelogs
+
 ## [0.23.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.22.0...lychee-v0.23.0) - 2026-02-13
 
 ### Added

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.23.0", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.24.0", default-features = false }
 
 anyhow = "1.0.102"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,62 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.23.0...lychee-lib-v0.24.0) - 2026-04-24
+
+### Added
+
+- check text fragments ([#2138](https://github.com/lycheeverse/lychee/pull/2138))
+- allow bool flag merging ([#2137](https://github.com/lycheeverse/lychee/pull/2137))
+- show redirects & remaps ([#2094](https://github.com/lycheeverse/lychee/pull/2094))
+- Support sitemap.xml ([#2071](https://github.com/lycheeverse/lychee/pull/2071))
+- allow accepting timeouts ([#2063](https://github.com/lycheeverse/lychee/pull/2063))
+- Support multiple config files ([#2007](https://github.com/lycheeverse/lychee/pull/2007))
+
+### Fixed
+
+- check HTTP status in archive snapshots, and ignore 503 in test ([#2158](https://github.com/lycheeverse/lychee/pull/2158))
+- prevent autolink duplication ([#2151](https://github.com/lycheeverse/lychee/pull/2151))
+- prevent 0 value for max-concurrency and threads ([#2145](https://github.com/lycheeverse/lychee/pull/2145))
+- quirk: remove line number fragments from github URLs ([#2116](https://github.com/lycheeverse/lychee/pull/2116))
+- use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/pull/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
+
+### Other
+
+- make website checker return Status always, rather than Result ([#2140](https://github.com/lycheeverse/lychee/pull/2140))
+- Fix matching logic for glob hidden files ([#2130](https://github.com/lycheeverse/lychee/pull/2130))
+- Remove the `Redirect` and `Remapped` wrapper variants from the `Status` enum. ([#2129](https://github.com/lycheeverse/lychee/pull/2129))
+- allow root-dir that doesn't exist ([#2127](https://github.com/lycheeverse/lychee/pull/2127))
+- *(deps)* bump the dependencies group with 3 updates
+- *(deps)* bump the dependencies group with 3 updates
+- Respect HTTP error codes in CLI inputs ([#2101](https://github.com/lycheeverse/lychee/pull/2101))
+- *(deps)* bump the dependencies group with 5 updates
+- Unify input URL fetching with the link-checker's HostPool ([#2100](https://github.com/lycheeverse/lychee/pull/2100))
+- Merge pull request #2098 from lycheeverse/dependabot/cargo/dependencies-94675db464
+- Add missing field
+- *(deps)* bump the dependencies group across 1 directory with 12 updates
+- Add RelativeUri enum for types of relative links ([#2078](https://github.com/lycheeverse/lychee/pull/2078))
+- Fix Windows Absolute Path Parsing and Remove HTTP Assumption ([#1837](https://github.com/lycheeverse/lychee/pull/1837))
+- Adds shell completions for lychee ([#1972](https://github.com/lycheeverse/lychee/pull/1972))
+- Increase value for --max-redirects ([#2087](https://github.com/lycheeverse/lychee/pull/2087))
+- Remove raw mode ([#2086](https://github.com/lycheeverse/lychee/pull/2086))
+- Remove file url trailing slash warning ([#2083](https://github.com/lycheeverse/lychee/pull/2083))
+- *(deps)* bump the dependencies group with 3 updates
+- Box ErrorKind & RawUri within RequestError to fix oversize lint  ([#2079](https://github.com/lycheeverse/lychee/pull/2079))
+- Remove deduplication of requests ([#2075](https://github.com/lycheeverse/lychee/pull/2075))
+- Add Tor Project's support website
+- Add JUnit format ([#2066](https://github.com/lycheeverse/lychee/pull/2066))
+- Prevent duplicate requests to the same URLs ([#2067](https://github.com/lycheeverse/lychee/pull/2067))
+- *(deps)* bump the dependencies group with 3 updates
+- add WaitGroup for waiting for a dynamic set of tasks  ([#2046](https://github.com/lycheeverse/lychee/pull/2046))
+- Show line & column numbers ([#2056](https://github.com/lycheeverse/lychee/pull/2056))
+- *(deps)* bump the dependencies group with 6 updates
+- Fix toc action ([#2055](https://github.com/lycheeverse/lychee/pull/2055))
+- [**breaking**] add BaseInfo for resolving links, delete Base, cleanup utils ([#2005](https://github.com/lycheeverse/lychee/pull/2005))
+- Document file format support ([#2052](https://github.com/lycheeverse/lychee/pull/2052))
+- Improve help message as proposed by @katrinafyi
+- *(deps)* bump the dependencies group with 8 updates
+- Update changelogs
+
 ## [0.23.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.22.0...lychee-lib-v0.23.0) - 2026-02-13
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.23.0 -> 0.24.0 (⚠ API breaking changes)
* `lychee`: 0.23.0 -> 0.24.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ResponseBody.redirects in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/response.rs:121
  field ResponseBody.remap in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/response.rs:124
  field ResponseBody.span in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/response.rs:127
  field ResponseBody.duration in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/response.rs:130
  field Request.span in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/request.rs:27

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum lychee_lib::Base, previously in file /tmp/.tmpjyVAre/lychee-lib/src/types/base.rs:13

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant FileType::Plaintext 3 -> 4 in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/file.rs:126

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant RequestError:InputSourceError in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/request_error.rs:30
  variant FileType:Xml in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/file.rs:123

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant ErrorKind::InvalidBaseJoin, previously in file /tmp/.tmpjyVAre/lychee-lib/src/types/error.rs:97
  variant ErrorKind::InvalidPathToUri, previously in file /tmp/.tmpjyVAre/lychee-lib/src/types/error.rs:101
  variant ErrorKind::InvalidRootDir, previously in file /tmp/.tmpjyVAre/lychee-lib/src/types/error.rs:105
  variant ErrorKind::InvalidFile, previously in file /tmp/.tmpjyVAre/lychee-lib/src/types/error.rs:117
  variant Status::Redirected, previously in file /tmp/.tmpjyVAre/lychee-lib/src/types/status.rs:34

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Collector::client, previously in file /tmp/.tmpjyVAre/lychee-lib/src/collector.rs:136
  Collector::client, previously in file /tmp/.tmpjyVAre/lychee-lib/src/collector.rs:136

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lychee_lib::Request::new now takes 2 parameters instead of 5, in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/request.rs:38
  lychee_lib::Response::new now takes 7 parameters instead of 3, in /tmp/.tmp8kMsc8/lychee/lychee-lib/src/types/response.rs:29
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.24.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.23.0...lychee-lib-v0.24.0) - 2026-04-24

### Added

- check text fragments ([#2138](https://github.com/lycheeverse/lychee/pull/2138))
- allow bool flag merging ([#2137](https://github.com/lycheeverse/lychee/pull/2137))
- show redirects & remaps ([#2094](https://github.com/lycheeverse/lychee/pull/2094))
- Support sitemap.xml ([#2071](https://github.com/lycheeverse/lychee/pull/2071))
- allow accepting timeouts ([#2063](https://github.com/lycheeverse/lychee/pull/2063))
- Support multiple config files ([#2007](https://github.com/lycheeverse/lychee/pull/2007))

### Fixed

- check HTTP status in archive snapshots, and ignore 503 in test ([#2158](https://github.com/lycheeverse/lychee/pull/2158))
- prevent autolink duplication ([#2151](https://github.com/lycheeverse/lychee/pull/2151))
- prevent 0 value for max-concurrency and threads ([#2145](https://github.com/lycheeverse/lychee/pull/2145))
- quirk: remove line number fragments from github URLs ([#2116](https://github.com/lycheeverse/lychee/pull/2116))
- use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/pull/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))

### Other

- make website checker return Status always, rather than Result ([#2140](https://github.com/lycheeverse/lychee/pull/2140))
- Fix matching logic for glob hidden files ([#2130](https://github.com/lycheeverse/lychee/pull/2130))
- Remove the `Redirect` and `Remapped` wrapper variants from the `Status` enum. ([#2129](https://github.com/lycheeverse/lychee/pull/2129))
- allow root-dir that doesn't exist ([#2127](https://github.com/lycheeverse/lychee/pull/2127))
- *(deps)* bump the dependencies group with 3 updates
- *(deps)* bump the dependencies group with 3 updates
- Respect HTTP error codes in CLI inputs ([#2101](https://github.com/lycheeverse/lychee/pull/2101))
- *(deps)* bump the dependencies group with 5 updates
- Unify input URL fetching with the link-checker's HostPool ([#2100](https://github.com/lycheeverse/lychee/pull/2100))
- Merge pull request #2098 from lycheeverse/dependabot/cargo/dependencies-94675db464
- Add missing field
- *(deps)* bump the dependencies group across 1 directory with 12 updates
- Add RelativeUri enum for types of relative links ([#2078](https://github.com/lycheeverse/lychee/pull/2078))
- Fix Windows Absolute Path Parsing and Remove HTTP Assumption ([#1837](https://github.com/lycheeverse/lychee/pull/1837))
- Adds shell completions for lychee ([#1972](https://github.com/lycheeverse/lychee/pull/1972))
- Increase value for --max-redirects ([#2087](https://github.com/lycheeverse/lychee/pull/2087))
- Remove raw mode ([#2086](https://github.com/lycheeverse/lychee/pull/2086))
- Remove file url trailing slash warning ([#2083](https://github.com/lycheeverse/lychee/pull/2083))
- *(deps)* bump the dependencies group with 3 updates
- Box ErrorKind & RawUri within RequestError to fix oversize lint  ([#2079](https://github.com/lycheeverse/lychee/pull/2079))
- Remove deduplication of requests ([#2075](https://github.com/lycheeverse/lychee/pull/2075))
- Add Tor Project's support website
- Add JUnit format ([#2066](https://github.com/lycheeverse/lychee/pull/2066))
- Prevent duplicate requests to the same URLs ([#2067](https://github.com/lycheeverse/lychee/pull/2067))
- *(deps)* bump the dependencies group with 3 updates
- add WaitGroup for waiting for a dynamic set of tasks  ([#2046](https://github.com/lycheeverse/lychee/pull/2046))
- Show line & column numbers ([#2056](https://github.com/lycheeverse/lychee/pull/2056))
- *(deps)* bump the dependencies group with 6 updates
- Fix toc action ([#2055](https://github.com/lycheeverse/lychee/pull/2055))
- [**breaking**] add BaseInfo for resolving links, delete Base, cleanup utils ([#2005](https://github.com/lycheeverse/lychee/pull/2005))
- Document file format support ([#2052](https://github.com/lycheeverse/lychee/pull/2052))
- Improve help message as proposed by @katrinafyi
- *(deps)* bump the dependencies group with 8 updates
- Update changelogs
</blockquote>

## `lychee`

<blockquote>

## [0.24.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.23.0...lychee-v0.24.0) - 2026-04-24

### Added

- check text fragments ([#2138](https://github.com/lycheeverse/lychee/pull/2138))
- allow bool flag merging ([#2137](https://github.com/lycheeverse/lychee/pull/2137))
- show redirects & remaps ([#2094](https://github.com/lycheeverse/lychee/pull/2094))
- hide progress bar if input is `stdin` only ([#1938](https://github.com/lycheeverse/lychee/pull/1938))
- Support sitemap.xml ([#2071](https://github.com/lycheeverse/lychee/pull/2071))
- allow accepting timeouts ([#2063](https://github.com/lycheeverse/lychee/pull/2063))
- Support multiple config files ([#2007](https://github.com/lycheeverse/lychee/pull/2007))

### Fixed

- prevent 0 value for max-concurrency and threads ([#2145](https://github.com/lycheeverse/lychee/pull/2145))
- use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/pull/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
- *(cli)* bump open files limit on macOS and Linux ([#2106](https://github.com/lycheeverse/lychee/pull/2106))

### Other

- Unify Releases Across Operating Systems ([#1957](https://github.com/lycheeverse/lychee/pull/1957))
- make website checker return Status always, rather than Result ([#2140](https://github.com/lycheeverse/lychee/pull/2140))
- Fix matching logic for glob hidden files ([#2130](https://github.com/lycheeverse/lychee/pull/2130))
- Remove the `Redirect` and `Remapped` wrapper variants from the `Status` enum. ([#2129](https://github.com/lycheeverse/lychee/pull/2129))
- Fix output path not validated before the run ([#2148](https://github.com/lycheeverse/lychee/pull/2148))
- Always show full config parse errors with full details in output ([#2149](https://github.com/lycheeverse/lychee/pull/2149))
- allow root-dir that doesn't exist ([#2127](https://github.com/lycheeverse/lychee/pull/2127))
- Add tests for the current state of "Checking a Local Folder with URL Remapping" ([#1965](https://github.com/lycheeverse/lychee/pull/1965))
- *(deps)* bump the dependencies group with 3 updates
- Simplify match as suggested by @mre
- move caching logic to cache ([#2123](https://github.com/lycheeverse/lychee/pull/2123))
- *(deps)* bump the dependencies group with 3 updates
- Respect HTTP error codes in CLI inputs ([#2101](https://github.com/lycheeverse/lychee/pull/2101))
- Support multiple config file formats and refactor config module ([#2104](https://github.com/lycheeverse/lychee/pull/2104))
- Fix double count ([#2088](https://github.com/lycheeverse/lychee/pull/2088))
- *(deps)* bump the dependencies group with 5 updates
- Never cache errors on disk
- Unify input URL fetching with the link-checker's HostPool ([#2100](https://github.com/lycheeverse/lychee/pull/2100))
- Merge pull request #2098 from lycheeverse/dependabot/cargo/dependencies-94675db464
- Fix Windows Absolute Path Parsing and Remove HTTP Assumption ([#1837](https://github.com/lycheeverse/lychee/pull/1837))
- Adds shell completions for lychee ([#1972](https://github.com/lycheeverse/lychee/pull/1972))
- Increase value for --max-redirects ([#2087](https://github.com/lycheeverse/lychee/pull/2087))
- Remove raw mode ([#2086](https://github.com/lycheeverse/lychee/pull/2086))
- Report input source errors rather than tokio panics ([#2074](https://github.com/lycheeverse/lychee/pull/2074))
- *(deps)* bump the dependencies group with 3 updates
- Add Tor Project's support website
- Add JUnit format ([#2066](https://github.com/lycheeverse/lychee/pull/2066))
- Prevent duplicate requests to the same URLs ([#2067](https://github.com/lycheeverse/lychee/pull/2067))
- *(deps)* bump the dependencies group with 3 updates
- add WaitGroup for waiting for a dynamic set of tasks  ([#2046](https://github.com/lycheeverse/lychee/pull/2046))
- Show line & column numbers ([#2056](https://github.com/lycheeverse/lychee/pull/2056))
- *(deps)* bump the dependencies group with 6 updates
- Fix toc action ([#2055](https://github.com/lycheeverse/lychee/pull/2055))
- [**breaking**] add BaseInfo for resolving links, delete Base, cleanup utils ([#2005](https://github.com/lycheeverse/lychee/pull/2005))
- Document file format support ([#2052](https://github.com/lycheeverse/lychee/pull/2052))
- Improve help message as proposed by @katrinafyi
- *(deps)* bump the dependencies group with 8 updates
- Update changelogs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).