### PR TITLE
feat: Add generation of shell completion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2274,6 +2283,7 @@ dependencies = [
  "assert-json-diff",
  "assert_cmd",
  "clap",
+ "clap_complete",
  "clap_mangen",
  "console",
  "const_format",

--- a/README.md
+++ b/README.md
@@ -502,9 +502,11 @@ Options:
           - Empty lines are also ignored.
 
       --generate <GENERATE>
-          Generate special output (e.g. the man page) instead of performing link checking
+          Generate special output (e.g. the man page and shell completions) instead of performing link checking
 
-          [possible values: man]
+          Example: `source <(lychee --generate complete_bash)` to get shell completion for bash
+
+          [possible values: man, complete_bash, complete_zsh, complete_fish, complete_powershell, complete_elvish]
 
       --github-token <GITHUB_TOKEN>
           GitHub API token to use when checking github.com links, to avoid rate limiting

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -55,6 +55,7 @@ tokio-stream = "0.1.18"
 toml = "1.0.6"
 url = "2.5.8"
 quick-junit = "0.5.2"
+clap_complete = "4.6.0"
 
 
 [dev-dependencies]

--- a/lychee-bin/src/commands/generate.rs
+++ b/lychee-bin/src/commands/generate.rs
@@ -5,6 +5,7 @@
 
 use anyhow::Result;
 use clap::{CommandFactory, crate_authors};
+use clap_complete::aot::Shell;
 use clap_mangen::{
     Man,
     roff::{Roff, roman},
@@ -70,6 +71,7 @@ const EXIT_CODE_SECTION: &str = "
 ";
 
 /// What to generate when providing the --generate flag
+/// The interface is inspired by ripgrep
 #[derive(Debug, Deserialize, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq)]
 #[non_exhaustive]
 #[strum(serialize_all = "snake_case")]
@@ -77,12 +79,27 @@ const EXIT_CODE_SECTION: &str = "
 pub(crate) enum GenerateMode {
     /// Generate roff used for the man page
     Man,
+    /// Generate bash completion script
+    CompleteBash,
+    /// Generate zsh completion script
+    CompleteZsh,
+    /// Generate fish completion script
+    CompleteFish,
+    /// Generate Powershell completion script. Lowercase "s" to match ripgrep's naming
+    CompletePowershell,
+    /// Generate Elvish completion script
+    CompleteElvish,
 }
 
 /// Generate special output according to the [`GenerateMode`]
 pub(crate) fn generate(mode: &GenerateMode) -> Result<String> {
     match mode {
         GenerateMode::Man => man_page(),
+        GenerateMode::CompleteBash => generate_completion(Shell::Bash),
+        GenerateMode::CompleteZsh => generate_completion(Shell::Zsh),
+        GenerateMode::CompleteFish => generate_completion(Shell::Fish),
+        GenerateMode::CompletePowershell => generate_completion(Shell::PowerShell),
+        GenerateMode::CompleteElvish => generate_completion(Shell::Elvish),
     }
 }
 
@@ -138,6 +155,15 @@ fn render_section(title: &str, content: &str, buffer: &mut Vec<u8>) -> Result<()
     roff.text([roman(content)]);
     roff.to_writer(buffer)?;
     Ok(())
+}
+
+/// Generate shell completion script for the given shell using [`clap_complete`]
+fn generate_completion(shell: Shell) -> Result<String> {
+    let mut cmd = LycheeOptions::command();
+    let name = cmd.get_name().to_string();
+    let mut buffer = Vec::new();
+    clap_complete::generate(shell, &mut cmd, name, &mut buffer);
+    Ok(String::from_utf8(buffer)?)
 }
 
 #[cfg(test)]

--- a/lychee-bin/src/options.rs
+++ b/lychee-bin/src/options.rs
@@ -784,7 +784,9 @@ pub(crate) struct Config {
     #[arg(short, long, value_parser = PossibleValuesParser::new(StatsFormat::VARIANTS).map(|s| s.parse::<StatsFormat>().unwrap()))]
     format: Option<StatsFormat>,
 
-    /// Generate special output (e.g. the man page) instead of performing link checking
+    /// Generate special output (e.g. the man page and shell completions) instead of performing link checking
+    ///
+    /// Example: `source <(lychee --generate complete_bash)` to get shell completion for bash
     #[arg(long, value_parser = PossibleValuesParser::new(GenerateMode::VARIANTS).map(|s| s.parse::<GenerateMode>().unwrap()))]
     pub(crate) generate: Option<GenerateMode>,
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -3667,4 +3667,17 @@ https://lychee.cli.rs/guides/cli/#fragments-ignored
             .assert()
             .success();
     }
+
+    #[test]
+    fn test_generate_complete_for_all_shells() {
+        // We trust the maintainers of clap_complete, so here we only perform smoke tests
+        for shell in ["bash", "elvish", "fish", "powershell", "zsh"] {
+            cargo_bin_cmd!()
+                .arg("--generate")
+                .arg(format!("complete_{}", shell))
+                .assert()
+                .success()
+                .stdout(contains("max-concurrency"));
+        }
+    }
 }


### PR DESCRIPTION
Fixes #1564 

Example usage:

```console
$ source <(cargo run -- --generate complete_bash)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.41s
     Running `target/debug/lychee --generate complete_bash`
$ lychee --ma<TAB>
--max-cache-age    --max-redirects    --max-retries      --max-concurrency  
$ lychee --max-
```