### PR TITLE
fix: prevent 0 value for max-concurrency and threads

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -31,7 +31,7 @@ where
     S: futures::Stream<Item = Result<Request, RequestError>>,
 {
     // Setup
-    let max_concurrency = params.cfg.max_concurrency();
+    let max_concurrency = params.cfg.max_concurrency().get();
     let (send_req, recv_req) = mpsc::channel(max_concurrency);
     let (send_resp, recv_resp) = mpsc::channel(max_concurrency);
     let (waiter, wait_guard) = WaitGroup::new();

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -33,6 +33,7 @@ use lychee_lib::{DEFAULT_USER_AGENT, Preprocessor};
 use secrecy::SecretString;
 use serde::{Deserialize, Deserializer};
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::{path::PathBuf, time::Duration};
 use strum::VariantNames;
@@ -280,7 +281,7 @@ pub(crate) struct Config {
     ///
     /// [default: 128]
     #[arg(long)]
-    max_concurrency: Option<usize>,
+    max_concurrency: Option<NonZeroUsize>,
 
     /// Default maximum concurrent requests per host (default: 10)
     ///
@@ -312,7 +313,7 @@ pub(crate) struct Config {
     /// Number of threads to utilize.
     /// Defaults to number of cores available to the system
     #[arg(short = 'T', long)]
-    pub(crate) threads: Option<usize>,
+    pub(crate) threads: Option<NonZeroUsize>,
 
     /// User agent
     ///
@@ -721,13 +722,13 @@ impl Config {
         self.format.clone().unwrap_or_default()
     }
 
-    pub(crate) const fn set_max_concurrency(&mut self, concurrency: usize) {
+    pub(crate) const fn set_max_concurrency(&mut self, concurrency: NonZeroUsize) {
         self.max_concurrency = Some(concurrency);
     }
 
     /// Maximum number of concurrent network requests
-    pub(crate) fn max_concurrency(&self) -> usize {
-        const DEFAULT_MAX_CONCURRENCY: usize = 128;
+    pub(crate) fn max_concurrency(&self) -> NonZeroUsize {
+        const DEFAULT_MAX_CONCURRENCY: NonZeroUsize = NonZeroUsize::new(128).unwrap();
         self.max_concurrency.unwrap_or(DEFAULT_MAX_CONCURRENCY)
     }
 

--- a/lychee-bin/src/formatters/log.rs
+++ b/lychee-bin/src/formatters/log.rs
@@ -60,7 +60,7 @@ pub(crate) fn init_logging(verbose: &Verbosity, mode: &OutputMode) {
         builder.format(move |buf, record| {
             let level = record.level();
             let level_text = format!("{level}");
-            let padding = (MAX_RESPONSE_OUTPUT_WIDTH.saturating_sub(max_level_text_width)).max(0);
+            let padding = MAX_RESPONSE_OUTPUT_WIDTH.saturating_sub(max_level_text_width);
             let level_padding = max_level_text_width.saturating_sub(level_text.len() + 2);
             let prefix = format!("{:>width$}[{level_text}]", "", width = level_padding);
             let color = formatters::color::color_for_level(level);

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -60,6 +60,7 @@
 
 use std::fs::{self, File};
 use std::io::{self, BufRead, BufReader, ErrorKind, IsTerminal, stdin};
+use std::num::NonZeroUsize;
 
 use anyhow::{Context, Error, Result};
 use clap::{Parser, crate_version};
@@ -156,10 +157,10 @@ fn handle_fd_limits(opts: &mut LycheeOptions) {
             reason = "max_concurrency is small in practice"
         )]
         let concurrency = soft_limit.saturating_sub(BASELINE_OVERHEAD) as usize;
+        let concurrency = NonZeroUsize::new(concurrency).unwrap_or(NonZeroUsize::MIN);
 
         let requested_concurrency = opts.config.max_concurrency();
         if requested_concurrency > concurrency {
-            let concurrency = concurrency.max(1);
             warn!(
                 "System file descriptor limit is {soft_limit} which is too low for the requested \
                 concurrency of {requested_concurrency}. Lowering `max_concurrency` to \
@@ -308,7 +309,7 @@ fn run_main() -> Result<i32> {
             // We define our own runtime instead of the `tokio::main` attribute
             // since we want to make the number of threads configurable
             tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(threads)
+                .worker_threads(threads.get())
                 .enable_all()
                 .build()?
         }

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -305,10 +305,8 @@ pub(crate) fn extract_markdown_fragments(input: &str) -> HashSet<String> {
 
                 in_heading = false;
             }
-            Event::Text(text) | Event::Code(text) => {
-                if in_heading {
-                    heading_text.push_str(&text);
-                }
+            Event::Text(text) | Event::Code(text) if in_heading => {
+                heading_text.push_str(&text);
             }
 
             // An HTML node

--- a/lychee-lib/src/extract/xml.rs
+++ b/lychee-lib/src/extract/xml.rs
@@ -31,29 +31,27 @@ pub(crate) fn extract_xml<S: SpanProvider>(input: &str, span_provider: &S) -> Ve
                 },
                 _ => {}
             },
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"link" {
-                    for attr in e.attributes().flatten() {
-                        if attr.key.as_ref() == b"href" {
-                            let text = std::str::from_utf8(attr.value.as_ref())
-                                .unwrap_or("")
-                                .to_string();
-                            let element = std::str::from_utf8(e.name().as_ref())
-                                .unwrap_or("")
-                                .to_string();
-                            let end_of_empty_tag: usize =
-                                reader.buffer_position().try_into().unwrap_or_default();
-                            // Span is a bit imprecise, as it points to the end of the element. However, quick_xml does not provide the position of attributes, so this is the best we can do.
-                            let span = span_provider.span(end_of_empty_tag);
+            Event::Empty(e) if e.name().as_ref() == b"link" => {
+                for attr in e.attributes().flatten() {
+                    if attr.key.as_ref() == b"href" {
+                        let text = std::str::from_utf8(attr.value.as_ref())
+                            .unwrap_or("")
+                            .to_string();
+                        let element = std::str::from_utf8(e.name().as_ref())
+                            .unwrap_or("")
+                            .to_string();
+                        let end_of_empty_tag: usize =
+                            reader.buffer_position().try_into().unwrap_or_default();
+                        // Span is a bit imprecise, as it points to the end of the element. However, quick_xml does not provide the position of attributes, so this is the best we can do.
+                        let span = span_provider.span(end_of_empty_tag);
 
-                            if !text.is_empty() && !element.is_empty() {
-                                uris.push(RawUri {
-                                    text,
-                                    element: Some(element),
-                                    attribute: Some("href".to_string()),
-                                    span,
-                                });
-                            }
+                        if !text.is_empty() && !element.is_empty() {
+                            uris.push(RawUri {
+                                text,
+                                element: Some(element),
+                                attribute: Some("href".to_string()),
+                                span,
+                            });
                         }
                     }
                 }

--- a/lychee-lib/src/utils/reqwest.rs
+++ b/lychee-lib/src/utils/reqwest.rs
@@ -189,7 +189,7 @@ fn analyze_io_error(io_error: &std::io::Error) -> String {
                         .to_string()
                 }
                 _ => {
-                    format!("I/O error ({kind_name}). Check network connectivity and server status",)
+                    format!("I/O error ({kind_name}). Check network connectivity and server status")
                 }
             }
         }


### PR DESCRIPTION
Using NonZeroUsize means we get nice error messages automatically from clap.

    error: invalid value '0' for '--max-concurrency <MAX_CONCURRENCY>': number would be zero for non-zero type

    For more information, try '--help'.

Unfortunately, the error is more cryptic when using a zero in the toml:

    [ERROR] Error while loading config: Cannot load configuration file: lychee.toml
    See: https://github.com/lycheeverse/lychee/blob/lychee-v0.23.0/lychee.example.toml

Fixes https://github.com/lycheeverse/lychee/issues/2141