### PR TITLE
fix: update binstall metadata after 0.24.0 restructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,13 @@ jobs:
       - name: Verify the MSRV
         run: make verify
 
+  binstall-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cargo-bins/cargo-binstall@main
+      - run: cargo binstall --manifest-path . --strategies crate-meta-data lychee --no-confirm
+
   publish-check:
     runs-on: ubuntu-latest
     steps:

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -93,5 +93,3 @@ required-features = ["check_example_domains"]
 # Metadata for cargo-binstall to get the right artifacts
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }"
-bin-dir = "{ bin }{ binary-ext }"
-pkg-fmt = "tgz"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -93,3 +93,5 @@ required-features = ["check_example_domains"]
 # Metadata for cargo-binstall to get the right artifacts
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"


### PR DESCRIPTION
just remove bin-dir and pkg-fmt because they can be auto-detected and this is more robust against future changes and different operating systems: https://github.com/cargo-bins/cargo-binstall/blob/main/SUPPORT.md#defaults

this is the error without these changes:
```console
$ cargo binstall --no-cleanup lychee@0.24.1  --strategies crate-meta-data
 INFO resolve: Resolving package: 'lychee@=0.24.1'
ERROR resolve: When resolving lychee bin lychee is not found. This binary is not optional so it must be included in the archive, please contact with upstream to fix this issue.
 WARN resolve: Error while downloading and extracting from fetcher github.com: failed to find or install binaries: bin file /home/rina/.cargo/cargo-binstall4XM5HP/bin-lychee-x86_64-unknown-linux-gnu-GhCrateMeta/lychee not found
ERROR resolve: When resolving lychee bin lychee is not found. This binary is not optional so it must be included in the archive, please contact with upstream to fix this issue.
 WARN resolve: Error while downloading and extracting from fetcher github.com: failed to find or install binaries: bin file /home/rina/.cargo/cargo-binstall4XM5HP/bin-lychee-x86_64-unknown-linux-musl-GhCrateMeta/lychee not found
ERROR Fatal error:
  \x1b[31m×\x1b[0m For crate lychee: Fallback to cargo-install is disabled
\x1b[31m  ╰─▶ \x1b[0mFallback to cargo-install is disabled
```

related to https://github.com/lycheeverse/lychee/issues/2160. the failure of binstall breakas pre-commit (and probably other things)