### PR TITLE
Fix output path not validated before the run

### DIFF
--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -301,7 +301,9 @@ fn run_main() -> Result<i32> {
     // Exit if output path parent directory does not exist
     if let Some(output) = &opts.config.output {
         let parent = output.parent().filter(|p| !p.as_os_str().is_empty());
-        if let Some(parent) = parent && !parent.exists() {
+        if let Some(parent) = parent
+            && !parent.exists()
+        {
             error!(
                 "Output path `{}` is not writable: parent directory `{}` does not exist",
                 output.display(),

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -300,6 +300,7 @@ fn run_main() -> Result<i32> {
 
     // Exit if output path parent directory does not exist
     if let Some(output) = &opts.config.output {
+        // parent() returns Some("") for paths with no directory component
         let parent = output.parent().filter(|p| !p.as_os_str().is_empty());
         if let Some(parent) = parent
             && !parent.exists()

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -298,6 +298,19 @@ fn run_main() -> Result<i32> {
         }
     };
 
+    // Exit if output path parent directory does not exist
+    if let Some(output) = &opts.config.output {
+        let parent = output.parent().filter(|p| !p.as_os_str().is_empty());
+        if let Some(parent) = parent && !parent.exists() {
+            error!(
+                "Output path `{}` is not writable: parent directory `{}` does not exist",
+                output.display(),
+                parent.display()
+            );
+            exit(ExitCode::UnexpectedFailure as i32);
+        }
+    }
+
     if let Some(mode) = opts.config.generate {
         print!("{}", generate(&mode)?);
         exit(ExitCode::Success as i32);

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -4414,7 +4414,7 @@ fn test_output_invalid_path() {
     cmd.arg("--output")
         .arg("does/not/exist")
         .arg("https://example.com");
-    cmd.assert().stderr(predicates::str::contains(
+    cmd.assert().failure().stderr(predicates::str::contains(
         "Output path `does/not/exist` is not writable: parent directory `does/not` does not exist",
     ));
 }

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -4405,3 +4405,16 @@ fn test_file_limit_low_concurrency() {
         "System file descriptor limit is 64 which is too low for the requested concurrency of 128. Lowering `max_concurrency` to 44",
     ));
 }
+
+// Verify that lychee will fail before all checks run if the parent of the given output path does not exist
+// See https://github.com/lycheeverse/lychee/issues/2147
+#[test]
+fn test_output_invalid_path() {
+    let mut cmd = assert_cmd::Command::cargo_bin("lychee").unwrap();
+    cmd.arg("--output")
+        .arg("does/not/exist")
+        .arg("https://example.com");
+    cmd.assert().stderr(predicates::str::contains(
+        "Output path `does/not/exist` is not writable: parent directory `does/not` does not exist",
+    ));
+}


### PR DESCRIPTION
- Added check before execution, ensuring that the parent of the given output path exists
- Added test for the new logic

The already existing behavior is kept, the only difference being that the checks do not run if the parent directory of the output path does not exist.

`lychee --output tmp.txt https://example.com` succeeds even if tmp.txt does not exist (just like before).
`lychee --output does/not/exist/tmp.txt https://example.com` now fails before checks, since directory `does/not/exist/` does not exists.

Note: also affects --dump.

Closes #2147 