### PR TITLE
fix: update email test fixture

### DIFF
--- a/fixtures/TEST_EMAIL.md
+++ b/fixtures/TEST_EMAIL.md
@@ -1,3 +1,3 @@
 https://endler.dev
-octocat+github@github.com
+foobar@gmail.com
 mailto:info@wikipedia.org


### PR DESCRIPTION
Apparently GitHub started to require a reverse DNS PTR record to be able to retrieve information from their mail server.