### PR TITLE
Replace Wayback Availability API with direct snapshot URLs

### DIFF
--- a/examples/archive/archive.rs
+++ b/examples/archive/archive.rs
@@ -1,14 +1,12 @@
 use lychee_lib::archive::Archive;
-use std::{error::Error, time::Duration};
+use std::error::Error;
 use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let archive = Archive::WaybackMachine;
     let url = Url::parse("https://example.com")?;
-    let result = archive
-        .get_archive_snapshot(&url, Duration::from_secs(10))
-        .await?;
+    let result = archive.get_archive_snapshot(&url).await?;
 
     if let Some(replacement) = result {
         println!("Good news! {url} can be replaced with {replacement}");

--- a/examples/archive/archive.rs
+++ b/examples/archive/archive.rs
@@ -1,12 +1,15 @@
 use lychee_lib::archive::Archive;
 use std::error::Error;
+use std::time::Duration;
 use url::Url;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let archive = Archive::WaybackMachine;
     let url = Url::parse("https://example.com")?;
-    let result = archive.get_archive_snapshot(&url).await?;
+    let result = archive
+        .get_archive_snapshot(&url, Duration::from_secs(20))
+        .await?;
 
     if let Some(replacement) = result {
         println!("Good news! {url} can be replaced with {replacement}");

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::time::Duration;
 
 use futures::StreamExt;
 use http::StatusCode;
@@ -100,14 +99,7 @@ where
             level,
             &params.cfg.mode(),
         );
-        suggest_archived_links(
-            params.cfg.archive(),
-            &mut stats,
-            progress,
-            max_concurrency,
-            params.cfg.timeout(),
-        )
-        .await;
+        suggest_archived_links(params.cfg.archive(), &mut stats, progress, max_concurrency).await;
     }
 
     let is_success = if accept_timeouts {
@@ -129,7 +121,6 @@ async fn suggest_archived_links(
     stats: &mut ResponseStats,
     progress: Progress,
     max_concurrency: usize,
-    timeout: Duration,
 ) {
     let failed_urls = &get_failed_urls(stats);
     progress.set_length(failed_urls.len() as u64);
@@ -137,7 +128,7 @@ async fn suggest_archived_links(
     let suggestions = Mutex::new(&mut stats.suggestion_map);
 
     futures::stream::iter(failed_urls)
-        .map(|(input, url)| (input, url, archive.get_archive_snapshot(url, timeout)))
+        .map(|(input, url)| (input, url, archive.get_archive_snapshot(url)))
         .for_each_concurrent(max_concurrency, |(input, url, future)| async {
             if let Ok(Some(suggestion)) = future.await {
                 suggestions

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::time::Duration;
 
 use futures::StreamExt;
 use http::StatusCode;
@@ -99,7 +100,14 @@ where
             level,
             &params.cfg.mode(),
         );
-        suggest_archived_links(params.cfg.archive(), &mut stats, progress, max_concurrency).await;
+        suggest_archived_links(
+            params.cfg.archive(),
+            &mut stats,
+            progress,
+            max_concurrency,
+            params.cfg.timeout(),
+        )
+        .await;
     }
 
     let is_success = if accept_timeouts {
@@ -121,6 +129,7 @@ async fn suggest_archived_links(
     stats: &mut ResponseStats,
     progress: Progress,
     max_concurrency: usize,
+    timeout: Duration,
 ) {
     let failed_urls = &get_failed_urls(stats);
     progress.set_length(failed_urls.len() as u64);
@@ -128,18 +137,28 @@ async fn suggest_archived_links(
     let suggestions = Mutex::new(&mut stats.suggestion_map);
 
     futures::stream::iter(failed_urls)
-        .map(|(input, url)| (input, url, archive.get_archive_snapshot(url)))
+        .map(|(input, url)| (input, url, archive.get_archive_snapshot(url, timeout)))
         .for_each_concurrent(max_concurrency, |(input, url, future)| async {
-            if let Ok(Some(suggestion)) = future.await {
-                suggestions
-                    .lock()
-                    .unwrap()
-                    .entry(input.clone())
-                    .or_default()
-                    .insert(Suggestion {
-                        suggestion,
-                        original: url.clone(),
-                    });
+            match future.await {
+                Ok(Some(suggestion)) => {
+                    suggestions
+                        .lock()
+                        .unwrap()
+                        .entry(input.clone())
+                        .or_default()
+                        .insert(Suggestion {
+                            suggestion,
+                            original: url.clone(),
+                        });
+                }
+                // No snapshot exists for this URL; nothing to suggest.
+                Ok(None) => {}
+                // The archive lookup itself failed (rate limiting, 5xx,
+                // timeout, ...). Surface it so users understand why a
+                // suggestion is missing (rather than silently dropping it).
+                Err(e) => {
+                    log::warn!("Failed to get archive snapshot for {}: {e}", url.as_str());
+                }
             }
 
             progress.update(None);

--- a/lychee-lib/src/archive/mod.rs
+++ b/lychee-lib/src/archive/mod.rs
@@ -1,6 +1,5 @@
 use reqwest::{Error, Url};
 use serde::Deserialize;
-use std::time::Duration;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 mod wayback;
@@ -24,17 +23,12 @@ impl Archive {
     ///
     /// # Errors
     ///
-    /// Returns an error if the `reqwest` client cannot be built, the request itself fails
-    /// or the API response cannot be parsed.
-    pub async fn get_archive_snapshot(
-        &self,
-        url: &Url,
-        timeout: Duration,
-    ) -> Result<Option<Url>, Error> {
+    /// Returns an error if the underlying HTTP request fails.
+    pub async fn get_archive_snapshot(&self, url: &Url) -> Result<Option<Url>, Error> {
         let function = match self {
             Archive::WaybackMachine => wayback::get_archive_snapshot,
         };
 
-        function(url, timeout).await
+        function(url).await
     }
 }

--- a/lychee-lib/src/archive/mod.rs
+++ b/lychee-lib/src/archive/mod.rs
@@ -23,8 +23,8 @@ impl Archive {
     /// Query the `Archive` to try and find the latest snapshot of the specified `url`.
     /// Returns `None` if the specified `url` hasn't been archived in the past.
     ///
-    /// `timeout` bounds the lookup, so it can be kept in step with the timeout
-    /// used for ordinary link checks.
+    /// The timeout guarantees that the function doesn't wait indefinitely for a
+    /// response from the archive.
     ///
     /// # Errors
     ///

--- a/lychee-lib/src/archive/mod.rs
+++ b/lychee-lib/src/archive/mod.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use reqwest::{Error, Url};
 use serde::Deserialize;
 use strum::{Display, EnumIter, EnumString, VariantNames};
@@ -21,14 +23,21 @@ impl Archive {
     /// Query the `Archive` to try and find the latest snapshot of the specified `url`.
     /// Returns `None` if the specified `url` hasn't been archived in the past.
     ///
+    /// `timeout` bounds the lookup, so it can be kept in step with the timeout
+    /// used for ordinary link checks.
+    ///
     /// # Errors
     ///
     /// Returns an error if the underlying HTTP request fails.
-    pub async fn get_archive_snapshot(&self, url: &Url) -> Result<Option<Url>, Error> {
+    pub async fn get_archive_snapshot(
+        &self,
+        url: &Url,
+        timeout: Duration,
+    ) -> Result<Option<Url>, Error> {
         let function = match self {
             Archive::WaybackMachine => wayback::get_archive_snapshot,
         };
 
-        function(url).await
+        function(url, timeout).await
     }
 }

--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -1,181 +1,151 @@
+//! Wayback Machine integration for suggesting archived versions of dead pages.
+//!
+//! Builds URLs of the form:
+//!
+//! ```text
+//! https://web.archive.org/web/<url>
+//! ```
+//!
+//! Omitting the timestamp tells Wayback "give me the latest available
+//! snapshot". The server's response tells us whether a snapshot exists:
+//!
+//! - **`302 Found`** with a `Location:` header pointing at the actual
+//!   timestamped snapshot (e.g. `/web/20020120142510/http://example.com/`).
+//!   We read that header directly, without following the redirect, so users
+//!   see the capture date in the suggested link without paying to download
+//!   the archived page.
+//! - **`404 Not Found`** when no snapshot exists for that URL. We return
+//!   `None` so lychee won't suggest a dead-end "page not archived" link.
+//!
+//! This is far more reliable than the Availability JSON API
+//! (`https://archive.org/wayback/available`), which is heavily rate-limited,
+//! flaky, and frequently returns empty `archived_snapshots` for pages that are
+//! clearly archived.
+//!
+//! See <https://en.wikipedia.org/wiki/Help:Using_the_Wayback_Machine>.
+
 use std::sync::LazyLock;
 use std::time::Duration;
 
-use serde::de::Error as SerdeError;
-use serde::{Deserialize, Deserializer};
-
 use http::StatusCode;
+use reqwest::header::LOCATION;
+use reqwest::redirect::Policy;
 use reqwest::{Client, Error, Url};
 
-static WAYBACK_URL: LazyLock<Url> =
-    LazyLock::new(|| Url::parse("https://archive.org/wayback/available").unwrap());
+/// Per-request timeout for Wayback lookups.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 
-pub(crate) async fn get_archive_snapshot(
-    url: &Url,
-    timeout: Duration,
-) -> Result<Option<Url>, Error> {
-    get_archive_snapshot_internal(url, timeout, WAYBACK_URL.clone()).await
-}
+/// Shared HTTP client for all Wayback suggestion lookups.
+///
+/// The suggestion path may issue dozens of lookups in quick succession
+/// (one per failed URL), all aimed at the same host. Sharing a client
+/// lets them reuse the connection pool, TLS session cache, and DNS
+/// resolver instead of paying those costs per request.
+///
+/// Redirects are intentionally *not* followed: a Wayback hit answers with a
+/// `302` whose `Location` already holds the snapshot URL, so following it
+/// would just download the archived page for no reason.
+static CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .redirect(Policy::none())
+        .build()
+        .expect("Wayback HTTP client should always build with default config")
+});
 
-async fn get_archive_snapshot_internal(
-    url: &Url,
-    timeout: Duration,
-    mut api: Url,
-) -> Result<Option<Url>, Error> {
-    let url = url.to_string();
+/// Construct a Wayback Machine URL pointing at the latest available snapshot
+/// of `url`, or `None` if Wayback has no snapshot of the page.
+///
+/// Performs a single GET request against `https://web.archive.org/web/<url>`
+/// and inspects the response:
+///
+/// - a redirect (`302`) carries the timestamped snapshot in its `Location`
+///   header, which we return without following, and
+/// - a `404` means there is no snapshot, so we return `None`.
+pub(crate) async fn get_archive_snapshot(url: &Url) -> Result<Option<Url>, Error> {
+    let wayback = format!("https://web.archive.org/web/{url}");
+    // `Url::parse` cannot fail here for any well-formed input `url`, but
+    // if it ever did we'd rather report "no suggestion" than panic.
+    let Ok(snapshot_url) = Url::parse(&wayback) else {
+        log::debug!("failed to construct Wayback URL for {url}");
+        return Ok(None);
+    };
 
-    // The Wayback API doesn't return any snapshots for URLs with trailing slashes
-    let stripped = url.strip_suffix("/").unwrap_or(&url);
-    api.set_query(Some(&format!("url={stripped}")));
+    let response = CLIENT.get(snapshot_url).send().await?;
+    let status = response.status();
 
-    let response = Client::builder()
-        .timeout(timeout)
-        .build()?
-        .get(api)
-        .send()
-        .await?
-        .error_for_status()?
-        .json::<InternetArchiveResponse>()
-        .await?;
+    if status == StatusCode::NOT_FOUND {
+        return Ok(None);
+    }
 
-    Ok(response
-        .archived_snapshots
-        .closest
-        .map(|closest| closest.url))
-}
+    if status.is_redirection() {
+        // The `Location` header holds the resolved timestamped snapshot URL
+        // (e.g. `/web/20020120142510/http://example.com/`). It may be
+        // relative, so resolve it against the request URL.
+        let snapshot = response
+            .headers()
+            .get(LOCATION)
+            .and_then(|location| location.to_str().ok())
+            .and_then(|location| response.url().join(location).ok());
+        return Ok(snapshot);
+    }
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
-pub(crate) struct InternetArchiveResponse {
-    pub(crate) url: Url,
-    pub(crate) archived_snapshots: ArchivedSnapshots,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq)]
-pub(crate) struct ArchivedSnapshots {
-    pub(crate) closest: Option<Closest>,
-}
-
-#[derive(Debug, Deserialize, Eq, PartialEq)]
-pub(crate) struct Closest {
-    #[serde(deserialize_with = "from_string")]
-    pub(crate) status: StatusCode,
-    pub(crate) available: bool,
-    pub(crate) url: Url,
-    pub(crate) timestamp: String,
-}
-
-fn from_string<'d, D>(deserializer: D) -> Result<StatusCode, D::Error>
-where
-    D: Deserializer<'d>,
-{
-    let value: &str = Deserialize::deserialize(deserializer)?;
-    let result = value
-        .parse::<u16>()
-        .map_err(|e| D::Error::custom(e.to_string()))?;
-    StatusCode::from_u16(result).map_err(|e| D::Error::custom(e.to_string()))
+    // Any other non-success (rate limiting, 5xx, ...) bubbles up so the
+    // caller can decide; the suggestion path currently swallows errors.
+    // Anything else (an unexpected `2xx`) means no usable snapshot.
+    response.error_for_status()?;
+    Ok(None)
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::archive::wayback::{get_archive_snapshot, get_archive_snapshot_internal};
     use http::StatusCode;
-    use reqwest::{Client, Error, Url};
-    use std::{error::Error as StdError, time::Duration};
-    use wiremock::matchers::query_param;
+    use std::error::Error;
+    use url::Url;
 
-    const TIMEOUT: Duration = Duration::from_secs(20);
-
-    #[tokio::test]
-    /// Test retrieval by mocking the Wayback API.
-    /// We mock their API because unfortunately it happens quite often that the
-    /// `archived_snapshots` field is empty because the API is unreliable.
-    /// This way we avoid flaky tests.
-    async fn wayback_suggestion_mocked() -> Result<(), Box<dyn StdError>> {
-        let mock_server = wiremock::MockServer::start().await;
-        let api_url = mock_server.uri();
-        let api_response = wiremock::ResponseTemplate::new(StatusCode::OK).set_body_raw(
-            r#"
-                {
-                    "url": "https://google.com/jobs.html",
-                    "archived_snapshots": {
-                        "closest": {
-                            "available": true,
-                            "url": "http://web.archive.org/web/20130919044612/http://example.com/",
-                            "timestamp": "20130919044612",
-                            "status": "200"
-                        }
-                    }
-                }
-                "#,
-            "application/json",
-        );
-
-        let url_to_restore = "https://example.com".parse::<Url>()?;
-        wiremock::Mock::given(wiremock::matchers::method("GET"))
-            .and(query_param(
-                "url",
-                url_to_restore.as_str().strip_suffix("/").unwrap(),
-            ))
-            .respond_with(api_response)
-            .mount(&mock_server)
-            .await;
-
-        let result =
-            get_archive_snapshot_internal(&url_to_restore, TIMEOUT, api_url.parse()?).await;
-
-        assert_eq!(
-            result?,
-            Some("http://web.archive.org/web/20130919044612/http://example.com/".parse()?)
-        );
-
-        Ok(())
-    }
+    use super::get_archive_snapshot;
 
     #[tokio::test]
-    /// Their API documentation mentions when the last changes occurred.
-    /// Because we mock their API in previous tests we try to detect breaking API changes with this test.
-    async fn wayback_api_no_breaking_changes() -> Result<(), Error> {
-        let api_docs_url = "https://archive.org/help/wayback_api.php";
-        let html = Client::builder()
-            .timeout(TIMEOUT)
-            .build()?
-            .get(api_docs_url)
-            .send()
-            .await?
-            .text()
-            .await?;
-
-        assert!(html.contains("Updated on September, 24, 2013"));
-        Ok(())
-    }
-
-    #[ignore = "
-        It is flaky because the API does not reliably return snapshots,
-        i.e. the `archived_snapshots` field is unreliable.
-        That's why the test is ignored. For development and documentation this test is still useful."]
-    #[tokio::test]
-    /// This tests the real Wayback API without any mocks.
-    async fn wayback_suggestion_real() -> Result<(), Box<dyn StdError>> {
-        let url = &"https://example.com".try_into()?;
-        let response = get_archive_snapshot(url, TIMEOUT).await?;
-        assert_eq!(
-            response,
-            Some("http://web.archive.org/web/20250603204626/http://www.example.com/".parse()?)
-        );
-        Ok(())
-    }
-
-    #[tokio::test]
-    /// This tests the real Wayback API without any mocks.
-    /// The flakiness of the API doesn't affect this test because it originates from
-    /// the `archived_snapshots` field. However, this test is flaky due to the API
-    /// server's flakiness.
-    async fn wayback_suggestion_real_unknown() -> Result<(), Box<dyn StdError>> {
-        let url = &"https://github.com/mre/idiomatic-rust-doesnt-exist-man".try_into()?;
-        match get_archive_snapshot(url, TIMEOUT).await {
-            Ok(response) => {
-                assert_eq!(response, None);
+    /// Real Wayback request: `example.com` is archived many times over,
+    /// so this should resolve to a concrete timestamped snapshot URL.
+    ///
+    /// Tolerates 503s, which `web.archive.org` returns intermittently
+    /// under load.
+    async fn wayback_suggestion_real() -> Result<(), Box<dyn Error>> {
+        let url: Url = "https://example.com".parse()?;
+        match get_archive_snapshot(&url).await {
+            Ok(snapshot) => {
+                let snapshot = snapshot.expect("example.com should have a snapshot");
+                let s = snapshot.as_str();
+                let after = s
+                    .strip_prefix("https://web.archive.org/web/")
+                    .unwrap_or_else(|| panic!("unexpected snapshot URL: {s}"));
+                // A resolved snapshot embeds a numeric timestamp
+                // (e.g. `/web/20020120142510/...`). If we got the bare,
+                // un-timestamped request URL back, reading `Location`
+                // silently broke.
+                let timestamp: String = after.chars().take_while(char::is_ascii_digit).collect();
+                assert!(
+                    !timestamp.is_empty(),
+                    "expected a timestamped snapshot, got: {s}"
+                );
             }
+            Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {
+                // ignore 503s which are *probably* transient
+            }
+            Err(e) => Err(e)?,
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    /// Real Wayback request for a URL that doesn't exist (and therefore
+    /// can't have been archived). Wayback responds 404 and we must
+    /// return `None` so lychee doesn't suggest a dead-end link.
+    async fn wayback_suggestion_real_unknown() -> Result<(), Box<dyn Error>> {
+        let url: Url = "https://example.com/this-page-does-not-exist-abc123xyz".parse()?;
+        match get_archive_snapshot(&url).await {
+            Ok(snapshot) => assert_eq!(snapshot, None),
             Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {
                 // ignore 503s which are *probably* transient
             }

--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -41,13 +41,11 @@ const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
 /// (one per failed URL), all aimed at the same host. Sharing a client
 /// lets them reuse the connection pool, TLS session cache, and DNS
 /// resolver instead of paying those costs per request.
-///
-/// Redirects are intentionally *not* followed: a Wayback hit answers with a
-/// `302` whose `Location` already holds the snapshot URL, so following it
-/// would just download the archived page for no reason.
 static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()
         .timeout(REQUEST_TIMEOUT)
+        // Wayback's `302` response directly gives
+        // us the snapshot URL in the `Location`
         .redirect(Policy::none())
         .build()
         .expect("Wayback HTTP client should always build with default config")
@@ -79,7 +77,11 @@ pub(crate) async fn get_archive_snapshot(url: &Url) -> Result<Option<Url>, Error
     }
 
     if status.is_redirection() {
-        // The `Location` header holds the resolved timestamped snapshot URL
+        // Read the snapshot straight from the `Location` header rather than
+        // following the redirect. We only need the URL, not the archived
+        // page body, and skipping the second request avoids downloading it.
+        //
+        // The header holds the resolved timestamped snapshot URL
         // (e.g. `/web/20020120142510/http://example.com/`). It may be
         // relative, so resolve it against the request URL.
         let snapshot = response

--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -32,18 +32,17 @@ use reqwest::header::LOCATION;
 use reqwest::redirect::Policy;
 use reqwest::{Client, Error, Url};
 
-/// Per-request timeout for Wayback lookups.
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(20);
-
 /// Shared HTTP client for all Wayback suggestion lookups.
 ///
 /// The suggestion path may issue dozens of lookups in quick succession
 /// (one per failed URL), all aimed at the same host. Sharing a client
 /// lets them reuse the connection pool, TLS session cache, and DNS
 /// resolver instead of paying those costs per request.
+///
+/// The timeout is applied per-request (see [`get_archive_snapshot`]) so it can
+/// honour the caller's `--timeout`
 static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()
-        .timeout(REQUEST_TIMEOUT)
         // Wayback's `302` response directly gives
         // us the snapshot URL in the `Location`
         .redirect(Policy::none())
@@ -60,7 +59,13 @@ static CLIENT: LazyLock<Client> = LazyLock::new(|| {
 /// - a redirect (`302`) carries the timestamped snapshot in its `Location`
 ///   header, which we return without following, and
 /// - a `404` means there is no snapshot, so we return `None`.
-pub(crate) async fn get_archive_snapshot(url: &Url) -> Result<Option<Url>, Error> {
+///
+/// `timeout` bounds the lookup so callers can keep it in step with the
+/// `--timeout` they use for ordinary requests.
+pub(crate) async fn get_archive_snapshot(
+    url: &Url,
+    timeout: Duration,
+) -> Result<Option<Url>, Error> {
     let wayback = format!("https://web.archive.org/web/{url}");
     // `Url::parse` cannot fail here for any well-formed input `url`, but
     // if it ever did we'd rather report "no suggestion" than panic.
@@ -69,7 +74,7 @@ pub(crate) async fn get_archive_snapshot(url: &Url) -> Result<Option<Url>, Error
         return Ok(None);
     };
 
-    let response = CLIENT.get(snapshot_url).send().await?;
+    let response = CLIENT.get(snapshot_url).timeout(timeout).send().await?;
     let status = response.status();
 
     if status == StatusCode::NOT_FOUND {
@@ -92,8 +97,8 @@ pub(crate) async fn get_archive_snapshot(url: &Url) -> Result<Option<Url>, Error
         return Ok(snapshot);
     }
 
-    // Any other non-success (rate limiting, 5xx, ...) bubbles up so the
-    // caller can decide; the suggestion path currently swallows errors.
+    // Any other non-success (rate limiting, 5xx, ...) bubbles up as an `Err`
+    // so the caller can log it and explain why a suggestion is missing.
     // Anything else (an unexpected `2xx`) means no usable snapshot.
     response.error_for_status()?;
     Ok(None)
@@ -103,9 +108,12 @@ pub(crate) async fn get_archive_snapshot(url: &Url) -> Result<Option<Url>, Error
 mod tests {
     use http::StatusCode;
     use std::error::Error;
+    use std::time::Duration;
     use url::Url;
 
     use super::get_archive_snapshot;
+
+    const TEST_TIMEOUT: Duration = Duration::from_secs(20);
 
     /// Both cases run in a single test (and therefore a single Tokio runtime)
     /// on purpose: `get_archive_snapshot` uses a process-wide static
@@ -113,12 +121,16 @@ mod tests {
     /// first initializes it. Splitting these into two `#[tokio::test]`s would
     /// give each its own runtime and let one reuse a pooled connection whose
     /// runtime has already been torn down, failing with `DispatchGone`.
+    ///
+    /// Hits the live Wayback Machine, which is flaky, so it's ignored to
+    /// keep CI deterministic.
     #[tokio::test]
+    #[ignore = "requires network access to web.archive.org"]
     async fn wayback_suggestion_real() -> Result<(), Box<dyn Error>> {
         // Real Wayback request: `example.com` is archived many times over,
         // so this should resolve to a concrete timestamped snapshot URL.
         let url: Url = "https://example.com".parse()?;
-        match get_archive_snapshot(&url).await {
+        match get_archive_snapshot(&url, TEST_TIMEOUT).await {
             Ok(snapshot) => {
                 let snapshot = snapshot.expect("example.com should have a snapshot");
                 let s = snapshot.as_str();
@@ -145,7 +157,7 @@ mod tests {
         // can't have been archived). Wayback responds 404 and we must
         // return `None` so lychee doesn't suggest a dead-end link.
         let url: Url = "https://example.com/this-page-does-not-exist-abc123xyz".parse()?;
-        match get_archive_snapshot(&url).await {
+        match get_archive_snapshot(&url, TEST_TIMEOUT).await {
             Ok(snapshot) => assert_eq!(snapshot, None),
             Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {}
             Err(e) => Err(e)?,

--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -32,15 +32,18 @@ use reqwest::header::LOCATION;
 use reqwest::redirect::Policy;
 use reqwest::{Client, Error, Url};
 
+/// Base URL for Wayback Machine snapshot lookups.
+///
+/// Appending a URL (and omitting a timestamp) tells Wayback to resolve the
+/// latest available snapshot of that page.
+const WAYBACK_BASE_URL: &str = "https://web.archive.org/web/";
+
 /// Shared HTTP client for all Wayback suggestion lookups.
 ///
 /// The suggestion path may issue dozens of lookups in quick succession
 /// (one per failed URL), all aimed at the same host. Sharing a client
 /// lets them reuse the connection pool, TLS session cache, and DNS
 /// resolver instead of paying those costs per request.
-///
-/// The timeout is applied per-request (see [`get_archive_snapshot`]) so it can
-/// honour the caller's `--timeout`
 static CLIENT: LazyLock<Client> = LazyLock::new(|| {
     Client::builder()
         // Wayback's `302` response directly gives
@@ -59,14 +62,11 @@ static CLIENT: LazyLock<Client> = LazyLock::new(|| {
 /// - a redirect (`302`) carries the timestamped snapshot in its `Location`
 ///   header, which we return without following, and
 /// - a `404` means there is no snapshot, so we return `None`.
-///
-/// `timeout` bounds the lookup so callers can keep it in step with the
-/// `--timeout` they use for ordinary requests.
 pub(crate) async fn get_archive_snapshot(
     url: &Url,
     timeout: Duration,
 ) -> Result<Option<Url>, Error> {
-    let wayback = format!("https://web.archive.org/web/{url}");
+    let wayback = format!("{WAYBACK_BASE_URL}{url}");
     // `Url::parse` cannot fail here for any well-formed input `url`, but
     // if it ever did we'd rather report "no suggestion" than panic.
     let Ok(snapshot_url) = Url::parse(&wayback) else {
@@ -92,6 +92,8 @@ pub(crate) async fn get_archive_snapshot(
         let snapshot = response
             .headers()
             .get(LOCATION)
+            // HTTP header values aren't guaranteed to be UTF-8.
+            // If string conversion fails, it gets treated as "no snapshot."
             .and_then(|location| location.to_str().ok())
             .and_then(|location| response.url().join(location).ok());
         return Ok(snapshot);
@@ -111,7 +113,7 @@ mod tests {
     use std::time::Duration;
     use url::Url;
 
-    use super::get_archive_snapshot;
+    use super::{WAYBACK_BASE_URL, get_archive_snapshot};
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -135,7 +137,7 @@ mod tests {
                 let snapshot = snapshot.expect("example.com should have a snapshot");
                 let s = snapshot.as_str();
                 let after = s
-                    .strip_prefix("https://web.archive.org/web/")
+                    .strip_prefix(WAYBACK_BASE_URL)
                     .unwrap_or_else(|| panic!("unexpected snapshot URL: {s}"));
                 // A resolved snapshot embeds a numeric timestamp
                 // (e.g. `/web/20020120142510/...`). If we got the bare,

--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -107,13 +107,16 @@ mod tests {
 
     use super::get_archive_snapshot;
 
+    /// Both cases run in a single test (and therefore a single Tokio runtime)
+    /// on purpose: `get_archive_snapshot` uses a process-wide static
+    /// `reqwest::Client` whose connection pool is bound to the runtime that
+    /// first initializes it. Splitting these into two `#[tokio::test]`s would
+    /// give each its own runtime and let one reuse a pooled connection whose
+    /// runtime has already been torn down, failing with `DispatchGone`.
     #[tokio::test]
-    /// Real Wayback request: `example.com` is archived many times over,
-    /// so this should resolve to a concrete timestamped snapshot URL.
-    ///
-    /// Tolerates 503s, which `web.archive.org` returns intermittently
-    /// under load.
     async fn wayback_suggestion_real() -> Result<(), Box<dyn Error>> {
+        // Real Wayback request: `example.com` is archived many times over,
+        // so this should resolve to a concrete timestamped snapshot URL.
         let url: Url = "https://example.com".parse()?;
         match get_archive_snapshot(&url).await {
             Ok(snapshot) => {
@@ -132,27 +135,22 @@ mod tests {
                     "expected a timestamped snapshot, got: {s}"
                 );
             }
-            Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {
-                // ignore 503s which are *probably* transient
-            }
+            // Ignore 503s, which `web.archive.org` returns intermittently
+            // under load.
+            Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {}
             Err(e) => Err(e)?,
         }
-        Ok(())
-    }
 
-    #[tokio::test]
-    /// Real Wayback request for a URL that doesn't exist (and therefore
-    /// can't have been archived). Wayback responds 404 and we must
-    /// return `None` so lychee doesn't suggest a dead-end link.
-    async fn wayback_suggestion_real_unknown() -> Result<(), Box<dyn Error>> {
+        // Real Wayback request for a URL that doesn't exist (and therefore
+        // can't have been archived). Wayback responds 404 and we must
+        // return `None` so lychee doesn't suggest a dead-end link.
         let url: Url = "https://example.com/this-page-does-not-exist-abc123xyz".parse()?;
         match get_archive_snapshot(&url).await {
             Ok(snapshot) => assert_eq!(snapshot, None),
-            Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {
-                // ignore 503s which are *probably* transient
-            }
+            Err(e) if e.status() == Some(StatusCode::SERVICE_UNAVAILABLE) => {}
             Err(e) => Err(e)?,
         }
+
         Ok(())
     }
 }


### PR DESCRIPTION
I came across [this internal Wikipedia page](https://en.wikipedia.org/wiki/Help:Using_the_Wayback_Machine) and learned about Wayback Machine URL formats. Based on this, I believe we can simplify our code.

We can replace the call to https://archive.org/wayback/available with a client-side construction of https://web.archive.org/web/0/<url>.

~The '0' timestamp tells Wayback to redirect to the newest available snapshot, which is far more reliable than the Availability JSON API (which is heavily rate-limited and is a frequent source of frustration due to flakiness. It also sometimes returns empty archived_snapshots for pages that are clearly archived).~

Edit: turns out "0" means "give me the first snapshot". What I was looking for was https://web.archive.org/web/<url> without the `/0/`, which returns the **latest** snapshot. Thanks for the correction.
