### PR TITLE
 refactor: move basic auth credentials out of Request 

### DIFF
--- a/lychee-bin/src/client.rs
+++ b/lychee-bin/src/client.rs
@@ -2,6 +2,7 @@ use crate::config::{Config, HeaderMapExt};
 use crate::parse::parse_remaps;
 use anyhow::{Context, Result};
 use http::{HeaderMap, StatusCode};
+use lychee_lib::BasicAuthExtractor;
 use lychee_lib::{Client, ClientBuilder, ratelimit::RateLimitConfig};
 use regex::RegexSet;
 use reqwest_cookie_store::CookieStoreMutex;
@@ -27,6 +28,12 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
     };
 
     let headers = HeaderMap::from_header_pairs(&cfg.headers())?;
+
+    let basic_auth = if let Some(basic_auth) = &cfg.basic_auth {
+        BasicAuthExtractor::new(basic_auth)?
+    } else {
+        BasicAuthExtractor::empty()
+    };
 
     ClientBuilder::builder()
         .remaps(remaps)
@@ -60,6 +67,7 @@ pub(crate) fn create(cfg: &Config, cookie_jar: Option<&Arc<CookieStoreMutex>>) -
             cfg.host_concurrency,
             cfg.host_request_interval,
         ))
+        .basic_auth(basic_auth)
         .hosts(cfg.hosts.clone())
         .build()
         .client()

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -321,7 +321,7 @@ mod tests {
     async fn test_invalid_url() {
         let client = ClientBuilder::builder().build().client().unwrap();
         let uri = Uri::try_from("http://\"").unwrap();
-        let (status, _redirects) = client.check_website(&uri, None).await;
+        let (status, _redirects) = client.check_website(&uri).await;
         assert!(matches!(
             status,
             Status::Unsupported(ErrorKind::BuildRequestClient(_))

--- a/lychee-lib/src/basic_auth/mod.rs
+++ b/lychee-lib/src/basic_auth/mod.rs
@@ -12,7 +12,10 @@ pub enum BasicAuthExtractorError {
 /// Extracts basic auth credentials from a given URI.
 /// Credentials are extracted if the URI matches one of the provided
 /// [`BasicAuthSelector`] instances.
-#[derive(Debug, Clone)]
+///
+/// One [`BasicAuthExtractor`] holds multiple basic auth credentials, each
+/// associated with a different domain regex.
+#[derive(Debug, Clone, Default)]
 pub struct BasicAuthExtractor {
     credentials: Vec<BasicAuthCredentials>,
     regex_set: RegexSet,
@@ -56,6 +59,14 @@ impl BasicAuthExtractor {
             credentials,
             regex_set,
         })
+    }
+
+    /// Creates a new empty [`BasicAuthExtractor`] with no credentials.
+    pub fn empty() -> Self {
+        Self {
+            credentials: vec![],
+            regex_set: RegexSet::empty(),
+        }
     }
 
     /// Matches the provided URI against the [`RegexSet`] and returns

--- a/lychee-lib/src/basic_auth/mod.rs
+++ b/lychee-lib/src/basic_auth/mod.rs
@@ -62,6 +62,7 @@ impl BasicAuthExtractor {
     }
 
     /// Creates a new empty [`BasicAuthExtractor`] with no credentials.
+    #[must_use]
     pub fn empty() -> Self {
         Self {
             credentials: vec![],

--- a/lychee-lib/src/basic_auth/mod.rs
+++ b/lychee-lib/src/basic_auth/mod.rs
@@ -74,13 +74,10 @@ impl BasicAuthExtractor {
     /// that only the first match will be used to return the appropriate
     /// credentials.
     pub(crate) fn matches(&self, uri: &Uri) -> Option<BasicAuthCredentials> {
-        let matches: Vec<_> = self.regex_set.matches(uri.as_str()).into_iter().collect();
+        let matches = self.regex_set.matches(uri.as_str());
+        let match_index = matches.into_iter().next()?;
 
-        if matches.is_empty() {
-            return None;
-        }
-
-        Some(self.credentials[matches[0]].clone())
+        Some(self.credentials[match_index].clone())
     }
 }
 

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -1,7 +1,5 @@
 use crate::{
-    BasicAuthCredentials, ErrorKind, FileType, FragmentCheckerOptions, Status, Uri,
-    BasicAuthCredentials, BasicAuthExtractor, ErrorKind, FileType, Status, Uri,
-    basic_auth::BasicAuthExtractorError,
+    BasicAuthExtractor, ErrorKind, FileType, FragmentCheckerOptions, Status, Uri,
     chain::{Chain, ChainResult, ClientRequestChains, Handler, RequestChain},
     quirks::Quirks,
     ratelimit::HostPool,
@@ -213,10 +211,7 @@ impl WebsiteChecker {
     /// - The request failed.
     /// - The response status code is not accepted.
     /// - The URI cannot be converted to HTTPS.
-    pub(crate) async fn check_website(
-        &self,
-        uri: &Uri,
-    ) -> (Status, Option<Redirects>) {
+    pub(crate) async fn check_website(&self, uri: &Uri) -> (Status, Option<Redirects>) {
         let credentials = self.basic_auth.matches(uri);
 
         let default_chain: RequestChain = Chain::new(vec![
@@ -359,8 +354,7 @@ mod tests {
     use octocrab::Octocrab;
 
     use crate::{
-        FragmentCheckerOptions, Uri,
-        BasicAuthExtractor, Uri,
+        BasicAuthExtractor, FragmentCheckerOptions, Uri,
         chain::RequestChain,
         checker::website::WebsiteChecker,
         ratelimit::HostPool,

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -1,5 +1,7 @@
 use crate::{
     BasicAuthCredentials, ErrorKind, FileType, FragmentCheckerOptions, Status, Uri,
+    BasicAuthCredentials, BasicAuthExtractor, ErrorKind, FileType, Status, Uri,
+    basic_auth::BasicAuthExtractorError,
     chain::{Chain, ChainResult, ClientRequestChains, Handler, RequestChain},
     quirks::Quirks,
     ratelimit::HostPool,
@@ -61,6 +63,9 @@ pub(crate) struct WebsiteChecker {
     /// When present, HTTP requests will be routed through this pool for
     /// rate limiting. When None, requests go directly through `reqwest_client`.
     host_pool: Arc<HostPool>,
+
+    /// Basic auth extractor to obtain credentials from.
+    basic_auth: BasicAuthExtractor,
 }
 
 impl WebsiteChecker {
@@ -82,6 +87,7 @@ impl WebsiteChecker {
         plugin_request_chain: RequestChain,
         fragment_checker_options: FragmentCheckerOptions,
         host_pool: Arc<HostPool>,
+        basic_auth: BasicAuthExtractor,
     ) -> Self {
         Self {
             method,
@@ -95,6 +101,7 @@ impl WebsiteChecker {
             fragment_checker_options,
             fragment_checker: FragmentChecker::new(),
             host_pool,
+            basic_auth,
         }
     }
 
@@ -209,8 +216,9 @@ impl WebsiteChecker {
     pub(crate) async fn check_website(
         &self,
         uri: &Uri,
-        credentials: Option<BasicAuthCredentials>,
     ) -> (Status, Option<Redirects>) {
+        let credentials = self.basic_auth.matches(uri);
+
         let default_chain: RequestChain = Chain::new(vec![
             Box::<Quirks>::default(),
             Box::new(credentials),
@@ -352,6 +360,7 @@ mod tests {
 
     use crate::{
         FragmentCheckerOptions, Uri,
+        BasicAuthExtractor, Uri,
         chain::RequestChain,
         checker::website::WebsiteChecker,
         ratelimit::HostPool,
@@ -390,6 +399,7 @@ mod tests {
             RequestChain::default(),
             FragmentCheckerOptions::default(),
             Arc::new(host_pool),
+            BasicAuthExtractor::empty(),
         )
     }
 }

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -29,7 +29,7 @@ use secrecy::{ExposeSecret, SecretString};
 use typed_builder::TypedBuilder;
 
 use crate::{
-    BaseInfo, BasicAuthCredentials, ErrorKind, Request, Response, Result, Status, Uri,
+    BaseInfo, ErrorKind, Request, Response, Result, Status, Uri,
     chain::RequestChain,
     checker::{file::FileChecker, mail::MailChecker, website::WebsiteChecker},
     filter::Filter,

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -13,7 +13,7 @@
     clippy::default_trait_access,
     clippy::used_underscore_binding
 )]
-use crate::remap::Remap;
+use crate::{BasicAuthExtractor, remap::Remap};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use http::{
@@ -333,6 +333,9 @@ pub struct ClientBuilder {
 
     /// Per-host configuration overrides
     hosts: HostConfigs,
+
+    /// Basic auth credentials extractor.
+    basic_auth: BasicAuthExtractor,
 }
 
 impl Default for ClientBuilder {
@@ -408,6 +411,7 @@ impl ClientBuilder {
             self.plugin_request_chain,
             self.fragment_checker_options,
             Arc::new(host_pool),
+            self.basic_auth,
         );
 
         Ok(Client {
@@ -551,7 +555,6 @@ impl Client {
     {
         let Request {
             mut uri,
-            credentials,
             source,
             span,
             ..
@@ -565,7 +568,7 @@ impl Client {
             _ if uri.is_tel() => (Status::Excluded, None), // We don't check tel: URIs
             _ if uri.is_file() => (self.check_file(&uri).await, None),
             _ if uri.is_mail() => (self.check_mail(&uri).await, None),
-            _ => self.check_website(&uri, credentials).await,
+            _ => self.check_website(&uri).await,
         };
 
         Ok(Response::new(
@@ -619,12 +622,8 @@ impl Client {
     /// - The request failed.
     /// - The response status code is not accepted.
     /// - The URI cannot be converted to HTTPS.
-    pub async fn check_website(
-        &self,
-        uri: &Uri,
-        credentials: Option<BasicAuthCredentials>,
-    ) -> (Status, Option<Redirects>) {
-        self.website_checker.check_website(uri, credentials).await
+    pub async fn check_website(&self, uri: &Uri) -> (Status, Option<Redirects>) {
+        self.website_checker.check_website(uri).await
     }
 
     /// Checks a `mailto` URI.
@@ -658,6 +657,7 @@ where
 mod tests {
     use std::{
         fs::File,
+        str::FromStr,
         time::{Duration, Instant},
     };
 
@@ -675,7 +675,7 @@ mod tests {
 
     use super::ClientBuilder;
     use crate::{
-        ErrorKind, Redirect, Redirects, Request, Status, Uri,
+        BasicAuthExtractor, ErrorKind, Redirect, Redirects, Request, Status, Uri,
         chain::{ChainResult, Handler, RequestChain},
         remap::{Remap, Remaps},
     };
@@ -727,19 +727,25 @@ mod tests {
 
     #[tokio::test]
     async fn test_basic_auth() {
-        let mut r: Request = "https://authenticationtest.com/HTTPAuth/"
+        let r: Request = "https://authenticationtest.com/HTTPAuth/"
             .try_into()
             .unwrap();
 
         let res = get_mock_client_response!(r.clone()).await;
         assert_eq!(res.status().code(), Some(401.try_into().unwrap()));
 
-        r.credentials = Some(crate::BasicAuthCredentials {
-            username: "user".into(),
-            password: "pass".into(),
-        });
+        let basic_auth =
+            BasicAuthExtractor::new(&[crate::BasicAuthSelector::from_str(".* user:pass").unwrap()]);
 
-        let res = get_mock_client_response!(r).await;
+        let res = ClientBuilder::builder()
+            .basic_auth(basic_auth.unwrap())
+            .build()
+            .client()
+            .unwrap()
+            .check(r)
+            .await
+            .unwrap();
+
         assert!(res.status().is_success());
     }
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -551,7 +551,6 @@ impl Client {
     {
         let Request {
             mut uri,
-            credentials,
             source,
             span,
             ..
@@ -565,7 +564,7 @@ impl Client {
             _ if uri.is_tel() => (Status::Excluded, None), // We don't check tel: URIs
             _ if uri.is_file() => (self.check_file(&uri).await, None),
             _ if uri.is_mail() => (self.check_mail(&uri).await, None),
-            _ => self.check_website(&uri, credentials).await,
+            _ => self.check_website(&uri, None).await,
         };
 
         Ok(Response::new(
@@ -734,10 +733,10 @@ mod tests {
         let res = get_mock_client_response!(r.clone()).await;
         assert_eq!(res.status().code(), Some(401.try_into().unwrap()));
 
-        r.credentials = Some(crate::BasicAuthCredentials {
-            username: "user".into(),
-            password: "pass".into(),
-        });
+        // r.credentials = Some(crate::BasicAuthCredentials {
+        //     username: "user".into(),
+        //     password: "pass".into(),
+        // });
 
         let res = get_mock_client_response!(r).await;
         assert!(res.status().is_success());

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -551,6 +551,7 @@ impl Client {
     {
         let Request {
             mut uri,
+            credentials,
             source,
             span,
             ..
@@ -564,7 +565,7 @@ impl Client {
             _ if uri.is_tel() => (Status::Excluded, None), // We don't check tel: URIs
             _ if uri.is_file() => (self.check_file(&uri).await, None),
             _ if uri.is_mail() => (self.check_mail(&uri).await, None),
-            _ => self.check_website(&uri, None).await,
+            _ => self.check_website(&uri, credentials).await,
         };
 
         Ok(Response::new(
@@ -733,10 +734,10 @@ mod tests {
         let res = get_mock_client_response!(r.clone()).await;
         assert_eq!(res.status().code(), Some(401.try_into().unwrap()));
 
-        // r.credentials = Some(crate::BasicAuthCredentials {
-        //     username: "user".into(),
-        //     password: "pass".into(),
-        // });
+        r.credentials = Some(crate::BasicAuthCredentials {
+            username: "user".into(),
+            password: "pass".into(),
+        });
 
         let res = get_mock_client_response!(r).await;
         assert!(res.status().is_success());

--- a/lychee-lib/src/collector.rs
+++ b/lychee-lib/src/collector.rs
@@ -281,17 +281,11 @@ impl Collector {
             .par_then_unordered(None, move |content| {
                 let global_base = global_base.clone();
                 let root_dir = self.root_dir.clone();
-                let basic_auth_extractor = self.basic_auth_extractor.clone();
                 async move {
                     let content = content?;
                     let uris: Vec<RawUri> = extractor.extract(&content);
-                    let requests = request::create(
-                        uris,
-                        &content.source,
-                        root_dir.as_deref(),
-                        &global_base,
-                        basic_auth_extractor.as_ref(),
-                    );
+                    let requests =
+                        request::create(uris, &content.source, root_dir.as_deref(), &global_base);
                     Result::Ok(stream::iter(requests))
                 }
             })

--- a/lychee-lib/src/types/request.rs
+++ b/lychee-lib/src/types/request.rs
@@ -25,9 +25,6 @@ pub struct Request {
 
     /// Where the URI is located
     pub span: Option<RawUriSpan>,
-
-    /// Basic auth credentials
-    pub credentials: Option<BasicAuthCredentials>,
 }
 
 impl Request {
@@ -42,7 +39,6 @@ impl Request {
             element: None,
             attribute: None,
             span: None,
-            credentials: None,
         }
     }
 
@@ -64,13 +60,6 @@ impl Request {
     #[must_use]
     pub const fn with_span(mut self, span: RawUriSpan) -> Self {
         self.span = Some(span);
-        self
-    }
-
-    /// Set [`Self::credentials`]
-    #[must_use]
-    pub fn with_credentials(mut self, credentials: BasicAuthCredentials) -> Self {
-        self.credentials = Some(credentials);
         self
     }
 }

--- a/lychee-lib/src/types/request.rs
+++ b/lychee-lib/src/types/request.rs
@@ -25,6 +25,9 @@ pub struct Request {
 
     /// Where the URI is located
     pub span: Option<RawUriSpan>,
+
+    /// Basic auth credentials
+    pub credentials: Option<BasicAuthCredentials>,
 }
 
 impl Request {
@@ -39,6 +42,7 @@ impl Request {
             element: None,
             attribute: None,
             span: None,
+            credentials: None,
         }
     }
 
@@ -60,6 +64,13 @@ impl Request {
     #[must_use]
     pub const fn with_span(mut self, span: RawUriSpan) -> Self {
         self.span = Some(span);
+        self
+    }
+
+    /// Set [`Self::credentials`]
+    #[must_use]
+    pub fn with_credentials(mut self, credentials: BasicAuthCredentials) -> Self {
+        self.credentials = Some(credentials);
         self
     }
 }

--- a/lychee-lib/src/types/request.rs
+++ b/lychee-lib/src/types/request.rs
@@ -1,6 +1,6 @@
 use std::{borrow::Cow, convert::TryFrom, fmt::Display};
 
-use crate::{BasicAuthCredentials, ErrorKind, Uri, types::uri::raw::RawUriSpan};
+use crate::{ErrorKind, Uri, types::uri::raw::RawUriSpan};
 
 use super::ResolvedInputSource;
 

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -29,7 +29,6 @@ fn create_request(
     let element = raw_uri.element.clone();
     let attribute = raw_uri.attribute.clone();
     let span = Some(raw_uri.span);
-    let credentials = extract_credentials(extractor, &uri);
 
     Ok(Request {
         uri,
@@ -37,7 +36,6 @@ fn create_request(
         element,
         attribute,
         span,
-        credentials,
     })
 }
 

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -37,7 +37,6 @@ fn create_request(
         element,
         attribute,
         span,
-        credentials,
     })
 }
 

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -37,6 +37,7 @@ fn create_request(
         element,
         attribute,
         span,
+        credentials,
     })
 }
 

--- a/lychee-lib/src/utils/request.rs
+++ b/lychee-lib/src/utils/request.rs
@@ -22,7 +22,6 @@ fn create_request(
     source: &ResolvedInputSource,
     root_dir: Option<&Path>,
     base: &BaseInfo,
-    extractor: Option<&BasicAuthExtractor>,
 ) -> LycheeResult<Request> {
     let uri = try_parse_into_uri(raw_uri, root_dir, base)?;
     let source = source.clone();
@@ -83,7 +82,6 @@ pub(crate) fn create(
     source: &ResolvedInputSource,
     root_dir: Option<&Path>,
     fallback_base: &BaseInfo,
-    extractor: Option<&BasicAuthExtractor>,
 ) -> Vec<Result<Request, RequestError>> {
     let source_base = match source.to_base_info() {
         Ok(base) => base,
@@ -105,7 +103,7 @@ pub(crate) fn create(
 
     uris.into_iter()
         .map(|raw_uri| {
-            create_request(&raw_uri, source, root_dir, base, extractor).map_err(|e| {
+            create_request(&raw_uri, source, root_dir, base).map_err(|e| {
                 RequestError::CreateRequestItem(raw_uri.clone().into(), source.clone(), e.into())
             })
         })
@@ -139,9 +137,8 @@ mod tests {
         source: &ResolvedInputSource,
         root_dir: Option<&Path>,
         base: &BaseInfo,
-        extractor: Option<&BasicAuthExtractor>,
     ) -> Vec<Request> {
-        create(uris, source, root_dir, base, extractor)
+        create(uris, source, root_dir, base)
             .into_iter()
             .filter_map(Result::ok)
             .collect()
@@ -162,7 +159,7 @@ mod tests {
         let source = ResolvedInputSource::String(Cow::Borrowed(""));
 
         let uris = vec![raw_uri("relative.html")];
-        let requests = create_ok_only(uris, &source, None, &base, None);
+        let requests = create_ok_only(uris, &source, None, &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -178,7 +175,7 @@ mod tests {
         let source = ResolvedInputSource::String(Cow::Borrowed(""));
 
         let uris = vec![raw_uri("https://another.com/page")];
-        let requests = create_ok_only(uris, &source, None, &base, None);
+        let requests = create_ok_only(uris, &source, None, &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -194,7 +191,7 @@ mod tests {
         let source = ResolvedInputSource::String(Cow::Borrowed(""));
 
         let uris = vec![raw_uri("/root-relative")];
-        let requests = create_ok_only(uris, &source, None, &base, None);
+        let requests = create_ok_only(uris, &source, None, &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -210,7 +207,7 @@ mod tests {
         let source = ResolvedInputSource::String(Cow::Borrowed(""));
 
         let uris = vec![raw_uri("../parent")];
-        let requests = create_ok_only(uris, &source, None, &base, None);
+        let requests = create_ok_only(uris, &source, None, &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -226,7 +223,7 @@ mod tests {
         let source = ResolvedInputSource::String(Cow::Borrowed(""));
 
         let uris = vec![raw_uri("#fragment")];
-        let requests = create_ok_only(uris, &source, None, &base, None);
+        let requests = create_ok_only(uris, &source, None, &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -242,7 +239,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("relative.html")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none(), None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none());
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -258,7 +255,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("https://another.com/page")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none(), None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none());
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -274,7 +271,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("/root-relative")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none(), None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none());
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -290,7 +287,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("../parent")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none(), None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none());
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -306,7 +303,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("#fragment")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none(), None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &BaseInfo::none());
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -323,7 +320,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("relative.html")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &base, None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -340,7 +337,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("https://another.com/page")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &base, None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -357,7 +354,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("/root-relative")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &base, None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -374,7 +371,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("../parent")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &base, None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -391,7 +388,7 @@ mod tests {
         let source = ResolvedInputSource::FsPath(PathBuf::from("/some/page.html"));
 
         let uris = vec![raw_uri("#fragment")];
-        let requests = create_ok_only(uris, &source, Some(&root_dir), &base, None);
+        let requests = create_ok_only(uris, &source, Some(&root_dir), &base);
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -406,7 +403,7 @@ mod tests {
         let source = ResolvedInputSource::String(Cow::Borrowed(""));
 
         let uris = vec![raw_uri("https://example.com/page")];
-        let requests = create_ok_only(uris, &source, None, &BaseInfo::none(), None);
+        let requests = create_ok_only(uris, &source, None, &BaseInfo::none());
 
         assert_eq!(requests.len(), 1);
         assert!(
@@ -421,8 +418,7 @@ mod tests {
         let base = BaseInfo::from_path(&PathBuf::from("/tmp/lychee")).unwrap();
         let input_source = ResolvedInputSource::FsPath(PathBuf::from("page.html"));
 
-        let actual =
-            create_request(&raw_uri("file.html"), &input_source, None, &base, None).unwrap();
+        let actual = create_request(&raw_uri("file.html"), &input_source, None, &base).unwrap();
 
         assert_eq!(
             actual,
@@ -445,7 +441,6 @@ mod tests {
                 &ResolvedInputSource::Stdin,
                 None,
                 &BaseInfo::none(),
-                None,
             )
             .is_err()
         );
@@ -457,7 +452,6 @@ mod tests {
                 &ResolvedInputSource::FsPath(PathBuf::from("page.html")),
                 None,
                 &BaseInfo::none(),
-                None,
             )
             .is_err()
         );
@@ -474,7 +468,6 @@ mod tests {
             &input_source,
             None,
             &base,
-            None,
         )
         .unwrap();
 


### PR DESCRIPTION
the basic auth extractor is now held by WebsiteChecker which makes sense because it's only applicable to website checks.

previously, the basic auth credentials were attached to the Request during the collecting phase, which is unnecessarily early i think. this change also avoids the need to repeatedly pass the "basic auth extractor" into helper functions.

i should add that i find the basic auth extractor and basic auth selector names to be very confusing. to me, "basic auth extractor" sounds like it parses basic auth strings from URLs when it's actually just a known database of basic auth credentials. "basic auth selector" sounds like it should do what basic auth extract actually does - select from a list of known basic auths. i haven't changed it in this PR but just something to think about.

One goal of this refactor is to make it more palatable to store Request inside Response (for https://github.com/lycheeverse/lychee/issues/2097), since it no longer has sensitive information.