### PR TITLE
ci: fix flaky binstall-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,20 @@ jobs:
 
   binstall-check:
     runs-on: ubuntu-latest
+    # Skip on release-plz PRs: those bump the version to one that has not been
+    # published yet, so binstall cannot find a matching release. We still want
+    # PR coverage on regular PRs to catch regressions in the binstall metadata.
+    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
+    env:
+      # Authenticate against api.github.com to avoid 403 rate-limit failures
+      # when binstall queries GitHub releases.
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v6
       - uses: cargo-bins/cargo-binstall@main
-      - run: cargo binstall --manifest-path . --strategies crate-meta-data lychee --no-confirm
+      # Drop `--manifest-path .` so binstall resolves the latest published
+      # version of `lychee` instead of the in-tree (possibly unreleased) one.
+      - run: cargo binstall --strategies crate-meta-data lychee --no-confirm
 
   publish-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: cargo-bins/cargo-binstall@main
-      # Drop `--manifest-path .` so binstall resolves the latest published
-      # version of `lychee` instead of the in-tree (possibly unreleased) one.
-      - run: cargo binstall --strategies crate-meta-data lychee --no-confirm
+      # Use `--manifest-path .` so binstall validates the in-tree binstall
+      # metadata. Resolving against the latest published version would mask
+      # metadata fixes (e.g. #2165) until after the next release ships.
+      - run: cargo binstall --manifest-path . --strategies crate-meta-data lychee --no-confirm
 
   publish-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The binstall-check job from #2165 fails for two reasons:

- Unauthenticated api.github.com requests get 403 under contention. Fix by passing GITHUB_TOKEN.
- Release-plz PRs bump the in-tree version to one that is not published yet, so binstall (with --manifest-path .) cannot find a matching release. Drop the flag so binstall resolves the latest published version, and skip the job on release-plz branches as a safety net.

Should unblock #2169 and future release-plz PRs.