### PR TITLE
Remove deduplication of Request after source tracking

### DIFF
--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -87,7 +87,7 @@ fn try_parse_into_uri(
 ///
 /// Requests are not deduplicated because repeated URLs may occur at different
 /// source locations. Caching and deduplication happens elsewhere (e.g., in the
-/// per-host HostCache and the top-level persistent cache).
+/// per-host `HostCache` and the top-level persistent cache).
 pub(crate) fn create(
     uris: Vec<RawUri>,
     source: &ResolvedInputSource,


### PR DESCRIPTION
After source tracking, adding a Request to a HashSet is ineffective because it contains a unique location for each request.

As a side-effect, removing the deduplication means URLs will be sent to the stream in file order, which is nice for consistency.