### PR TITLE
pre-commit hook: use pre-commit's built-in rust boostrapping

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,19 @@
 - id: lychee
   name: lychee
-  description: "Run 'lychee' for fast, async, stream-based link checking (auto-installs)"
+  description: "Run 'lychee' for fast, async, stream-based link checking (auto-installs from binary)"
+  entry: scripts/lychee_pre_commit.sh
+  language: script
+  # defaults to the version of the current repo checkout, i.e., the 'rev' field in
+  # .pre-commit-config.yaml. to use a different lychee version, pass "LYCHEE_VERSION=0.xx.0"
+  # as the first arg in 'args'.
+  args: ["--no-progress"]
+  types: [text]
+  pass_filenames: true
+  require_serial: true
+  minimum_pre_commit_version: "2.9.2"
+- id: lychee-src
+  name: lychee-src
+  description: "Run 'lychee' for fast, async, stream-based link checking (auto-installs from source)"
   entry: lychee
   language: rust
   args: ["--no-progress"]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,11 +1,8 @@
 - id: lychee
   name: lychee
   description: "Run 'lychee' for fast, async, stream-based link checking (auto-installs)"
-  entry: scripts/lychee_pre_commit.sh
-  language: script
-  # defaults to the version of the current repo checkout, i.e., the 'rev' field in
-  # .pre-commit-config.yaml. to use a different lychee version, pass "LYCHEE_VERSION=0.xx.0"
-  # as the first arg in 'args'.
+  entry: lychee
+  language: rust
   args: ["--no-progress"]
   types: [text]
   pass_filenames: true


### PR DESCRIPTION
When trying to use the `lychee` pre-commit hook at tag `lychee-v0.23.0`,  I get:

```
lychee...................................................................Failed
- hook id: lychee
- exit code: 127

  Installing lychee...
  Using cargo install (this may take a few minutes)...
  /root/.cache/prek/repos/2c023200f7174f5a/scripts/lychee_pre_commit.sh: line 18: cargo: command not found
```

because I don't have cargo installed.

Pre-commit supports [bootstrapping rust](https://pre-commit.com/#rust) so while this new hook that leverages `cargo install` under the hood may be slower upon first invocation than `cargo binstall`, it avoids all the hoops currently begin jumped through by `lychee_pre_commit.sh`, and ensures that the rust environment is fully set up and available.

Edit: I see that [this issue](https://github.com/pre-commit/pre-commit/issues/2931) has been causing problems and still remains a problem with my changes, however [prek](https://github.com/j178/prek) does seem to handle bootstrapping with workspaces as desired, so I still think my proposed changes are worthwhile. Not sure of the best way to indicate that this hook only works with the pre-commit replacement rather than the original, though...  

Alternatively, once #1931 is resolved, that may allow for a similar approach to how [`typos` manages it](https://github.com/crate-ci/typos)