### PR TITLE
quirk: remove line number fragments from github URLs

### DIFF
--- a/lychee-lib/src/quirks/mod.rs
+++ b/lychee-lib/src/quirks/mod.rs
@@ -15,7 +15,7 @@ static CRATES_PATTERN: LazyLock<Regex> =
 static YOUTUBE_PATTERN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(https?://)?(www\.)?youtube(-nocookie)?\.com").unwrap());
 static YOUTUBE_SHORT_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(https?://)?(www\.)?(youtu\.?be)").unwrap());
+    LazyLock::new(|| Regex::new(r"^(https?://)?(www\.)?(youtu\.be)").unwrap());
 static GITHUB_BLOB_MARKDOWN_FRAGMENT_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^https://github\.com/(?<user>.*?)/(?<repo>.*?)/blob/(?<path>.*?)/(?<file>.*\.(md|markdown)#.*)$")
         .unwrap()


### PR DESCRIPTION
we have no hope of checking these and they're probably unlikely to break as long as the file itself continues to exist.

big remaining github fragment cases:
- `#readme` fragment going to implicit readme file - api
- fragments in implicit readme files (within a directory view) - api
- issue comment numbers - use api
- pr comment numbers - use api
- other branch tree views?

Might close https://github.com/lycheeverse/lychee/issues/2113 and also addresses https://github.com/lycheeverse/lychee/issues/1729 for this particular case.