### PR TITLE
refactor: make website checker return Status always, rather than Result

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -321,7 +321,7 @@ mod tests {
     async fn test_invalid_url() {
         let client = ClientBuilder::builder().build().client().unwrap();
         let uri = Uri::try_from("http://\"").unwrap();
-        let (status, _redirects) = client.check_website(&uri, None).await.unwrap();
+        let (status, _redirects) = client.check_website(&uri, None).await;
         assert!(matches!(
             status,
             Status::Unsupported(ErrorKind::BuildRequestClient(_))

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -209,7 +209,7 @@ impl WebsiteChecker {
         &self,
         uri: &Uri,
         credentials: Option<BasicAuthCredentials>,
-    ) -> Result<(Status, Option<Redirects>), ErrorKind> {
+    ) -> (Status, Option<Redirects>) {
         let default_chain: RequestChain = Chain::new(vec![
             Box::<Quirks>::default(),
             Box::new(credentials),
@@ -217,12 +217,10 @@ impl WebsiteChecker {
         ]);
 
         let status = self.check_website_inner(uri, &default_chain).await;
-        let status = self
-            .handle_insecure_url(uri, &default_chain, status)
-            .await?;
+        let status = self.handle_insecure_url(uri, &default_chain, status).await;
 
         let redirects = self.redirect_history.resolve(&uri.url);
-        Ok((status, redirects))
+        (status, redirects)
     }
 
     /// Mark HTTP URLs as insecure, if the user required HTTPS
@@ -232,23 +230,23 @@ impl WebsiteChecker {
         uri: &Uri,
         default_chain: &Chain<Request, Status>,
         status: Status,
-    ) -> Result<Status, ErrorKind> {
+    ) -> Status {
         if self.require_https
             && uri.scheme() == "http"
             && let Status::Ok(_) = status
+            && let Ok(https_uri) = uri.to_https()
         {
-            let https_uri = uri.to_https()?;
             let is_https_available = self
                 .check_website_inner(&https_uri, default_chain)
                 .await
                 .is_success();
 
             if is_https_available {
-                return Ok(Status::Error(ErrorKind::InsecureURL(https_uri)));
+                return Status::Error(ErrorKind::InsecureURL(https_uri));
             }
         }
 
-        Ok(status)
+        status
     }
 
     /// Checks the given URI of a website.

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -548,7 +548,7 @@ impl Client {
             _ if uri.is_tel() => (Status::Excluded, None), // We don't check tel: URIs
             _ if uri.is_file() => (self.check_file(&uri).await, None),
             _ if uri.is_mail() => (self.check_mail(&uri).await, None),
-            _ => self.check_website(&uri, credentials).await?,
+            _ => self.check_website(&uri, credentials).await,
         };
 
         Ok(Response::new(
@@ -606,7 +606,7 @@ impl Client {
         &self,
         uri: &Uri,
         credentials: Option<BasicAuthCredentials>,
-    ) -> Result<(Status, Option<Redirects>)> {
+    ) -> (Status, Option<Redirects>) {
         self.website_checker.check_website(uri, credentials).await
     }
 


### PR DESCRIPTION
this means that the Err case of `Client::check` will only happen due to remap failures. this means the error cases we have to handle are much clearer.

this commit re-lands this refactor which was previously part of https://github.com/lycheeverse/lychee/pull/2124. there's a bit more context in that PR.