### PR TITLE
ci: fix links.yml by adding --root-dir argument

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@master
         with:
-          args: --verbose --exclude-path benches --exclude-path fixtures .
+          args: --verbose --exclude-path benches --exclude-path fixtures --root-dir . .
 
       - name: Create Issue From File
         if: github.repository_owner == 'lycheeverse' && env.lychee_exit_code != 0


### PR DESCRIPTION
the daily link check of this repo has been failing for some time:

    [ERROR] error: | Error building URL for "/CONTRIBUTING.md" (Attribute:
    Some("href")): Cannot convert path '/CONTRIBUTING.md' to a URI: To
    resolve root-relative links in local files, provide a root dir

https://github.com/lycheeverse/lychee/actions/workflows/links.yml

i didn't look into why the create issue step isn't working. maybe `env.lychee_exit_code` is referencing the wrong thing?