### PR TITLE
feat: warn when exclusive '..' syntax is used in accept ranges

### DIFF
--- a/lychee-lib/src/types/accept/range.rs
+++ b/lychee-lib/src/types/accept/range.rs
@@ -76,11 +76,12 @@ impl FromStr for StatusRange {
             if inclusive {
                 Self::new(start, end)
             } else {
-                warn!(
-                    "Accept range '{s}' uses exclusive '..' syntax, which excludes the upper bound ({end}). \
-                     This matches Rust range semantics but is a common source of confusion. \
-                     If you intended to include {end}, use '{start}..={end}' or list codes explicitly (e.g. '{start}, {end}')."
-                );
+                if end == start + 1 {
+                    warn!(
+                        "Accept range '{s}' only matches status code {start}. \
+                         Did you mean '{start}..={end}' or '{start}, {end}'?"
+                    );
+                }
                 Self::new(start, end - 1)
             }
         }

--- a/lychee-lib/src/types/accept/range.rs
+++ b/lychee-lib/src/types/accept/range.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use http::StatusCode;
+use log::warn;
 use regex::Regex;
 use thiserror::Error;
 
@@ -75,6 +76,11 @@ impl FromStr for StatusRange {
             if inclusive {
                 Self::new(start, end)
             } else {
+                warn!(
+                    "Accept range '{s}' uses exclusive '..' syntax, which excludes the upper bound ({end}). \
+                     This matches Rust range semantics but is a common source of confusion. \
+                     If you intended to include {end}, use '{start}..={end}' or list codes explicitly (e.g. '{start}, {end}')."
+                );
                 Self::new(start, end - 1)
             }
         }


### PR DESCRIPTION
Closes lycheeverse/lychee#2178.

The exclusive `..` range syntax follows Rust semantics and excludes the upper bound, which is a common source of confusion (e.g. `301..302` only accepts 301). Emit a warning to make this visible.

This could be promoted to an error or downgraded to a hint once #2021 lands.