### PR TITLE
chore: release v0.24.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2290,7 +2290,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2341,7 +2341,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4221,7 +4221,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.24.1"
+version = "0.24.2"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
 
 [profile.release]
 debug = true

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.1...lychee-v0.24.2) - 2026-04-30
+
+### Added
+
+- user hints ([#2021](https://github.com/lycheeverse/lychee/pull/2021))
+
+### Fixed
+
+- typo in README.md ([#2173](https://github.com/lycheeverse/lychee/pull/2173))
+- update binstall metadata after 0.24.0 restructure ([#2165](https://github.com/lycheeverse/lychee/pull/2165))
+
+### Other
+
+- *(deps)* bump the dependencies group with 8 updates
+
 ## [0.24.1](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.0...lychee-v0.24.1) - 2026-04-24
 
 ### Other

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.24.1", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.24.2", default-features = false }
 
 anyhow = "1.0.102"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.1...lychee-lib-v0.24.2) - 2026-04-30
+
+### Added
+
+- user hints ([#2021](https://github.com/lycheeverse/lychee/pull/2021))
+
+### Fixed
+
+- typo in README.md ([#2173](https://github.com/lycheeverse/lychee/pull/2173))
+
+### Other
+
+- *(deps)* bump the dependencies group with 8 updates
+
 ## [0.24.1](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.0...lychee-lib-v0.24.1) - 2026-04-24
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.24.1 -> 0.24.2 (✓ API compatible changes)
* `lychee`: 0.24.1 -> 0.24.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.1...lychee-lib-v0.24.2) - 2026-04-30

### Added

- user hints ([#2021](https://github.com/lycheeverse/lychee/pull/2021))

### Fixed

- typo in README.md ([#2173](https://github.com/lycheeverse/lychee/pull/2173))

### Other

- *(deps)* bump the dependencies group with 8 updates
</blockquote>

## `lychee`

<blockquote>

## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.1...lychee-v0.24.2) - 2026-04-30

### Added

- user hints ([#2021](https://github.com/lycheeverse/lychee/pull/2021))

### Fixed

- typo in README.md ([#2173](https://github.com/lycheeverse/lychee/pull/2173))
- update binstall metadata after 0.24.0 restructure ([#2165](https://github.com/lycheeverse/lychee/pull/2165))

### Other

- *(deps)* bump the dependencies group with 8 updates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).