### PR TITLE
Always show full config parse errors with full details in output

### DIFF
--- a/fixtures/configs/invalid-type.toml
+++ b/fixtures/configs/invalid-type.toml
@@ -1,0 +1,1 @@
+threads = 'a'

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -290,7 +290,7 @@ fn run_main() -> Result<i32> {
         Ok(opts) => opts,
         Err(e) => {
             error!(
-                "Error while loading config: {}\n\
+                "Error while loading config: {:?}\n\
                 See: https://github.com/lycheeverse/lychee/blob/lychee-v{}/lychee.example.toml",
                 e,
                 crate_version!()

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1018,6 +1018,28 @@ mod cli {
             .stderr(contains("TOML parse error"));
     }
 
+    /// Make sure that TOML type errors include all error details (line/column
+    /// info and invalid type message), not just a generic "Failed to parse"
+    /// message.
+    ///
+    /// This is a regression test for
+    /// https://github.com/lycheeverse/lychee/issues/2146
+    #[tokio::test]
+    async fn test_invalid_config_type_error_shows_details() {
+        let config = fixtures_path!().join("configs").join("invalid-type.toml");
+        cargo_bin_cmd!()
+            .arg("--config")
+            .arg(config)
+            .arg("-")
+            .env_clear()
+            .assert()
+            .failure()
+            .stderr(contains("Cannot load configuration file"))
+            .stderr(contains("TOML parse error"))
+            .stderr(contains("invalid type"))
+            .stderr(contains("threads = 'a'"));
+    }
+
     #[tokio::test]
     async fn test_configs_precedence() {
         let path = fixtures_path!().join("configs");


### PR DESCRIPTION
The root cause is that the error was formatted with `{}` (Display), which for `anyhow` only shows the outermost message in the error chain. 

Since https://github.com/lycheeverse/lychee/commit/d5d22bc2cf4e485f4a8beeaa66c42a794b0607e9 restructured the error handling to use `e.context(msg)`, which wraps the TOML details *under* the context message, the Display format only shows the context message and loses the TOML parse error details (line number, column, offending value, etc.).

Changing `{}` to `{:?}` uses `anyhow`'s Debug format, which prints the full error chain:

Fixes #2146