### PR TITLE
set user-agent when fetching remote input URLs

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -339,7 +339,8 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         // File a bug if you rely on this envvar! It's going to go away eventually.
         .use_html5ever(std::env::var("LYCHEE_USE_HTML5EVER").is_ok_and(|x| x == "1"))
         .include_wikilinks(opts.config.include_wikilinks)
-        .preprocessor(opts.config.preprocess.clone());
+        .preprocessor(opts.config.preprocess.clone())
+        .user_agent(opts.config.user_agent());
 
     collector = if let Some(ref basic_auth) = opts.config.basic_auth {
         collector.basic_auth_extractor(BasicAuthExtractor::new(basic_auth)?)

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -2776,6 +2776,64 @@ The config file should contain every possible key for documentation purposes."
         server.verify().await;
     }
 
+    #[tokio::test]
+    async fn test_user_agent_set_on_remote_input() {
+        // When a URL is passed directly as a CLI input, the configured user-agent
+        // should be sent in the request headers. Previously the resolver used a
+        // bare reqwest::Client with no user-agent at all.
+        let server = wiremock::MockServer::start().await;
+        server
+            .register(
+                wiremock::Mock::given(wiremock::matchers::method("GET"))
+                    .and(wiremock::matchers::header("user-agent", "test-agent/1.0"))
+                    .respond_with(wiremock::ResponseTemplate::new(200))
+                    .expect(1)
+                    .named("GET expecting user-agent header"),
+            )
+            .await;
+
+        cargo_bin_cmd!()
+            .arg("--user-agent")
+            .arg("test-agent/1.0")
+            .arg(server.uri())
+            .assert()
+            .success();
+
+        // wiremock will fail if the expected request was not received
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn test_default_user_agent_set_on_remote_input() {
+        // Even without an explicit --user-agent, the default lychee user-agent
+        // should be sent when fetching a remote input URL.
+        let server = wiremock::MockServer::start().await;
+        server
+            .register(
+                wiremock::Mock::given(wiremock::matchers::method("GET"))
+                    .respond_with(wiremock::ResponseTemplate::new(200))
+                    .expect(1),
+            )
+            .await;
+
+        cargo_bin_cmd!().arg(server.uri()).assert().success();
+
+        let received_requests = server.received_requests().await.unwrap();
+        assert_eq!(received_requests.len(), 1);
+
+        let received_request = &received_requests[0];
+        let user_agent = received_request
+            .headers
+            .get("user-agent")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        assert!(
+            user_agent.starts_with("lychee/"),
+            "Expected user-agent to start with 'lychee/', got: {user_agent:?}"
+        );
+    }
+
     #[test]
     fn test_sorted_error_output() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -36,6 +36,7 @@ pub struct Collector {
     headers: HeaderMap,
     client: Client,
     preprocessor: Option<Preprocessor>,
+    user_agent: Option<String>,
 }
 
 impl Default for Collector {
@@ -60,6 +61,7 @@ impl Default for Collector {
             client: Client::new(),
             excluded_paths: PathExcludes::empty(),
             preprocessor: None,
+            user_agent: None,
         }
     }
 }
@@ -114,6 +116,7 @@ impl Collector {
             excluded_paths: PathExcludes::empty(),
             root_dir,
             base,
+            user_agent: None,
         })
     }
 
@@ -149,6 +152,13 @@ impl Collector {
     #[must_use]
     pub fn client(mut self, client: Client) -> Self {
         self.client = client;
+        self
+    }
+
+    /// Set the user agent to use when fetching remote input URLs
+    #[must_use]
+    pub fn user_agent(mut self, user_agent: String) -> Self {
+        self.user_agent = Some(user_agent);
         self
     }
 
@@ -225,10 +235,19 @@ impl Collector {
         let global_base = self.base;
         let excluded_paths = self.excluded_paths;
 
+        let resolver_client = if let Some(ref ua) = self.user_agent {
+            Client::builder()
+                .user_agent(ua.as_str())
+                .build()
+                .unwrap_or(self.client)
+        } else {
+            self.client
+        };
+
         let resolver = UrlContentResolver {
             basic_auth_extractor: self.basic_auth_extractor.clone(),
             headers: self.headers.clone(),
-            client: self.client,
+            client: resolver_client,
         };
 
         let extractor = Extractor::new(
@@ -597,6 +616,42 @@ mod tests {
         let expected_links = HashSet::from_iter([mail!("user@example.com")]);
 
         assert_eq!(links, expected_links);
+    }
+
+    #[tokio::test]
+    async fn test_user_agent_is_sent_for_remote_input_url() {
+        use wiremock::matchers::{header, method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/"))
+            .and(header("user-agent", "test-agent/1.0"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"<a href="https://example.com">Link</a>"#),
+            )
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let url = Url::parse(&mock_server.uri()).unwrap();
+        let inputs = HashSet::from_iter([Input {
+            source: InputSource::RemoteUrl(Box::new(url)),
+            file_type_hint: Some(FileType::Html),
+        }]);
+
+        let links = Collector::new(None, BaseInfo::none())
+            .unwrap()
+            .user_agent("test-agent/1.0".to_string())
+            .collect_links_from_file_types(inputs, FileExtensions::default())
+            .map(|r| r.unwrap().uri)
+            .collect::<HashSet<_>>()
+            .await;
+
+        assert!(links.iter().any(|u| u.url.as_str().contains("example.com")));
+        // wiremock will panic here if the expected request was not received
     }
 
     #[tokio::test]


### PR DESCRIPTION
This is a veeery conservative attempt at fixing https://github.com/lycheeverse/lychee/issues/1886.

Previously, the `reqwest::Client` used by the `UrlContentResolver` (which fetches CLI URL inputs) was built without a user-agent. This meant that passing a URL directly as a CLI argument resulted in a request with no user-agent header, unlike links discovered during checking which correctly use the configured user-agent.

This caused subtle bugs such as Wikipedia returning a 403 for CLI inputs (since it requires a user-agent), resulting in lychee finding zero links on pages that actually contain hundreds.

Fixed by storing the configured user-agent on the `Collector` and using it to build the resolver's `reqwest::Client`.

Let me say that I believe the `collector` is already doing way too much and that this is probably not the right approach going forward. The fact that the `collector` is responsible for building a `reqwest::Client` for the resolver is a sign of tight coupling and a violation of separation of concerns. The `collector` should ideally only be responsible for collecting links, while the resolver should be responsible for fetching content.

That said, I opened the PR to get some early feedback and perhaps to fix the immediate issue. I also wanted to avoid a larger refactor that would touch many parts of the codebase and potentially cause more disruption in the short term. (See below.)

As an alternative, I considered to unify the two code paths where we deal with "building request clients." Instead of the `Collector` using its own bare `reqwest::Client`, we can make it reuse the same fully-configured `lychee_lib::Client` (with rate limiting, retries, per-host config, TLS settings, etc.) that's used for link checking. The original issue already notes that unifying these paths would also help with recursion support. The downside is it's a much larger refactor touching the `Client` API.
But it's probably still worth it? I can create another PR for that and we can compare.
I'm a bit hesitant to do it because large PRs have caused some churn in the past and it took a while to get them merged. But I'm willing to do it if we think it's the right move. I just don't want to cause too much disruption in the short term.

Let me know what you think!

@katrinafyi  @thomas-zahner @cristiklein feedback welcome.