### PR TITLE
Remove the `Redirect` and `Remapped` wrapper variants from the `Status` enum.

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -255,7 +255,9 @@ async fn check_url(client: &Client, request: Request) -> Response {
         log::error!("Error checking URL {uri}: {e}");
         Response::new(
             uri.clone(),
-            Status::Error(ErrorKind::InvalidURI(uri.clone())),
+            Status::Error(ErrorKind::InvalidURI(uri)),
+            None,
+            None,
             source.into(),
             span,
             None,
@@ -316,6 +318,8 @@ async fn handle(
         return Ok(Response::new(
             cache_key.clone(),
             status,
+            None,
+            None,
             request.source.into(),
             request.span,
             None,
@@ -389,9 +393,9 @@ mod tests {
     async fn test_invalid_url() {
         let client = ClientBuilder::builder().build().client().unwrap();
         let uri = Uri::try_from("http://\"").unwrap();
-        let response = client.check_website(&uri, None).await.unwrap();
+        let (status, _redirects) = client.check_website(&uri, None).await.unwrap();
         assert!(matches!(
-            response,
+            status,
             Status::Unsupported(ErrorKind::BuildRequestClient(_))
         ));
     }

--- a/lychee-bin/src/formatters/response/color.rs
+++ b/lychee-bin/src/formatters/response/color.rs
@@ -25,7 +25,6 @@ impl ColorFormatter {
             Status::Error(_) | Status::RequestError(_) | Status::Cached(CacheStatus::Error(_)) => {
                 &PINK
             }
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => Self::status_color(inner),
         }
     }
 

--- a/lychee-bin/src/formatters/response/emoji.rs
+++ b/lychee-bin/src/formatters/response/emoji.rs
@@ -23,9 +23,6 @@ impl EmojiFormatter {
             Status::Error(_) | Status::RequestError(_) | Status::Cached(CacheStatus::Error(_)) => {
                 "❌"
             }
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => {
-                Self::emoji_for_status(inner)
-            }
         }
     }
 }
@@ -41,7 +38,7 @@ impl ResponseFormatter for EmojiFormatter {
 mod emoji_tests {
     use super::*;
     use http::StatusCode;
-    use lychee_lib::{ErrorKind, Redirects, Status, Uri};
+    use lychee_lib::{ErrorKind, Redirects, ResponseBody, Status, Uri};
     use test_utils::mock_response_body;
 
     #[test]
@@ -77,13 +74,15 @@ mod emoji_tests {
     #[test]
     fn test_format_response_with_redirect_status() {
         let formatter = EmojiFormatter;
-        let body = mock_response_body!(
-            Status::Redirected(
-                Box::new(Status::Ok(StatusCode::OK)),
-                Redirects::new("https://example.com/redirect".try_into().unwrap())
-            ),
-            "https://example.com/redirect",
-        );
+        let redirects = Redirects::new("https://example.com/redirect".try_into().unwrap());
+        let body = ResponseBody {
+            uri: Uri::try_from("https://example.com/redirect").unwrap(),
+            status: Status::Ok(StatusCode::OK),
+            redirects: Some(redirects),
+            remap: None,
+            span: None,
+            duration: None,
+        };
         assert_eq!(
             formatter.format_response(&body),
             "✅ https://example.com/redirect | 200 OK | Followed 0 redirects. Redirects: https://example.com/redirect"

--- a/lychee-bin/src/formatters/response/plain.rs
+++ b/lychee-bin/src/formatters/response/plain.rs
@@ -68,10 +68,14 @@ mod plain_tests {
             code: StatusCode::PERMANENT_REDIRECT,
         });
 
-        let body = mock_response_body!(
-            Status::Redirected(Box::new(Status::Ok(StatusCode::OK)), redirects),
-            "https://example.com/redirect",
-        );
+        let body = ResponseBody {
+            uri: Uri::try_from("https://example.com/redirect").unwrap(),
+            status: Status::Ok(StatusCode::OK),
+            redirects: Some(redirects),
+            remap: None,
+            span: None,
+            duration: None,
+        };
         assert_eq!(
             formatter.format_response(&body),
             "[200] https://example.com/redirect | 200 OK | Followed 1 redirect. Redirects: https://from.dev/ --[308]--> https://to.dev/"

--- a/lychee-bin/src/formatters/response/task.rs
+++ b/lychee-bin/src/formatters/response/task.rs
@@ -58,10 +58,14 @@ mod task_tests {
             code: StatusCode::PERMANENT_REDIRECT,
         });
 
-        let body = mock_response_body!(
-            Status::Redirected(Box::new(Status::Ok(StatusCode::OK)), redirects),
-            "https://example.com/redirect",
-        );
+        let body = ResponseBody {
+            uri: Uri::try_from("https://example.com/redirect").unwrap(),
+            status: Status::Ok(StatusCode::OK),
+            redirects: Some(redirects),
+            remap: None,
+            span: None,
+            duration: None,
+        };
         assert_eq!(
             formatter.format_response(&body),
             "- [ ] [200] https://example.com/redirect | 200 OK | Followed 1 redirect. Redirects: https://from.dev/ --[308]--> https://to.dev/"

--- a/lychee-bin/src/formatters/stats/junit.rs
+++ b/lychee-bin/src/formatters/stats/junit.rs
@@ -140,6 +140,8 @@ mod tests {
             HashSet::from([ResponseBody {
                 uri: "https://success.org".try_into().unwrap(),
                 status: Status::Ok(StatusCode::OK),
+                redirects: None,
+                remap: None,
                 span: None,
                 duration: Some(Duration::from_secs(1)),
             }]),
@@ -150,6 +152,8 @@ mod tests {
             HashSet::from([ResponseBody {
                 uri: "https://excluded.org".try_into().unwrap(),
                 status: Status::Excluded,
+                redirects: None,
+                remap: None,
                 span: None,
                 duration: Some(Duration::from_millis(42)),
             }]),

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -199,6 +199,8 @@ mod tests {
         let response = ResponseBody {
             uri: Uri::try_from("http://example.com").unwrap(),
             status: Status::Ok(StatusCode::OK),
+            redirects: None,
+            remap: None,
             span: SPAN,
             duration: DURATION,
         };
@@ -211,6 +213,8 @@ mod tests {
         let response = ResponseBody {
             uri: Uri::try_from("http://example.com").unwrap(),
             status: Status::Cached(CacheStatus::Ok(StatusCode::OK)),
+            redirects: None,
+            remap: None,
             span: SPAN,
             duration: DURATION,
         };
@@ -226,6 +230,8 @@ mod tests {
         let response = ResponseBody {
             uri: Uri::try_from("http://example.com").unwrap(),
             status: Status::Cached(CacheStatus::Error(Some(StatusCode::BAD_REQUEST))),
+            redirects: None,
+            remap: None,
             span: SPAN,
             duration: DURATION,
         };

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -128,6 +128,8 @@ fn get_dummy_stats() -> OutputStats {
                 .try_into()
                 .unwrap(),
             status: Status::Ok(StatusCode::NOT_FOUND),
+            redirects: None,
+            remap: None,
             span: SPAN,
             duration: DURATION,
         }]),
@@ -138,6 +140,8 @@ fn get_dummy_stats() -> OutputStats {
         HashSet::from([ResponseBody {
             uri: "https://httpbin.org/delay/2".try_into().unwrap(),
             status: Status::Timeout(None),
+            redirects: None,
+            remap: None,
             span: SPAN,
             duration: DURATION,
         }]),
@@ -210,7 +214,15 @@ mod tests {
     fn make_test_response(url_str: &str, source: InputSource) -> Response {
         let uri = Uri::from(make_test_url(url_str));
 
-        Response::new(uri, Status::Error(ErrorKind::EmptyUrl), source, None, None)
+        Response::new(
+            uri,
+            Status::Error(ErrorKind::EmptyUrl),
+            None,
+            None,
+            source,
+            None,
+            None,
+        )
     }
 
     #[test]

--- a/lychee-bin/src/formatters/stats/response.rs
+++ b/lychee-bin/src/formatters/stats/response.rs
@@ -87,14 +87,6 @@ impl ResponseStats {
             Status::Error(_) | Status::RequestError(_) => self.errors += 1,
             Status::UnknownStatusCode(_) | Status::UnknownMailStatus(_) => self.unknown += 1,
             Status::Timeout(_) => self.timeouts += 1,
-            Status::Redirected(inner, _) => {
-                self.redirects += 1;
-                self.increment_status_counters(inner);
-            }
-            Status::Remapped(inner, _) => {
-                self.remaps += 1;
-                self.increment_status_counters(inner);
-            }
             Status::Excluded => self.excludes += 1,
             Status::Unsupported(_) => self.unsupported += 1,
             Status::Cached(cache_status) => {
@@ -115,7 +107,7 @@ impl ResponseStats {
         let source: InputSource = response.source().clone();
 
         if self.detailed_stats
-            && let Some(redirects) = status.redirects()
+            && let Some(redirects) = response.redirects()
         {
             self.redirect_map
                 .entry(source.clone())
@@ -145,6 +137,12 @@ impl ResponseStats {
         }
 
         self.total += 1;
+        if response.redirects().is_some() {
+            self.redirects += 1;
+        }
+        if response.remap().is_some() {
+            self.remaps += 1;
+        }
         self.increment_status_counters(response.status());
         self.add_response_status(response);
     }
@@ -189,7 +187,7 @@ mod tests {
     // and it's a lot faster to just generate a fake response
     fn mock_response(status: Status) -> Response {
         let uri = website("https://some-url.com/ok");
-        Response::new(uri, status, InputSource::Stdin, None, None)
+        Response::new(uri, status, None, None, InputSource::Stdin, None, None)
     }
 
     fn dummy_ok() -> Response {

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1965,23 +1965,17 @@ The config file should contain every possible key for documentation purposes."
         let json = stdout_to_json(&stdout);
         assert_eq!(json["remaps"], 1);
         assert_eq!(json["excludes"], 1);
+        let excluded = &json["excluded_map"]["stdin"][0];
+        assert_eq!(excluded["url"], "https://bbb.com/");
+        assert_eq!(excluded["status"]["text"], "Excluded");
         assert_eq!(
-            json["excluded_map"],
-            json!({
-            "stdin": [
-              {
-                "url": "https://bbb.com/",
-                "status": {
-                  "text": "Excluded",
-                  "details": "This is due to your 'exclude' values | Remaps: https://aaa.com/ --> https://bbb.com/"
-                },
-                "span": {
-                  "line": 1,
-                  "column": 1
-                },
-              }
-            ]})
+            excluded["status"]["details"],
+            "This is due to your 'exclude' values"
         );
+        assert_eq!(excluded["remap"]["original"]["url"], "https://aaa.com/");
+        assert_eq!(excluded["remap"]["new"]["url"], "https://bbb.com/");
+        assert_eq!(excluded["span"]["line"], 1);
+        assert_eq!(excluded["span"]["column"], 1);
     }
 
     #[test]
@@ -2636,6 +2630,13 @@ The config file should contain every possible key for documentation purposes."
                 json["success_map"],
                 json!({
                 "stdin":[{
+                    "redirects": {
+                        "origin": redirect_url,
+                        "redirects": [{
+                            "code": 308,
+                            "url": ok_url,
+                        }]
+                    },
                     "span": {
                         "column": 1,
                         "line": 1,
@@ -2643,13 +2644,6 @@ The config file should contain every possible key for documentation purposes."
                     "status": {
                         "code": 200,
                         "text": "200 OK",
-                        "redirects": {
-                            "origin": redirect_url,
-                            "redirects": [{
-                                "code": 308,
-                                "url": ok_url,
-                            }]
-                        },
                     },
                     "url": redirect_url
                 }]})

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1961,17 +1961,31 @@ The config file should contain every possible key for documentation purposes."
         let json = stdout_to_json(&stdout);
         assert_eq!(json["remaps"], 1);
         assert_eq!(json["excludes"], 1);
-        let excluded = &json["excluded_map"]["stdin"][0];
-        assert_eq!(excluded["url"], "https://bbb.com/");
-        assert_eq!(excluded["status"]["text"], "Excluded");
         assert_eq!(
-            excluded["status"]["details"],
-            "This is due to your 'exclude' values"
+            json["excluded_map"],
+            json!({
+            "stdin": [
+              {
+                "url": "https://bbb.com/",
+                "status": {
+                  "text": "Excluded",
+                  "details": "This is due to your 'exclude' values"
+                },
+                "remap": {
+                    "new": {
+                        "url": "https://bbb.com/",
+                    },
+                    "original": {
+                        "url": "https://aaa.com/",
+                     },
+                },
+                "span": {
+                  "line": 1,
+                  "column": 1
+                },
+              }
+            ]})
         );
-        assert_eq!(excluded["remap"]["original"]["url"], "https://aaa.com/");
-        assert_eq!(excluded["remap"]["new"]["url"], "https://bbb.com/");
-        assert_eq!(excluded["span"]["line"], 1);
-        assert_eq!(excluded["span"]["column"], 1);
     }
 
     #[test]

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1920,7 +1920,7 @@ The config file should contain every possible key for documentation purposes."
             .assert()
             .failure()
             .stdout(contains(r#"
-[404] http://rust-lang.org/lycheeverse (at 1:1) | Rejected status code: 404 Not Found (configurable with "accept" option) | Followed 1 redirect. Redirects: http://rust-lang.org/lycheeverse --[301]--> https://rust-lang.org/lycheeverse | Remaps: http://github.com/lycheeverse --> http://rust-lang.org/lycheeverse
+[404] http://rust-lang.org/lycheeverse (at 1:1) | Rejected status code: 404 Not Found (configurable with "accept" option) | Remaps: http://github.com/lycheeverse --> http://rust-lang.org/lycheeverse | Followed 1 redirect. Redirects: http://rust-lang.org/lycheeverse --[301]--> https://rust-lang.org/lycheeverse
 "#))
         // It is debugged when URIs are remapped
         .stderr(contains("[DEBUG] Remapping http://github.com/lycheeverse --> http://rust-lang.org/lycheeverse"))

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -4,7 +4,10 @@ use crate::{
     quirks::Quirks,
     ratelimit::HostPool,
     retry::RetryExt,
-    types::{redirect_history::RedirectHistory, uri::github::GithubUri},
+    types::{
+        redirect_history::{RedirectHistory, Redirects},
+        uri::github::GithubUri,
+    },
     utils::fragment_checker::{FragmentChecker, FragmentInput},
 };
 use async_trait::async_trait;
@@ -206,7 +209,7 @@ impl WebsiteChecker {
         &self,
         uri: &Uri,
         credentials: Option<BasicAuthCredentials>,
-    ) -> Result<Status, ErrorKind> {
+    ) -> Result<(Status, Option<Redirects>), ErrorKind> {
         let default_chain: RequestChain = Chain::new(vec![
             Box::<Quirks>::default(),
             Box::new(credentials),
@@ -218,7 +221,8 @@ impl WebsiteChecker {
             .handle_insecure_url(uri, &default_chain, status)
             .await?;
 
-        Ok(self.redirect_history.handle_redirected(&uri.url, status))
+        let redirects = self.redirect_history.resolve(&uri.url);
+        Ok((status, redirects))
     }
 
     /// Mark HTTP URLs as insecure, if the user required HTTPS

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -35,7 +35,7 @@ use crate::{
     filter::Filter,
     ratelimit::{ClientMap, HostConfigs, HostKey, HostPool, RateLimitConfig},
     remap::Remaps,
-    types::{DEFAULT_ACCEPTED_STATUS_CODES, redirect_history::RedirectHistory},
+    types::{DEFAULT_ACCEPTED_STATUS_CODES, Redirects, redirect_history::RedirectHistory},
 };
 
 /// Default number of redirects that are followed.
@@ -543,22 +543,19 @@ impl Client {
         let start = std::time::Instant::now(); // Measure check time
         let remap = self.remap(&mut uri)?.inspect(|r| debug!("Remapping {r}"));
 
-        let status = match uri.scheme() {
-            _ if self.is_excluded(&uri) => Status::Excluded,
-            _ if uri.is_tel() => Status::Excluded, // We don't check tel: URIs
-            _ if uri.is_file() => self.check_file(&uri).await,
-            _ if uri.is_mail() => self.check_mail(&uri).await,
+        let (status, redirects) = match uri.scheme() {
+            _ if self.is_excluded(&uri) => (Status::Excluded, None),
+            _ if uri.is_tel() => (Status::Excluded, None), // We don't check tel: URIs
+            _ if uri.is_file() => (self.check_file(&uri).await, None),
+            _ if uri.is_mail() => (self.check_mail(&uri).await, None),
             _ => self.check_website(&uri, credentials).await?,
-        };
-
-        let status = match remap {
-            Some(remap) => Status::Remapped(Box::new(status), remap),
-            None => status,
         };
 
         Ok(Response::new(
             uri,
             status,
+            redirects,
+            remap,
             source.into(),
             span,
             Some(start.elapsed()),
@@ -609,7 +606,7 @@ impl Client {
         &self,
         uri: &Uri,
         credentials: Option<BasicAuthCredentials>,
-    ) -> Result<Status> {
+    ) -> Result<(Status, Option<Redirects>)> {
         self.website_checker.check_website(uri, credentials).await
     }
 
@@ -726,10 +723,7 @@ mod tests {
         });
 
         let res = get_mock_client_response!(r).await;
-        assert!(matches!(
-            res.status(),
-            Status::Redirected(inner, _) if **inner == Status::Ok(StatusCode::OK)
-        ));
+        assert!(res.status().is_success());
     }
 
     #[tokio::test]
@@ -956,9 +950,13 @@ mod tests {
 
         assert!(matches!(
             res.status(),
-            Status::Redirected(inner, redirects) if **inner == Status::Error(
-                ErrorKind::RejectedStatusCode(StatusCode::PERMANENT_REDIRECT)
-            ) && redirects.count() == redirect_count,
+            Status::Error(ErrorKind::RejectedStatusCode(
+                StatusCode::PERMANENT_REDIRECT
+            ))
+        ));
+        assert!(matches!(
+            res.redirects(),
+            Some(redirects) if redirects.count() == redirect_count,
         ));
     }
 
@@ -980,10 +978,8 @@ mod tests {
                 code: StatusCode::PERMANENT_REDIRECT,
             });
 
-            assert_eq!(
-                res.status(),
-                &Status::Redirected(Box::new(Status::Ok(StatusCode::OK)), redirects)
-            );
+            assert_eq!(res.status(), &Status::Ok(StatusCode::OK));
+            assert_eq!(res.redirects(), Some(&redirects));
         })
         .await;
     }
@@ -1005,15 +1001,16 @@ mod tests {
 
         assert_eq!(
             res.status(),
-            &Status::Remapped(
-                Box::new(Status::Error(ErrorKind::InvalidFilePath(
-                    format!("{mapped}/").try_into().unwrap(),
-                ))),
-                Remap {
-                    original: input,
-                    new: format!("{mapped}/").try_into().unwrap(),
-                },
-            )
+            &Status::Error(ErrorKind::InvalidFilePath(
+                format!("{mapped}/").try_into().unwrap(),
+            ))
+        );
+        assert_eq!(
+            res.remap(),
+            Some(&Remap {
+                original: input,
+                new: format!("{mapped}/").try_into().unwrap(),
+            })
         );
     }
 

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::{
     },
     collector::Collector,
     filter::{Excludes, Filter, Includes},
+    remap::Remap,
     types::{
         BaseInfo, BasicAuthCredentials, BasicAuthSelector, CacheStatus, CookieJar, ErrorKind,
         FileExtensions, FileType, Input, InputContent, InputResolver, InputSource, LycheeResult,

--- a/lychee-lib/src/retry.rs
+++ b/lychee-lib/src/retry.rs
@@ -115,7 +115,6 @@ impl RetryExt for Status {
             | Status::Excluded
             | Status::Unsupported(_)
             | Status::Cached(_) => false,
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => inner.should_retry(),
         }
     }
 }

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -113,9 +113,6 @@ impl From<&Status> for CacheStatus {
             Status::Ok(code) | Status::UnknownStatusCode(code) => Self::Ok(*code),
             Status::Excluded => Self::Excluded,
             Status::Unsupported(_) => Self::Unsupported,
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => {
-                Self::from(inner as &Status)
-            }
             Status::Timeout(code) => Self::Error(*code),
             Status::Error(e) => match e {
                 ErrorKind::RejectedStatusCode(code) => Self::Error(Some(*code)),

--- a/lychee-lib/src/types/redirect_history.rs
+++ b/lychee-lib/src/types/redirect_history.rs
@@ -1,4 +1,3 @@
-use crate::Status;
 use crate::types::cache::serialize_status_code;
 use http::StatusCode;
 use reqwest::redirect::Attempt;
@@ -94,14 +93,9 @@ impl RedirectHistory {
         }
     }
 
-    /// Wrap the given [`Status`] in [`Status::Redirected`]
-    /// if the given [`Url`] was redirected.
-    pub(crate) fn handle_redirected(&self, url: &Url, status: Status) -> Status {
-        if let Some(redirected) = self.get_resolved(url) {
-            Status::Redirected(Box::new(status), redirected)
-        } else {
-            status
-        }
+    /// Resolve the redirect chain for the given URL, if any.
+    pub(crate) fn resolve(&self, url: &Url) -> Option<Redirects> {
+        self.get_resolved(url)
     }
 
     fn get_resolved(&self, original: &Url) -> Option<Redirects> {

--- a/lychee-lib/src/types/request_error.rs
+++ b/lychee-lib/src/types/request_error.rs
@@ -85,6 +85,8 @@ impl RequestError {
                 Ok(Response::new(
                     ERROR_URI.clone(),
                     Status::RequestError(e),
+                    None,
+                    None,
                     src,
                     span,
                     None,

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -5,6 +5,9 @@ use serde::Serialize;
 
 use crate::{InputSource, Status, Uri, types::uri::raw::RawUriSpan};
 
+use super::redirect_history::Redirects;
+use crate::remap::Remap;
+
 /// Response type returned by lychee after checking a URI
 //
 // Body is public to allow inserting into stats maps (error_map, success_map,
@@ -26,6 +29,8 @@ impl Response {
     pub const fn new(
         uri: Uri,
         status: Status,
+        redirects: Option<Redirects>,
+        remap: Option<Remap>,
         input_source: InputSource,
         span: Option<RawUriSpan>,
         duration: Option<Duration>,
@@ -35,6 +40,8 @@ impl Response {
             response_body: ResponseBody {
                 uri,
                 status,
+                redirects,
+                remap,
                 span,
                 duration,
             },
@@ -46,6 +53,20 @@ impl Response {
     /// Retrieve the underlying status of the response
     pub const fn status(&self) -> &Status {
         &self.response_body.status
+    }
+
+    #[inline]
+    #[must_use]
+    /// Retrieve the redirect chain (if any)
+    pub const fn redirects(&self) -> Option<&Redirects> {
+        self.response_body.redirects.as_ref()
+    }
+
+    #[inline]
+    #[must_use]
+    /// Retrieve the remap applied before checking (if any)
+    pub const fn remap(&self) -> Option<&Remap> {
+        self.response_body.remap.as_ref()
     }
 
     #[inline]
@@ -95,6 +116,12 @@ pub struct ResponseBody {
     pub uri: Uri,
     /// The status of the check
     pub status: Status,
+    /// Redirect chain followed during the check (if any)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub redirects: Option<Redirects>,
+    /// Remap applied before checking (if any)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remap: Option<Remap>,
     /// The location of the URI
     #[serde(skip_serializing_if = "Option::is_none")]
     pub span: Option<RawUriSpan>,
@@ -116,12 +143,27 @@ impl Display for ResponseBody {
             write!(f, " (at {span})")?;
         }
 
-        // Early return for OK status to avoid verbose output
-        if matches!(self.status, Status::Ok(StatusCode::OK)) {
+        // Early return for OK status without redirects/remaps to avoid verbose output
+        if matches!(self.status, Status::Ok(StatusCode::OK))
+            && self.redirects.is_none()
+            && self.remap.is_none()
+        {
             return Ok(());
         }
 
         let details = self.status.details();
-        write!(f, " | {details}")
+        write!(f, " | {details}")?;
+
+        if let Some(redirects) = &self.redirects {
+            let count = redirects.count();
+            let noun = if count == 1 { "redirect" } else { "redirects" };
+            write!(f, " | Followed {count} {noun}. Redirects: {redirects}")?;
+        }
+
+        if let Some(remap) = &self.remap {
+            write!(f, " | Remaps: {remap}")?;
+        }
+
+        Ok(())
     }
 }

--- a/lychee-lib/src/types/response.rs
+++ b/lychee-lib/src/types/response.rs
@@ -154,14 +154,14 @@ impl Display for ResponseBody {
         let details = self.status.details();
         write!(f, " | {details}")?;
 
+        if let Some(remap) = &self.remap {
+            write!(f, " | Remaps: {remap}")?;
+        }
+
         if let Some(redirects) = &self.redirects {
             let count = redirects.count();
             let noun = if count == 1 { "redirect" } else { "redirects" };
             write!(f, " | Followed {count} {noun}. Redirects: {redirects}")?;
-        }
-
-        if let Some(remap) = &self.remap {
-            write!(f, " | Remaps: {remap}")?;
         }
 
         Ok(())

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -1,11 +1,9 @@
 use std::{collections::HashSet, fmt::Display};
 
 use super::CacheStatus;
-use super::redirect_history::Redirects;
 use crate::ErrorKind;
 use crate::RequestError;
 use crate::ratelimit::CacheableResponse;
-use crate::remap::Remap;
 use http::StatusCode;
 use serde::ser::SerializeStruct;
 use serde::{Serialize, Serializer};
@@ -30,10 +28,6 @@ pub enum Status {
     RequestError(RequestError),
     /// Request timed out
     Timeout(Option<StatusCode>),
-    /// Got redirected to different resource
-    Redirected(Box<Status>, Redirects),
-    /// The original [`Url`] was remapped in the link check process
-    Remapped(Box<Status>, Remap),
     /// The given status code is not known by lychee
     UnknownStatusCode(StatusCode),
     /// The given mail address could not be reliably identified.
@@ -63,7 +57,6 @@ impl Display for Status {
             Status::RequestError(e) => write!(f, "{e}"),
             Status::Cached(status) => write!(f, "{status}"),
             Status::Excluded => f.write_str("Excluded"),
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => Status::fmt(inner, f),
         }
     }
 }
@@ -73,23 +66,21 @@ impl Serialize for Status {
     where
         S: Serializer,
     {
-        let mut s;
+        let s;
 
         if let Some(code) = self.code() {
             s = serializer.serialize_struct("Status", 2)?;
+            let mut s = s;
             s.serialize_field("text", &self.to_string())?;
             s.serialize_field("code", &code.as_u16())?;
+            s.end()
         } else {
             s = serializer.serialize_struct("Status", 2)?;
+            let mut s = s;
             s.serialize_field("text", &self.to_string())?;
             s.serialize_field("details", &self.details())?;
+            s.end()
         }
-
-        if let Status::Redirected(_, redirects) = self {
-            s.serialize_field("redirects", redirects)?;
-        }
-
-        s.end()
     }
 }
 
@@ -147,16 +138,6 @@ impl Status {
     pub fn details(&self) -> String {
         match &self {
             Status::Ok(code) => code.to_string(),
-            Status::Redirected(inner, redirects) => {
-                let count = redirects.count();
-                let noun = if count == 1 { "redirect" } else { "redirects" };
-                let inner = inner.details();
-                format!("{inner} | Followed {count} {noun}. Redirects: {redirects}")
-            }
-            Status::Remapped(inner, remap) => {
-                let inner = inner.details();
-                format!("{inner} | Remaps: {remap}")
-            }
             Status::Error(e) => e.details(),
             Status::RequestError(e) => e.error().details(),
             Status::UnknownMailStatus(reason) => reason.clone(),
@@ -172,10 +153,7 @@ impl Status {
     #[inline]
     #[must_use]
     pub const fn is_success(&self) -> bool {
-        matches!(
-            self.innermost(),
-            Status::Ok(_) | Status::Cached(CacheStatus::Ok(_))
-        )
+        matches!(self, Status::Ok(_) | Status::Cached(CacheStatus::Ok(_)))
     }
 
     /// Returns `true` if the check was not successful
@@ -183,7 +161,7 @@ impl Status {
     #[must_use]
     pub const fn is_error(&self) -> bool {
         matches!(
-            self.innermost(),
+            self,
             Status::Error(_)
                 | Status::RequestError(_)
                 | Status::Cached(CacheStatus::Error(_))
@@ -196,7 +174,7 @@ impl Status {
     #[must_use]
     pub const fn is_excluded(&self) -> bool {
         matches!(
-            self.innermost(),
+            self,
             Status::Excluded | Status::Cached(CacheStatus::Excluded)
         )
     }
@@ -205,7 +183,7 @@ impl Status {
     #[inline]
     #[must_use]
     pub const fn is_timeout(&self) -> bool {
-        matches!(self.innermost(), Status::Timeout(_))
+        matches!(self, Status::Timeout(_))
     }
 
     /// Returns `true` if a URI is unsupported
@@ -213,7 +191,7 @@ impl Status {
     #[must_use]
     pub const fn is_unsupported(&self) -> bool {
         matches!(
-            self.innermost(),
+            self,
             Status::Unsupported(_) | Status::Cached(CacheStatus::Unsupported)
         )
     }
@@ -226,26 +204,7 @@ impl Status {
     #[inline]
     #[must_use]
     pub const fn is_unknown(&self) -> bool {
-        matches!(self.innermost(), Status::UnknownStatusCode(_))
-    }
-
-    /// Extract the innermost [`Status`], handling nested variants
-    #[must_use]
-    pub const fn innermost(&self) -> &Self {
-        match self {
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => inner.innermost(),
-            other => other,
-        }
-    }
-
-    /// Extract (potentially nested) [`Redirects`]
-    #[must_use]
-    pub const fn redirects(&self) -> Option<&Redirects> {
-        match self {
-            Status::Remapped(inner, _) => inner.redirects(),
-            Status::Redirected(_, redirects) => Some(redirects),
-            _ => None,
-        }
+        matches!(self, Status::UnknownStatusCode(_))
     }
 
     /// Return a unicode icon to visualize the status
@@ -259,7 +218,6 @@ impl Status {
             Status::Timeout(_) => ICON_TIMEOUT,
             Status::Unsupported(_) => ICON_UNSUPPORTED,
             Status::Cached(_) => ICON_CACHED,
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => inner.icon(),
         }
     }
 
@@ -278,7 +236,6 @@ impl Status {
                     None => None,
                 },
             },
-            Status::Redirected(inner, _) => inner.code(),
             _ => None,
         }
     }
@@ -315,7 +272,6 @@ impl Status {
                 CacheStatus::Excluded => "EXCLUDED".to_string(),
                 CacheStatus::Unsupported => "IGNORED".to_string(),
             },
-            Status::Redirected(inner, _) | Status::Remapped(inner, _) => inner.code_as_string(),
         }
     }
 }
@@ -344,9 +300,7 @@ impl From<ErrorKind> for Status {
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        CacheStatus, ErrorKind, Status, Uri, remap::Remap, types::redirect_history::Redirects,
-    };
+    use crate::{CacheStatus, ErrorKind, Status};
     use http::StatusCode;
 
     #[test]
@@ -391,15 +345,6 @@ mod tests {
             999
         );
         assert_eq!(
-            Status::Redirected(
-                Box::new(Status::Ok(StatusCode::from_u16(300).unwrap())),
-                Redirects::new("http://example.com".try_into().unwrap())
-            )
-            .code()
-            .unwrap(),
-            300
-        );
-        assert_eq!(
             Status::Cached(CacheStatus::Ok(StatusCode::OK))
                 .code()
                 .unwrap(),
@@ -424,30 +369,5 @@ mod tests {
     fn test_status_unknown() {
         assert!(Status::UnknownStatusCode(StatusCode::from_u16(999).unwrap()).is_unknown());
         assert!(!Status::Ok(StatusCode::from_u16(200).unwrap()).is_unknown());
-    }
-
-    #[test]
-    fn test_inner_status() {
-        let erroneous = get_nested(Status::Error(ErrorKind::EmptyUrl));
-        assert!(erroneous.is_error());
-        assert!(!erroneous.is_success());
-
-        let success = get_nested(Status::Ok(200.try_into().unwrap()));
-        assert!(success.is_success());
-        assert!(!success.is_error());
-    }
-
-    fn get_nested(inner: Status) -> Status {
-        let dummy_uri = Uri::try_from("https://example.com").unwrap();
-        Status::Redirected(
-            Box::new(Status::Remapped(
-                Box::new(inner),
-                Remap {
-                    original: dummy_uri.clone(),
-                    new: dummy_uri.clone(),
-                },
-            )),
-            Redirects::new(dummy_uri.url),
-        )
     }
 }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -175,6 +175,8 @@ macro_rules! mock_response_body {
         ResponseBody {
             uri: Uri::try_from($uri).unwrap(),
             status: $status,
+            redirects: None,
+            remap: None,
             span: None,
             duration: None,
         }


### PR DESCRIPTION
The goal of this refactor is to make a step towards cleaning up the `Status` enum as proposed in #2097.

Previously, redirect and remap information was nested inside the `Status` enum, which forced every exhaustive match (~8 places) to either recurse through these wrappers or delegate via the `innermost()` helper. This made the enum harder to work with and obscured the actual status.

The proposal is to have redirect and remap data live as separate fields on `ResponseBody`.
This gets rid of innermost() and redirects() methods from Status and all is_success/is_error/etc. methods now match directly on self.

I am aware that the three `None`s in a row in `Response` are pretty bad. The constructor already had too many positional params before this change, and I made it worse.

However, this change will unlock the possibility to move redirects into `Outcome` in the future, e.g.

```rust
pub enum Outcome {
    Website {
        result: Result<StatusCode, reqwest::Error>,
        redirects: Redirects,
        fragment_check: Option<bool>,
    },
    // ...
}
```

This way, we can get rid of the `None` fields in `Response` again in the future when we introduce `Outcome`.

(I attempted that first, but it turned out to be a much bigger refactor, so I broke out a smaller chunk for now.)

