### PR TITLE
Allow merge bool v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,8 +349,6 @@ Options:
       --accept-timeouts[=<false|true>]
           Accept timed out requests and return exit code 0 when encountering timeouts but not any other errors
 
-          [default: false]
-
       --archive <ARCHIVE>
           Web archive to use to provide suggestions for `--suggest`.
 
@@ -396,8 +394,6 @@ Options:
       --cache[=<false|true>]
           Use request cache stored on disk at `.lycheecache`
 
-          [default: false]
-
       --cache-exclude-status <CACHE_EXCLUDE_STATUS>
           A list of status codes that will be ignored from the cache
 
@@ -432,18 +428,12 @@ Options:
       --dump[=<false|true>]
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked
 
-          [default: false]
-
       --dump-inputs[=<false|true>]
           Don't perform any link extraction and checking. Instead, dump all input sources from which links would be collected
-
-          [default: false]
 
   -E, --exclude-all-private[=<false|true>]
           Exclude all private IPs from checking.
           Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
-
-          [default: false]
 
       --exclude <EXCLUDE>
           Exclude URLs and mail addresses from checking. The values are treated as regular expressions
@@ -454,20 +444,14 @@ Options:
       --exclude-link-local[=<false|true>]
           Exclude link-local IP address range from checking
 
-          [default: false]
-
       --exclude-loopback[=<false|true>]
           Exclude loopback IP address range and localhost from checking
-
-          [default: false]
 
       --exclude-path <EXCLUDE_PATH>
           Exclude paths from getting checked. The values are treated as regular expressions
 
       --exclude-private[=<false|true>]
           Exclude private IP address ranges from checking
-
-          [default: false]
 
       --extensions <EXTENSIONS>
           A list of file extensions. Files not matching the specified extensions are skipped.
@@ -530,8 +514,6 @@ Options:
       --glob-ignore-case[=<false|true>]
           Ignore case when expanding filesystem path glob inputs
 
-          [default: false]
-
   -h, --help
           Print help (see a summary with '-h')
 
@@ -547,8 +529,6 @@ Options:
 
       --hidden[=<false|true>]
           Do not skip hidden directories and files
-
-          [default: false]
 
       --host-concurrency <HOST_CONCURRENCY>
           Default maximum concurrent requests per host (default: 10)
@@ -577,12 +557,8 @@ Options:
       --host-stats[=<false|true>]
           Show per-host statistics at the end of the run
 
-          [default: false]
-
   -i, --insecure[=<false|true>]
           Proceed for server connections considered insecure (invalid TLS)
-
-          [default: false]
 
       --include <INCLUDE>
           URLs to check (supports regex). Has preference over all excludes
@@ -590,22 +566,14 @@ Options:
       --include-fragments[=<false|true>]
           Enable the checking of fragments in links
 
-          [default: false]
-
       --include-mail[=<false|true>]
           Also check email addresses
-
-          [default: false]
 
       --include-verbatim[=<false|true>]
           Find links in verbatim sections like `pre`- and `code` blocks
 
-          [default: false]
-
       --include-wikilinks[=<false|true>]
           Check WikiLinks in Markdown files, this requires specifying --base-url
-
-          [default: false]
 
       --index-files <INDEX_FILES>
           When checking locally, resolves directory links to a separate index file.
@@ -667,20 +635,14 @@ Options:
           Do not show progress bar.
           This is recommended for non-interactive shells (e.g. for continuous integration)
 
-          [default: false]
-
       --no-ignore[=<false|true>]
           Do not skip files that would otherwise be ignored by '.gitignore', '.ignore', or the global ignore file
-
-          [default: false]
 
   -o, --output <OUTPUT>
           Output file of status report
 
       --offline[=<false|true>]
           Only check local files and block network requests
-
-          [default: false]
 
   -p, --preprocess <COMMAND>
           Preprocess input files with the given command.
@@ -723,8 +685,6 @@ Options:
       --require-https[=<false|true>]
           When HTTPS is available, treat HTTP links as errors
 
-          [default: false]
-
       --root-dir <ROOT_DIR>
           Root directory to use when checking absolute links in local files. This option is
           required if absolute links appear in local files, otherwise those links will be
@@ -747,12 +707,8 @@ Options:
       --skip-missing[=<false|true>]
           Skip missing input files (default is to error if they don't exist)
 
-          [default: false]
-
       --suggest[=<false|true>]
           Suggest link replacements for broken links, using a web archive. The web archive can be specified with `--archive`
-
-          [default: false]
 
   -t, --timeout <TIMEOUT>
           Website timeout in seconds from connect to response finished

--- a/README.md
+++ b/README.md
@@ -429,15 +429,21 @@ Options:
             --default-extension md
             --default-extension html
 
-      --dump
+      --dump[=<DUMP>]
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked
 
-      --dump-inputs
+          [possible values: true, false]
+
+      --dump-inputs[=<DUMP_INPUTS>]
           Don't perform any link extraction and checking. Instead, dump all input sources from which links would be collected
 
-  -E, --exclude-all-private
+          [possible values: true, false]
+
+  -E, --exclude-all-private[=<EXCLUDE_ALL_PRIVATE>]
           Exclude all private IPs from checking.
           Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
+
+          [possible values: true, false]
 
       --exclude <EXCLUDE>
           Exclude URLs and mail addresses from checking. The values are treated as regular expressions
@@ -445,17 +451,23 @@ Options:
       --exclude-file <EXCLUDE_FILE>
           Deprecated; use `--exclude-path` instead
 
-      --exclude-link-local
+      --exclude-link-local[=<EXCLUDE_LINK_LOCAL>]
           Exclude link-local IP address range from checking
 
-      --exclude-loopback
+          [possible values: true, false]
+
+      --exclude-loopback[=<EXCLUDE_LOOPBACK>]
           Exclude loopback IP address range and localhost from checking
+
+          [possible values: true, false]
 
       --exclude-path <EXCLUDE_PATH>
           Exclude paths from getting checked. The values are treated as regular expressions
 
-      --exclude-private
+      --exclude-private[=<EXCLUDE_PRIVATE>]
           Exclude private IP address ranges from checking
+
+          [possible values: true, false]
 
       --extensions <EXTENSIONS>
           A list of file extensions. Files not matching the specified extensions are skipped.
@@ -515,8 +527,10 @@ Options:
 
           [env: GITHUB_TOKEN]
 
-      --glob-ignore-case
+      --glob-ignore-case[=<GLOB_IGNORE_CASE>]
           Ignore case when expanding filesystem path glob inputs
+
+          [possible values: true, false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -531,8 +545,10 @@ Options:
           The specified headers are used for ALL requests.
           Use the `hosts` option to configure headers on a per-host basis.
 
-      --hidden
+      --hidden[=<HIDDEN>]
           Do not skip hidden directories and files
+
+          [possible values: true, false]
 
       --host-concurrency <HOST_CONCURRENCY>
           Default maximum concurrent requests per host (default: 10)
@@ -558,26 +574,38 @@ Options:
             --host-request-interval 50ms   # Fast for robust APIs
             --host-request-interval 1s     # Conservative for rate-limited APIs
 
-      --host-stats
+      --host-stats[=<HOST_STATS>]
           Show per-host statistics at the end of the run
 
-  -i, --insecure
+          [possible values: true, false]
+
+  -i, --insecure[=<INSECURE>]
           Proceed for server connections considered insecure (invalid TLS)
+
+          [possible values: true, false]
 
       --include <INCLUDE>
           URLs to check (supports regex). Has preference over all excludes
 
-      --include-fragments
+      --include-fragments[=<INCLUDE_FRAGMENTS>]
           Enable the checking of fragments in links
 
-      --include-mail
+          [possible values: true, false]
+
+      --include-mail[=<INCLUDE_MAIL>]
           Also check email addresses
 
-      --include-verbatim
+          [possible values: true, false]
+
+      --include-verbatim[=<INCLUDE_VERBATIM>]
           Find links in verbatim sections like `pre`- and `code` blocks
 
-      --include-wikilinks
+          [possible values: true, false]
+
+      --include-wikilinks[=<INCLUDE_WIKILINKS>]
           Check WikiLinks in Markdown files, this requires specifying --base-url
+
+          [possible values: true, false]
 
       --index-files <INDEX_FILES>
           When checking locally, resolves directory links to a separate index file.
@@ -635,18 +663,24 @@ Options:
 
           [possible values: plain, color, emoji, task]
 
-  -n, --no-progress
+  -n, --no-progress[=<NO_PROGRESS>]
           Do not show progress bar.
           This is recommended for non-interactive shells (e.g. for continuous integration)
 
-      --no-ignore
+          [possible values: true, false]
+
+      --no-ignore[=<NO_IGNORE>]
           Do not skip files that would otherwise be ignored by '.gitignore', '.ignore', or the global ignore file
+
+          [possible values: true, false]
 
   -o, --output <OUTPUT>
           Output file of status report
 
-      --offline
+      --offline[=<OFFLINE>]
           Only check local files and block network requests
+
+          [possible values: true, false]
 
   -p, --preprocess <COMMAND>
           Preprocess input files with the given command.
@@ -686,8 +720,10 @@ Options:
       --remap <REMAP>
           Remap URI matching pattern to different URI
 
-      --require-https
+      --require-https[=<REQUIRE_HTTPS>]
           When HTTPS is available, treat HTTP links as errors
+
+          [possible values: true, false]
 
       --root-dir <ROOT_DIR>
           Root directory to use when checking absolute links in local files. This option is
@@ -708,11 +744,15 @@ Options:
           Omit to check links with any other scheme.
           At the moment, we support http, https, file, and mailto.
 
-      --skip-missing
+      --skip-missing[=<SKIP_MISSING>]
           Skip missing input files (default is to error if they don't exist)
 
-      --suggest
+          [possible values: true, false]
+
+      --suggest[=<SUGGEST>]
           Suggest link replacements for broken links, using a web archive. The web archive can be specified with `--archive`
+
+          [possible values: true, false]
 
   -t, --timeout <TIMEOUT>
           Website timeout in seconds from connect to response finished

--- a/README.md
+++ b/README.md
@@ -346,10 +346,10 @@ Options:
 
           [default: 100..=103,200..=299]
 
-      --accept-timeouts[=<ACCEPT_TIMEOUTS>]
+      --accept-timeouts[=<false|true>]
           Accept timed out requests and return exit code 0 when encountering timeouts but not any other errors
 
-          [possible values: true, false]
+          [default: false]
 
       --archive <ARCHIVE>
           Web archive to use to provide suggestions for `--suggest`.
@@ -393,10 +393,10 @@ Options:
 
           [default: lychee.toml]
 
-      --cache[=<CACHE>]
+      --cache[=<false|true>]
           Use request cache stored on disk at `.lycheecache`
 
-          [possible values: true, false]
+          [default: false]
 
       --cache-exclude-status <CACHE_EXCLUDE_STATUS>
           A list of status codes that will be ignored from the cache
@@ -429,21 +429,21 @@ Options:
             --default-extension md
             --default-extension html
 
-      --dump[=<DUMP>]
+      --dump[=<false|true>]
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked
 
-          [possible values: true, false]
+          [default: false]
 
-      --dump-inputs[=<DUMP_INPUTS>]
+      --dump-inputs[=<false|true>]
           Don't perform any link extraction and checking. Instead, dump all input sources from which links would be collected
 
-          [possible values: true, false]
+          [default: false]
 
-  -E, --exclude-all-private[=<EXCLUDE_ALL_PRIVATE>]
+  -E, --exclude-all-private[=<false|true>]
           Exclude all private IPs from checking.
           Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
 
-          [possible values: true, false]
+          [default: false]
 
       --exclude <EXCLUDE>
           Exclude URLs and mail addresses from checking. The values are treated as regular expressions
@@ -451,23 +451,23 @@ Options:
       --exclude-file <EXCLUDE_FILE>
           Deprecated; use `--exclude-path` instead
 
-      --exclude-link-local[=<EXCLUDE_LINK_LOCAL>]
+      --exclude-link-local[=<false|true>]
           Exclude link-local IP address range from checking
 
-          [possible values: true, false]
+          [default: false]
 
-      --exclude-loopback[=<EXCLUDE_LOOPBACK>]
+      --exclude-loopback[=<false|true>]
           Exclude loopback IP address range and localhost from checking
 
-          [possible values: true, false]
+          [default: false]
 
       --exclude-path <EXCLUDE_PATH>
           Exclude paths from getting checked. The values are treated as regular expressions
 
-      --exclude-private[=<EXCLUDE_PRIVATE>]
+      --exclude-private[=<false|true>]
           Exclude private IP address ranges from checking
 
-          [possible values: true, false]
+          [default: false]
 
       --extensions <EXTENSIONS>
           A list of file extensions. Files not matching the specified extensions are skipped.
@@ -527,10 +527,10 @@ Options:
 
           [env: GITHUB_TOKEN]
 
-      --glob-ignore-case[=<GLOB_IGNORE_CASE>]
+      --glob-ignore-case[=<false|true>]
           Ignore case when expanding filesystem path glob inputs
 
-          [possible values: true, false]
+          [default: false]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -545,10 +545,10 @@ Options:
           The specified headers are used for ALL requests.
           Use the `hosts` option to configure headers on a per-host basis.
 
-      --hidden[=<HIDDEN>]
+      --hidden[=<false|true>]
           Do not skip hidden directories and files
 
-          [possible values: true, false]
+          [default: false]
 
       --host-concurrency <HOST_CONCURRENCY>
           Default maximum concurrent requests per host (default: 10)
@@ -574,38 +574,38 @@ Options:
             --host-request-interval 50ms   # Fast for robust APIs
             --host-request-interval 1s     # Conservative for rate-limited APIs
 
-      --host-stats[=<HOST_STATS>]
+      --host-stats[=<false|true>]
           Show per-host statistics at the end of the run
 
-          [possible values: true, false]
+          [default: false]
 
-  -i, --insecure[=<INSECURE>]
+  -i, --insecure[=<false|true>]
           Proceed for server connections considered insecure (invalid TLS)
 
-          [possible values: true, false]
+          [default: false]
 
       --include <INCLUDE>
           URLs to check (supports regex). Has preference over all excludes
 
-      --include-fragments[=<INCLUDE_FRAGMENTS>]
+      --include-fragments[=<false|true>]
           Enable the checking of fragments in links
 
-          [possible values: true, false]
+          [default: false]
 
-      --include-mail[=<INCLUDE_MAIL>]
+      --include-mail[=<false|true>]
           Also check email addresses
 
-          [possible values: true, false]
+          [default: false]
 
-      --include-verbatim[=<INCLUDE_VERBATIM>]
+      --include-verbatim[=<false|true>]
           Find links in verbatim sections like `pre`- and `code` blocks
 
-          [possible values: true, false]
+          [default: false]
 
-      --include-wikilinks[=<INCLUDE_WIKILINKS>]
+      --include-wikilinks[=<false|true>]
           Check WikiLinks in Markdown files, this requires specifying --base-url
 
-          [possible values: true, false]
+          [default: false]
 
       --index-files <INDEX_FILES>
           When checking locally, resolves directory links to a separate index file.
@@ -663,24 +663,24 @@ Options:
 
           [possible values: plain, color, emoji, task]
 
-  -n, --no-progress[=<NO_PROGRESS>]
+  -n, --no-progress[=<false|true>]
           Do not show progress bar.
           This is recommended for non-interactive shells (e.g. for continuous integration)
 
-          [possible values: true, false]
+          [default: false]
 
-      --no-ignore[=<NO_IGNORE>]
+      --no-ignore[=<false|true>]
           Do not skip files that would otherwise be ignored by '.gitignore', '.ignore', or the global ignore file
 
-          [possible values: true, false]
+          [default: false]
 
   -o, --output <OUTPUT>
           Output file of status report
 
-      --offline[=<OFFLINE>]
+      --offline[=<false|true>]
           Only check local files and block network requests
 
-          [possible values: true, false]
+          [default: false]
 
   -p, --preprocess <COMMAND>
           Preprocess input files with the given command.
@@ -720,10 +720,10 @@ Options:
       --remap <REMAP>
           Remap URI matching pattern to different URI
 
-      --require-https[=<REQUIRE_HTTPS>]
+      --require-https[=<false|true>]
           When HTTPS is available, treat HTTP links as errors
 
-          [possible values: true, false]
+          [default: false]
 
       --root-dir <ROOT_DIR>
           Root directory to use when checking absolute links in local files. This option is
@@ -744,15 +744,15 @@ Options:
           Omit to check links with any other scheme.
           At the moment, we support http, https, file, and mailto.
 
-      --skip-missing[=<SKIP_MISSING>]
+      --skip-missing[=<false|true>]
           Skip missing input files (default is to error if they don't exist)
 
-          [possible values: true, false]
+          [default: false]
 
-      --suggest[=<SUGGEST>]
+      --suggest[=<false|true>]
           Suggest link replacements for broken links, using a web archive. The web archive can be specified with `--archive`
 
-          [possible values: true, false]
+          [default: false]
 
   -t, --timeout <TIMEOUT>
           Website timeout in seconds from connect to response finished

--- a/README.md
+++ b/README.md
@@ -393,8 +393,10 @@ Options:
 
           [default: lychee.toml]
 
-      --cache
+      --cache[=<CACHE>]
           Use request cache stored on disk at `.lycheecache`
+
+          [possible values: true, false]
 
       --cache-exclude-status <CACHE_EXCLUDE_STATUS>
           A list of status codes that will be ignored from the cache

--- a/README.md
+++ b/README.md
@@ -346,8 +346,10 @@ Options:
 
           [default: 100..=103,200..=299]
 
-      --accept-timeouts
+      --accept-timeouts[=<ACCEPT_TIMEOUTS>]
           Accept timed out requests and return exit code 0 when encountering timeouts but not any other errors
+
+          [possible values: true, false]
 
       --archive <ARCHIVE>
           Web archive to use to provide suggestions for `--suggest`.

--- a/lychee-bin/src/client.rs
+++ b/lychee-bin/src/client.rs
@@ -20,7 +20,7 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
     let accepted: HashSet<StatusCode> = cfg.accept().into();
 
     // Offline mode overrides the scheme
-    let schemes = if cfg.offline {
+    let schemes = if cfg.offline() {
         vec!["file".to_string()]
     } else {
         cfg.scheme.clone()
@@ -33,14 +33,14 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
         .base(cfg.base_url.clone().unwrap_or_default())
         .includes(includes)
         .excludes(excludes)
-        .exclude_all_private(cfg.exclude_all_private)
-        .exclude_private_ips(cfg.exclude_private)
-        .exclude_link_local_ips(cfg.exclude_link_local)
-        .exclude_loopback_ips(cfg.exclude_loopback)
-        .include_mail(cfg.include_mail)
+        .exclude_all_private(cfg.exclude_all_private())
+        .exclude_private_ips(cfg.exclude_private())
+        .exclude_link_local_ips(cfg.exclude_link_local())
+        .exclude_loopback_ips(cfg.exclude_loopback())
+        .include_mail(cfg.include_mail())
         .max_redirects(cfg.max_redirects())
         .user_agent(cfg.user_agent())
-        .allow_insecure(cfg.insecure)
+        .allow_insecure(cfg.insecure())
         .custom_headers(headers)
         .method(method)
         .timeout(timeout)
@@ -49,13 +49,13 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
         .github_token(cfg.github_token.clone())
         .schemes(HashSet::from_iter(schemes))
         .accepted(accepted)
-        .require_https(cfg.require_https)
+        .require_https(cfg.require_https())
         .cookie_jar(cookie_jar.cloned())
         .min_tls_version(cfg.min_tls.clone().map(Into::into))
-        .include_fragments(cfg.include_fragments)
+        .include_fragments(cfg.include_fragments())
         .fallback_extensions(cfg.fallback_extensions.clone())
         .index_files(cfg.index_files.clone())
-        .include_wikilinks(cfg.include_wikilinks)
+        .include_wikilinks(cfg.include_wikilinks())
         .rate_limit_config(RateLimitConfig::from_options(
             cfg.host_concurrency,
             cfg.host_request_interval,

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -61,7 +61,7 @@ where
         accept,
     ));
 
-    let hide_bar = params.cfg.no_progress || params.is_stdin_input;
+    let hide_bar = params.cfg.no_progress() || params.is_stdin_input;
     let level = params.cfg.verbose().log_level();
 
     let progress = Progress::new("Extracting links", hide_bar, level, &params.cfg.mode());
@@ -93,7 +93,7 @@ where
     // must go before printing the stats
     progress.finish("Finished extracting links");
 
-    if params.cfg.suggest {
+    if params.cfg.suggest() {
         let progress = Progress::new(
             "Searching for alternatives",
             hide_bar,

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -48,7 +48,7 @@ where
     let cache = params.cache;
     let cache_exclude_status = params.cfg.cache_exclude_status().into();
     let accept = params.cfg.accept().into();
-    let accept_timeouts = params.cfg.accept_timeouts;
+    let accept_timeouts = params.cfg.accept_timeouts();
 
     // Start receiving requests
     let request_handle = tokio::spawn(request_channel_task(

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -963,7 +963,6 @@ impl Config {
             (
                 option { $( $optional:ident ),* $(,)? },
                 chain { $( $chainable:ident ),* $(,)? },
-                bool { $( $bool:ident ),* $(,)? },
             ) => {
                 Config {
                     hosts,
@@ -971,13 +970,6 @@ impl Config {
                     $( $chainable: self.$chainable.into_iter().chain(other.$chainable).collect(), )*
                     // Use self if present, otherwise use other
                     $( $optional: self.$optional.or(other.$optional), )*
-                    // Use `true` when self or other is `true`.
-                    // Note that this has the drawback, that a value cannot be overwritten with
-                    // `false` in the merge chain, as there is no way to distinguish
-                    // between "default" `false` and user-provided `false`.
-                    // We would have to use `Option<bool>` in order to do that.
-                    // See: https://github.com/lycheeverse/lychee/issues/2051
-                    $( $bool: self.$bool || other.$bool, )*
                 }
             };
         }
@@ -1047,13 +1039,6 @@ impl Config {
                 remap,
                 scheme,
                 header,
-            },
-            bool {
-                /*
-                 * None for now. We prefer to use `Option<bool>` for boolean flags, because it allows us to distinguish between
-                 * "default" `false` and user-provided `false`, which is important for merging configs.
-                 * If you have a good reason, feel free to add `bool`s here which should be merged with OR.
-                 */
             },
         )
     }

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -70,7 +70,6 @@ impl ArgBoolOptionalExt for Arg {
             .require_equals(true) // Ensure that `--flag value` is not misinterpreted as `--flag=true value`
             .value_name("false|true") // Set the value name for help messages
             .hide_possible_values(true) // We already provide the values
-            .default_value("false") // Default to false if the flag is not provided
     }
 }
 

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -55,6 +55,7 @@ occurrences take precedence over previous occurrences.
 [default: {}]",
     loaders::lychee_toml::LYCHEE_CONFIG_FILE
 );
+
 /// lychee is a fast, asynchronous link checker which detects broken URLs and mail addresses
 /// in local files and websites. It supports Markdown and HTML and works with other file formats.
 ///
@@ -453,9 +454,14 @@ pub(crate) struct Config {
 
     /// Accept timed out requests and return exit code 0
     /// when encountering timeouts but not any other errors.
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true", // `--flag` is equivalent to `--flag=true`
+        num_args = 0..=1, // allow `--flag` with no value
+        require_equals = true, // ensures `--flag parameter` is interpreted as `--flag=true parameter`
+    )]
     #[serde(default)]
-    pub(crate) accept_timeouts: bool,
+    accept_timeouts: Option<bool>,
 
     /// Enable the checking of fragments in links.
     #[arg(long)]
@@ -742,6 +748,11 @@ impl Config {
             .unwrap_or(StatusCodeSelector::default_accepted())
     }
 
+    /// Whether to accept timeouts as valid results
+    pub(crate) fn accept_timeouts(&self) -> bool {
+        self.accept_timeouts.unwrap_or(false)
+    }
+
     /// Custom headers to send with requests
     pub(crate) fn headers(&self) -> HashMap<String, String> {
         self.header.iter().cloned().collect()
@@ -777,6 +788,7 @@ impl Config {
         merge!(
             option {
                 accept,
+                accept_timeouts,
                 archive,
                 base,
                 base_url,
@@ -819,7 +831,6 @@ impl Config {
                 header,
             },
             bool {
-                accept_timeouts,
                 cache,
                 dump,
                 dump_inputs,

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -110,7 +110,9 @@ impl LycheeOptions {
 
         all_inputs
             .iter()
-            .map(|raw_input| Input::new(raw_input, default_file_type, self.config.glob_ignore_case))
+            .map(|raw_input| {
+                Input::new(raw_input, default_file_type, self.config.glob_ignore_case())
+            })
             .collect::<Result<_, _>>()
             .context("Cannot parse inputs from arguments")
     }
@@ -154,14 +156,26 @@ pub(crate) struct Config {
 
     /// Do not show progress bar.
     /// This is recommended for non-interactive shells (e.g. for continuous integration)
-    #[arg(short, long, verbatim_doc_comment)]
+    #[arg(
+        short,
+        long,
+        verbatim_doc_comment,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) no_progress: bool,
+    no_progress: Option<bool>,
 
     /// Show per-host statistics at the end of the run
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) host_stats: bool,
+    host_stats: Option<bool>,
 
     /// A list of file extensions. Files not matching the specified extensions are skipped.
     ///
@@ -224,15 +238,25 @@ pub(crate) struct Config {
 
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) dump: bool,
+    dump: Option<bool>,
 
     /// Don't perform any link extraction and checking.
     /// Instead, dump all input sources from which links would be collected
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) dump_inputs: bool,
+    dump_inputs: Option<bool>,
 
     /// Web archive to use to provide suggestions for `--suggest`.
     ///
@@ -242,9 +266,14 @@ pub(crate) struct Config {
 
     /// Suggest link replacements for broken links, using a web archive.
     /// The web archive can be specified with `--archive`
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) suggest: bool,
+    suggest: Option<bool>,
 
     /// Maximum number of allowed redirects
     ///
@@ -307,9 +336,15 @@ pub(crate) struct Config {
     user_agent: Option<String>,
 
     /// Proceed for server connections considered insecure (invalid TLS)
-    #[arg(short, long)]
+    #[arg(
+        short,
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) insecure: bool,
+    insecure: Option<bool>,
 
     /// Only test links with the given schemes (e.g. https).
     /// Omit to check links with any other scheme.
@@ -319,9 +354,14 @@ pub(crate) struct Config {
     pub(crate) scheme: Vec<String>,
 
     /// Only check local files and block network requests.
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) offline: bool,
+    offline: Option<bool>,
 
     /// URLs to check (supports regex). Has preference over all excludes.
     #[arg(long)]
@@ -347,29 +387,56 @@ pub(crate) struct Config {
 
     /// Exclude all private IPs from checking.
     /// Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
-    #[arg(short = 'E', long, verbatim_doc_comment)]
+    #[arg(
+        short = 'E',
+        long,
+        verbatim_doc_comment,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) exclude_all_private: bool,
+    exclude_all_private: Option<bool>,
 
     /// Exclude private IP address ranges from checking
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) exclude_private: bool,
+    exclude_private: Option<bool>,
 
     /// Exclude link-local IP address range from checking
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) exclude_link_local: bool,
+    exclude_link_local: Option<bool>,
 
     /// Exclude loopback IP address range and localhost from checking
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) exclude_loopback: bool,
+    exclude_loopback: Option<bool>,
 
     /// Also check email addresses
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) include_mail: bool,
+    include_mail: Option<bool>,
 
     /// Remap URI matching pattern to different URI
     #[serde(default)]
@@ -469,9 +536,14 @@ pub(crate) struct Config {
     accept_timeouts: Option<bool>,
 
     /// Enable the checking of fragments in links.
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) include_fragments: bool,
+    include_fragments: Option<bool>,
 
     /// Website timeout in seconds from connect to response finished
     ///
@@ -548,30 +620,55 @@ pub(crate) struct Config {
     pub(crate) github_token: Option<SecretString>,
 
     /// Skip missing input files (default is to error if they don't exist)
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) skip_missing: bool,
+    skip_missing: Option<bool>,
 
     /// Do not skip files that would otherwise be ignored by
     /// '.gitignore', '.ignore', or the global ignore file.
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) no_ignore: bool,
+    no_ignore: Option<bool>,
 
     /// Do not skip hidden directories and files.
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) hidden: bool,
+    hidden: Option<bool>,
 
     /// Find links in verbatim sections like `pre`- and `code` blocks
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) include_verbatim: bool,
+    include_verbatim: Option<bool>,
 
     /// Ignore case when expanding filesystem path glob inputs
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) glob_ignore_case: bool,
+    glob_ignore_case: Option<bool>,
 
     /// Output file of status report
     #[arg(short, long, value_parser)]
@@ -594,9 +691,14 @@ pub(crate) struct Config {
     pub(crate) generate: Option<GenerateMode>,
 
     /// When HTTPS is available, treat HTTP links as errors
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) require_https: bool,
+    require_https: Option<bool>,
 
     /// Read and write cookies using the given file. Cookies will be stored in the
     /// cookie jar and sent with requests. New cookies will be stored in the cookie jar
@@ -607,9 +709,14 @@ pub(crate) struct Config {
     #[allow(clippy::doc_markdown)]
     /// Check WikiLinks in Markdown files, this requires specifying --base-url
     #[clap(requires = "base_url")]
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) include_wikilinks: bool,
+    include_wikilinks: Option<bool>,
 
     /// Preprocess input files with the given command.
     ///
@@ -751,6 +858,86 @@ impl Config {
         self.cache.unwrap_or(false)
     }
 
+    pub(crate) fn dump(&self) -> bool {
+        self.dump.unwrap_or(false)
+    }
+
+    pub(crate) fn dump_inputs(&self) -> bool {
+        self.dump_inputs.unwrap_or(false)
+    }
+
+    pub(crate) fn exclude_all_private(&self) -> bool {
+        self.exclude_all_private.unwrap_or(false)
+    }
+
+    pub(crate) fn exclude_link_local(&self) -> bool {
+        self.exclude_link_local.unwrap_or(false)
+    }
+
+    pub(crate) fn exclude_loopback(&self) -> bool {
+        self.exclude_loopback.unwrap_or(false)
+    }
+
+    pub(crate) fn exclude_private(&self) -> bool {
+        self.exclude_private.unwrap_or(false)
+    }
+
+    pub(crate) fn glob_ignore_case(&self) -> bool {
+        self.glob_ignore_case.unwrap_or(false)
+    }
+
+    pub(crate) fn hidden(&self) -> bool {
+        self.hidden.unwrap_or(false)
+    }
+
+    pub(crate) fn host_stats(&self) -> bool {
+        self.host_stats.unwrap_or(false)
+    }
+
+    pub(crate) fn include_fragments(&self) -> bool {
+        self.include_fragments.unwrap_or(false)
+    }
+
+    pub(crate) fn include_mail(&self) -> bool {
+        self.include_mail.unwrap_or(false)
+    }
+
+    pub(crate) fn include_verbatim(&self) -> bool {
+        self.include_verbatim.unwrap_or(false)
+    }
+
+    pub(crate) fn include_wikilinks(&self) -> bool {
+        self.include_wikilinks.unwrap_or(false)
+    }
+
+    pub(crate) fn insecure(&self) -> bool {
+        self.insecure.unwrap_or(false)
+    }
+
+    pub(crate) fn no_ignore(&self) -> bool {
+        self.no_ignore.unwrap_or(false)
+    }
+
+    pub(crate) fn no_progress(&self) -> bool {
+        self.no_progress.unwrap_or(false)
+    }
+
+    pub(crate) fn offline(&self) -> bool {
+        self.offline.unwrap_or(false)
+    }
+
+    pub(crate) fn require_https(&self) -> bool {
+        self.require_https.unwrap_or(false)
+    }
+
+    pub(crate) fn skip_missing(&self) -> bool {
+        self.skip_missing.unwrap_or(false)
+    }
+
+    pub(crate) fn suggest(&self) -> bool {
+        self.suggest.unwrap_or(false)
+    }
+
     /// Status codes that are considered successful
     pub(crate) fn accept(&self) -> StatusCodeSelector {
         self.accept
@@ -807,16 +994,36 @@ impl Config {
                 cache_exclude_status,
                 cookie_jar,
                 default_extension,
+                dump,
+                dump_inputs,
+                exclude_all_private,
+                exclude_link_local,
+                exclude_loopback,
+                exclude_private,
                 github_token,
+                glob_ignore_case,
+                hidden,
                 host_concurrency,
                 host_request_interval,
                 files_from,
                 generate,
+                host_stats,
+                include_fragments,
+                include_mail,
+                include_verbatim,
+                include_wikilinks,
                 index_files,
+                insecure,
                 min_tls,
+                no_ignore,
+                no_progress,
+                offline,
                 output,
                 preprocess,
+                require_https,
                 root_dir,
+                skip_missing,
+                suggest,
                 threads,
                 extensions,
                 format,
@@ -842,26 +1049,11 @@ impl Config {
                 header,
             },
             bool {
-                dump,
-                dump_inputs,
-                exclude_all_private,
-                exclude_link_local,
-                exclude_loopback,
-                exclude_private,
-                glob_ignore_case,
-                hidden,
-                host_stats,
-                include_fragments,
-                include_mail,
-                include_verbatim,
-                include_wikilinks,
-                insecure,
-                no_ignore,
-                no_progress,
-                offline,
-                require_https,
-                skip_missing,
-                suggest,
+                /*
+                 * None for now. We prefer to use `Option<bool>` for boolean flags, because it allows us to distinguish between
+                 * "default" `false` and user-provided `false`, which is important for merging configs.
+                 * If you have a good reason, feel free to add `bool`s here which should be merged with OR.
+                 */
             },
         )
     }

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -56,6 +56,21 @@ occurrences take precedence over previous occurrences.
     loaders::lychee_toml::LYCHEE_CONFIG_FILE
 );
 
+use clap::Arg;
+
+/// Extension trait for `clap::Arg` to add a custom method for boolean flags that can be specified without a value (e.g. `--flag` is equivalent to `--flag=true`).
+trait ArgBoolOptionalExt {
+    fn optional_bool_flag(self) -> Self;
+}
+
+impl ArgBoolOptionalExt for Arg {
+    fn optional_bool_flag(self) -> Self {
+        self.default_missing_value("true") // Ensure `--flag` is treated as `--flag=true`
+            .num_args(0..=1) // Allow the flag to be specified with no value
+            .require_equals(true) // Ensure that `--flag value` is not misinterpreted as `--flag=true value`
+    }
+}
+
 /// lychee is a fast, asynchronous link checker which detects broken URLs and mail addresses
 /// in local files and websites. It supports Markdown and HTML and works with other file formats.
 ///
@@ -156,24 +171,12 @@ pub(crate) struct Config {
 
     /// Do not show progress bar.
     /// This is recommended for non-interactive shells (e.g. for continuous integration)
-    #[arg(
-        short,
-        long,
-        verbatim_doc_comment,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(short, long, verbatim_doc_comment, optional_bool_flag())]
     #[serde(default)]
     no_progress: Option<bool>,
 
     /// Show per-host statistics at the end of the run
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     host_stats: Option<bool>,
 
@@ -203,12 +206,7 @@ pub(crate) struct Config {
     default_extension: Option<String>,
 
     #[arg(help = HELP_MSG_CACHE)]
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     cache: Option<bool>,
 
@@ -238,23 +236,13 @@ pub(crate) struct Config {
 
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     dump: Option<bool>,
 
     /// Don't perform any link extraction and checking.
     /// Instead, dump all input sources from which links would be collected
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     dump_inputs: Option<bool>,
 
@@ -266,12 +254,7 @@ pub(crate) struct Config {
 
     /// Suggest link replacements for broken links, using a web archive.
     /// The web archive can be specified with `--archive`
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     suggest: Option<bool>,
 
@@ -336,13 +319,7 @@ pub(crate) struct Config {
     user_agent: Option<String>,
 
     /// Proceed for server connections considered insecure (invalid TLS)
-    #[arg(
-        short,
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(short, long, optional_bool_flag())]
     #[serde(default)]
     insecure: Option<bool>,
 
@@ -354,12 +331,7 @@ pub(crate) struct Config {
     pub(crate) scheme: Vec<String>,
 
     /// Only check local files and block network requests.
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     offline: Option<bool>,
 
@@ -387,54 +359,27 @@ pub(crate) struct Config {
 
     /// Exclude all private IPs from checking.
     /// Equivalent to `--exclude-private --exclude-link-local --exclude-loopback`
-    #[arg(
-        short = 'E',
-        long,
-        verbatim_doc_comment,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(short = 'E', long, verbatim_doc_comment, optional_bool_flag())]
     #[serde(default)]
     exclude_all_private: Option<bool>,
 
     /// Exclude private IP address ranges from checking
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     exclude_private: Option<bool>,
 
     /// Exclude link-local IP address range from checking
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     exclude_link_local: Option<bool>,
 
     /// Exclude loopback IP address range and localhost from checking
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     exclude_loopback: Option<bool>,
 
     /// Also check email addresses
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     include_mail: Option<bool>,
 
@@ -526,22 +471,12 @@ pub(crate) struct Config {
 
     /// Accept timed out requests and return exit code 0
     /// when encountering timeouts but not any other errors.
-    #[arg(
-        long,
-        default_missing_value = "true", // `--flag` is equivalent to `--flag=true`
-        num_args = 0..=1, // allow `--flag` with no value
-        require_equals = true, // ensures `--flag parameter` is interpreted as `--flag=true parameter`
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     accept_timeouts: Option<bool>,
 
     /// Enable the checking of fragments in links.
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     include_fragments: Option<bool>,
 
@@ -620,53 +555,28 @@ pub(crate) struct Config {
     pub(crate) github_token: Option<SecretString>,
 
     /// Skip missing input files (default is to error if they don't exist)
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     skip_missing: Option<bool>,
 
     /// Do not skip files that would otherwise be ignored by
     /// '.gitignore', '.ignore', or the global ignore file.
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     no_ignore: Option<bool>,
 
     /// Do not skip hidden directories and files.
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     hidden: Option<bool>,
 
     /// Find links in verbatim sections like `pre`- and `code` blocks
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     include_verbatim: Option<bool>,
 
     /// Ignore case when expanding filesystem path glob inputs
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     glob_ignore_case: Option<bool>,
 
@@ -691,12 +601,7 @@ pub(crate) struct Config {
     pub(crate) generate: Option<GenerateMode>,
 
     /// When HTTPS is available, treat HTTP links as errors
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     require_https: Option<bool>,
 
@@ -709,12 +614,7 @@ pub(crate) struct Config {
     #[allow(clippy::doc_markdown)]
     /// Check WikiLinks in Markdown files, this requires specifying --base-url
     #[clap(requires = "base_url")]
-    #[arg(
-        long,
-        default_missing_value = "true",
-        num_args = 0..=1,
-        require_equals = true,
-    )]
+    #[arg(long, optional_bool_flag())]
     #[serde(default)]
     include_wikilinks: Option<bool>,
 

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -189,9 +189,14 @@ pub(crate) struct Config {
     default_extension: Option<String>,
 
     #[arg(help = HELP_MSG_CACHE)]
-    #[arg(long)]
+    #[arg(
+        long,
+        default_missing_value = "true",
+        num_args = 0..=1,
+        require_equals = true,
+    )]
     #[serde(default)]
-    pub(crate) cache: bool,
+    cache: Option<bool>,
 
     /// Discard all cached requests older than this duration
     ///
@@ -741,6 +746,11 @@ impl Config {
             .unwrap_or(StatusCodeSelector::empty())
     }
 
+    /// Whether to use the on-disk request cache
+    pub(crate) fn cache(&self) -> bool {
+        self.cache.unwrap_or(false)
+    }
+
     /// Status codes that are considered successful
     pub(crate) fn accept(&self) -> StatusCodeSelector {
         self.accept
@@ -793,6 +803,7 @@ impl Config {
                 base,
                 base_url,
                 basic_auth,
+                cache,
                 cache_exclude_status,
                 cookie_jar,
                 default_extension,
@@ -831,7 +842,6 @@ impl Config {
                 header,
             },
             bool {
-                cache,
                 dump,
                 dump_inputs,
                 exclude_all_private,

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -1079,6 +1079,25 @@ This convention also simplifies our default value testing."
     }
 
     #[test]
+    #[expect(clippy::bool_assert_comparison)]
+    fn test_bool_flags() {
+        // Values for boolean flags can be specified explicitly.
+        let explicit = parse_options(vec!["lychee", "-", "--dump=false"]);
+        assert_eq!(explicit.config.dump(), false);
+
+        let explicit = parse_options(vec!["lychee", "-", "--dump=true"]);
+        assert_eq!(explicit.config.dump(), true);
+
+        // Or implicitly
+        let implicit = parse_options(vec!["lychee", "-", "--dump"]);
+        assert_eq!(implicit.config.dump(), true);
+
+        // They default to `false`
+        let default = parse_options(vec!["lychee", "-"]);
+        assert_eq!(default.config.dump(), false);
+    }
+
+    #[test]
     fn test_header_parsing_and_merging() {
         // Simulate commandline arguments with multiple headers
         let args = vec![

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -68,6 +68,9 @@ impl ArgBoolOptionalExt for Arg {
         self.default_missing_value("true") // Ensure `--flag` is treated as `--flag=true`
             .num_args(0..=1) // Allow the flag to be specified with no value
             .require_equals(true) // Ensure that `--flag value` is not misinterpreted as `--flag=true value`
+            .value_name("false|true") // Set the value name for help messages
+            .hide_possible_values(true) // We already provide the values
+            .default_value("false") // Default to false if the flag is not provided
     }
 }
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -367,15 +367,15 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         }
     };
 
-    if opts.config.dump_inputs {
+    if opts.config.dump_inputs() {
         let exit_code = commands::dump_inputs(
             inputs,
             opts.config.output.as_ref(),
             &opts.config.exclude_path,
             &opts.config.extensions(),
-            !opts.config.hidden,
+            !opts.config.hidden(),
             // be aware that "no ignore" means do *not* ignore files
-            !opts.config.no_ignore,
+            !opts.config.no_ignore(),
         )
         .await?;
 
@@ -397,16 +397,16 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
     let client = client::create(&opts.config, cookie_jar.as_deref())?;
 
     let mut collector = Collector::new(opts.config.root_dir.clone(), base.unwrap_or_default())?
-        .skip_missing_inputs(opts.config.skip_missing)
-        .skip_hidden(!opts.config.hidden)
+        .skip_missing_inputs(opts.config.skip_missing())
+        .skip_hidden(!opts.config.hidden())
         // be aware that "no ignore" means do *not* ignore files
-        .skip_ignored(!opts.config.no_ignore)
-        .include_verbatim(opts.config.include_verbatim)
+        .skip_ignored(!opts.config.no_ignore())
+        .include_verbatim(opts.config.include_verbatim())
         .headers(HeaderMap::from_header_pairs(&opts.config.headers())?)
         .excluded_paths(PathExcludes::new(opts.config.exclude_path.clone())?)
         // File a bug if you rely on this envvar! It's going to go away eventually.
         .use_html5ever(std::env::var("LYCHEE_USE_HTML5EVER").is_ok_and(|x| x == "1"))
-        .include_wikilinks(opts.config.include_wikilinks)
+        .include_wikilinks(opts.config.include_wikilinks())
         .preprocessor(opts.config.preprocess.clone())
         .host_pool(client.host_pool());
 
@@ -425,7 +425,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         is_stdin_input,
     };
 
-    let exit_code = if opts.config.dump {
+    let exit_code = if opts.config.dump() {
         commands::dump(params).await?
     } else {
         let (response_stats, cache, exit_code, host_pool) = commands::check(params).await?;
@@ -434,7 +434,10 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
 
         let stats = OutputStats {
             response_stats,
-            host_stats: opts.config.host_stats.then_some(host_pool.all_host_stats()),
+            host_stats: opts
+                .config
+                .host_stats()
+                .then_some(host_pool.all_host_stats()),
         };
         output_statistics(stats, &opts.config)?;
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -234,7 +234,7 @@ fn load_cookie_jar(cfg: &Config) -> Result<Option<CookieJar>> {
 /// and we silently discard errors on purpose
 #[must_use]
 fn load_cache(cfg: &Config) -> Option<Cache> {
-    if !cfg.cache {
+    if !cfg.cache() {
         return None;
     }
 
@@ -438,7 +438,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         };
         output_statistics(stats, &opts.config)?;
 
-        if opts.config.cache {
+        if opts.config.cache() {
             cache.store(LYCHEE_CACHE_FILE)?;
         }
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -314,7 +314,6 @@ mod cli {
     }
 
     #[test]
-    #[ignore = "SMTP is blocked on my network."]
     fn test_email() -> Result<()> {
         cargo_bin_cmd!()
             .write_stdin("test@example.com idiomatic-rust-doesnt-exist-man@wikipedia.org")
@@ -2706,7 +2705,6 @@ The config file should contain every possible key for documentation purposes."
     }
 
     #[tokio::test]
-    #[ignore = "Skipping test because it is flaky on my laptop"]
     async fn test_retry_rate_limit_headers() {
         const RETRY_DELAY: Duration = Duration::from_secs(1);
         const TOLERANCE: Duration = Duration::from_millis(500);

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -314,6 +314,7 @@ mod cli {
     }
 
     #[test]
+    #[ignore = "SMTP is blocked on my network."]
     fn test_email() -> Result<()> {
         cargo_bin_cmd!()
             .write_stdin("test@example.com idiomatic-rust-doesnt-exist-man@wikipedia.org")
@@ -2705,6 +2706,7 @@ The config file should contain every possible key for documentation purposes."
     }
 
     #[tokio::test]
+    #[ignore = "Skipping test because it is flaky on my laptop"]
     async fn test_retry_rate_limit_headers() {
         const RETRY_DELAY: Duration = Duration::from_secs(1);
         const TOLERANCE: Duration = Duration::from_millis(500);

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -3902,6 +3902,22 @@ https://lychee.cli.rs/guides/cli/#fragments-ignored
     }
 
     #[tokio::test]
+    async fn test_set_bool_to_false() {
+        let mock_server_timeout = mock_server!(StatusCode::OK, set_delay(Duration::from_secs(30)));
+
+        cargo_bin_cmd!()
+            .arg("--max-retries=0")
+            .arg("--timeout=1")
+            .arg("--accept-timeouts=false")
+            .arg("-")
+            .write_stdin(mock_server_timeout.uri())
+            .assert()
+            .failure()
+            .code(2)
+            .stdout(contains("[TIMEOUT]"));
+    }
+
+    #[tokio::test]
     async fn test_pyproject_toml() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let pyproject = dir.path().join("pyproject.toml");

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -3900,22 +3900,6 @@ https://lychee.cli.rs/guides/cli/#fragments-ignored
     }
 
     #[tokio::test]
-    async fn test_set_bool_to_false() {
-        let mock_server_timeout = mock_server!(StatusCode::OK, set_delay(Duration::from_secs(30)));
-
-        cargo_bin_cmd!()
-            .arg("--max-retries=0")
-            .arg("--timeout=1")
-            .arg("--accept-timeouts=false")
-            .arg("-")
-            .write_stdin(mock_server_timeout.uri())
-            .assert()
-            .failure()
-            .code(2)
-            .stdout(contains("[TIMEOUT]"));
-    }
-
-    #[tokio::test]
     async fn test_pyproject_toml() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let pyproject = dir.path().join("pyproject.toml");


### PR DESCRIPTION
Fixes #2051 

Makes all boolean CLI flags mergeable by converting them to `Option<bool>`. For example, this allows `lychee.toml` to specify `accept_timeout = true` and calling `lychee --accept-timeout=false` with the combined effect being that timeouts are not accepted.

This PR uses the following overall patterns:

1. Boolean CLI flags are converted to `Option<bool>`.
2. Clap is configured with:
    ```
    #[arg(
        long,
        default_missing_value = "true", // `--flag` is equivalent to `--flag=true`
        num_args = 0..=1, // allow `--flag` with no value
        require_equals = true, // ensures `--flag parameter` is interpreted as `--flag=true parameter`
    )]
    ```
3. Field is made private and accessed via a getter to ensure all defaults are in `config/mod.rs`.

Decisions to be challenged:

1. The `#[arg(...)]` macro invokation looks tedious and repetative. I opted against factoring this into a macro, since the solution felt beyond my ability.
2. Should all boolean CLI flags be converted to `Option<bool>`, even e.g. `--dump`? I opted for this, since I felt this minimizes astonishment for the user.
3. Why not `--no-flag`, like ripgrep? This feels poorly supported in Clap. Furthermore, many CLI seems to move towards `--flag=false`.