### PR TITLE
Increase value for --max-redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Options:
   -m, --max-redirects <MAX_REDIRECTS>
           Maximum number of allowed redirects
 
-          [default: 5]
+          [default: 10]
 
       --max-cache-age <MAX_CACHE_AGE>
           Discard all cached requests older than this duration

--- a/examples/builder/builder.rs
+++ b/examples/builder/builder.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     let client = ClientBuilder::builder()
         .excludes(excludes)
         .includes(includes)
-        .max_redirects(3u8)
+        .max_redirects(10u8)
         .user_agent("custom useragent")
         .allow_insecure(true)
         .custom_headers(headers)

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -448,7 +448,7 @@ pub(crate) struct Config {
 
     /// Maximum number of allowed redirects
     ///
-    /// [default: 5]
+    /// [default: 10]
     #[arg(short, long)]
     max_redirects: Option<usize>,
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -37,8 +37,8 @@ use crate::{
     types::{DEFAULT_ACCEPTED_STATUS_CODES, redirect_history::RedirectHistory},
 };
 
-/// Default number of redirects before a request is deemed as failed, 5.
-pub const DEFAULT_MAX_REDIRECTS: usize = 5;
+/// Default number of redirects that are followed.
+pub const DEFAULT_MAX_REDIRECTS: usize = 10;
 /// Default number of retries before a request is deemed as failed, 3.
 pub const DEFAULT_MAX_RETRIES: u64 = 3;
 /// Default wait time in seconds between retries, 1.


### PR DESCRIPTION
Use a default value of 10 instead of 5. It was not entirely uncommon for websites to redirect more than five times. This fixes #1958.