### PR TITLE
readme: add text fragments to features table, other tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ outdated information.
 | Basic Auth           | ![yes]  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Custom user agent    | ![yes]  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Relative URLs        | ![yes]  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| Anchors/Fragments    | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
+| [URL anchor fragments]| ![yes] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
+| [URL text fragments] | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 | Include patterns     | ![yes]️  | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
 | Exclude patterns     | ![yes]  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | Handle redirects     | ![yes]  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
@@ -238,14 +239,18 @@ outdated information.
 [linkchecker]: https://github.com/linkchecker/linkchecker
 [markdown-link-check]: https://github.com/tcort/markdown-link-check
 [fink]: https://github.com/dantleech/fink
+
 [yes]: ./assets/yes.svg
 [no]: ./assets/no.svg
 [maybe]: ./assets/maybe.svg
+
 [custom headers]: https://github.com/rust-lang/crates.io/issues/788
 [filter status code]: https://github.com/tcort/markdown-link-check/issues/94
 [skip private domains]: https://github.com/appscodelabs/liche/blob/a5102b0bf90203b467a4f3b4597d22cd83d94f99/url_checker.go
 [use as library]: https://github.com/raviqqe/liche/issues/13
 [config file]: https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
+[URL anchor fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment
+[URL text fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
 
 <sup>1</sup> Other machine-readable formats like CSV are supported.
 

--- a/README.md
+++ b/README.md
@@ -213,14 +213,14 @@ outdated information.
 | Include patterns      | ![yes]️      | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
 | Exclude patterns      | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | Filter by scheme      | ![yes]      | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Skip private domains  | [![yes]][7] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Skip private domains  | [![yes]<sup>*</sup>][7] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 | **HTTP features**     |             |               |          |                       |              |                      |                       |        |
-| Custom user agent     | [![yes]][2] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Basic Auth            | [![yes]][1] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| Custom user agent     | [![yes]<sup>*</sup>][2] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| Basic Auth            | [![yes]<sup>*</sup>][1] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | [Filter status code]  | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
-| [Custom headers]      | [![yes]][4] | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
+| [Custom headers]      | [![yes]<sup>*</sup>][4] | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
 | Custom timeout        | ![yes]      | ![yes]        | ![yes]   | ![no]                 | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| `HEAD` requests       | [![yes]][5] | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![no]  |
+| `HEAD` requests       | [![yes]<sup>*</sup>][5] | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![no]  |
 | Handle redirects      | ![yes]      | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | Per-host throttling   | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Respect rate limits   | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
@@ -231,9 +231,9 @@ outdated information.
 | Cookies               | ![yes]      | ![no]         | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
 | **URL features**      |             |               |          |                       |              |                      |                       |        |
 | Relative URLs         | ![yes]      | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| [URL anchor fragments]| [![yes]][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
-| [URL text fragments]  | [![yes]][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| E-mail addresses      | [![yes]][6] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| [URL anchor fragments]| [![yes]<sup>*</sup>][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
+| [URL text fragments]  | [![yes]<sup>*</sup>][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| E-mail addresses      | [![yes]<sup>*</sup>][6] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | **Other**             |             |               |          |                       |              |                      |                       |        |
 | Recursion             | ![no]       | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![no]  |
 | Amazing lychee logo   | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
@@ -266,6 +266,7 @@ outdated information.
 [URL anchor fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment
 [URL text fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
 
+<sup>*</sup> May need configuration. Click the ![yes] icon for more information.
 <sup>1</sup> Other machine-readable formats like CSV are supported.
 
 ## Commandline usage

--- a/README.md
+++ b/README.md
@@ -190,47 +190,53 @@ Please tell us if this this negatively affects you in any way.
 This comparison is made on a best-effort basis. Please create a PR to fix
 outdated information.
 
-|                      | lychee  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| -------------------- | ------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
-| Language             | Rust    | Ruby          | Go       | JS                    | TypeScript   | Python               | JS                    | PHP    |
-| Async/Parallel       | ![yes]  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| JSON output          | ![yes]  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
-| Static binary        | ![yes]  | ![no]         | ![yes]   | ![no]                 | ![no]        | ️![no]               | ![no]                 | ![no]  |
-| Markdown files       | ![yes]  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
-| HTML files           | ![yes]  | ![no]         | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| Text files           | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Website support      | ![yes]  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| Chunked encodings    | ![yes]  | ![maybe]      | ![maybe] | ![maybe]              | ![maybe]     | ![no]                | ![yes]                | ![yes] |
-| GZIP compression     | ![yes]  | ![maybe]      | ![maybe] | ![yes]                | ![maybe]     | ![yes]               | ![maybe]              | ![no]  |
-| Basic Auth           | ![yes]  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Custom user agent    | ![yes]  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Relative URLs        | ![yes]  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| [URL anchor fragments]| ![yes] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
-| [URL text fragments] | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Include patterns     | ![yes]️  | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Exclude patterns     | ![yes]  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| Handle redirects     | ![yes]  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| Ignore insecure SSL  | ![yes]  | ![yes]        | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
-| File globbing        | ![yes]  | ![yes]        | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| Limit scheme         | ![yes]  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| [Custom headers]     | ![yes]  | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
-| Summary              | ![yes]  | ![yes]        | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| `HEAD` requests      | ![yes]  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![no]  |
-| Colored output       | ![yes]  | ![maybe]      | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| [Filter status code] | ![yes]  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
-| Custom timeout       | ![yes]  | ![yes]        | ![yes]   | ![no]                 | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| E-mail links         | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Progress bar         | ![yes]  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![yes] |
-| Retry and backoff    | ![yes]  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| Per-host throttling  | ![yes]  | ![no]         | ![yes]   | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Respect rate limits  | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Skip private domains | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| [Use as library]     | ![yes]  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| Quiet mode           | ![yes]  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| [Config file]        | ![yes]  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![no]  |
-| Cookies              | ![yes]  | ![no]         | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
-| Recursion            | ![no]   | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![no]  |
-| Amazing lychee logo  | ![yes]  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+|                       | lychee      | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| Language              | Rust        | Ruby          | Go       | JS                    | TypeScript   | Python               | JS                    | PHP    |
+| **Basic features**    |             |               |          |                       |              |                      |                       |        |
+| Async/Parallel        | ![yes]      | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Static binary         | ![yes]      | ![no]         | ![yes]   | ![no]                 | ![no]        | ️![no]                | ![no]                 | ![no]  |
+| Check Markdown files  | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
+| Check HTML files      | ![yes]      | ![no]         | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
+| Check text files      | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Check a website       | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| File globbing         | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
+| **User interface**    |             |               |          |                       |              |                      |                       |        |
+| Progress bar          | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![yes] |
+| Colored output        | ![yes]      | ![maybe]      | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| Summary               | ![yes]      | ![yes]        | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| Quiet mode            | ![yes]      | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| JSON output           | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
+| [Config file]         | ![yes]      | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![no]  |
+| [Use as library]      | ![yes]      | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
+| **Selecting links**   |             |               |          |                       |              |                      |                       |        |
+| Include patterns      | ![yes]️      | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Exclude patterns      | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Filter by scheme      | ![yes]      | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| Skip private domains  | [![yes]][7] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| **HTTP features**     |             |               |          |                       |              |                      |                       |        |
+| Custom user agent     | [![yes]][2] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| Basic Auth            | [![yes]][1] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| [Filter status code]  | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
+| [Custom headers]      | [![yes]][4] | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
+| Custom timeout        | ![yes]      | ![yes]        | ![yes]   | ![no]                 | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| `HEAD` requests       | [![yes]][5] | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![no]  |
+| Handle redirects      | ![yes]      | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Per-host throttling   | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| Respect rate limits   | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Retry and backoff     | ![yes]      | ![no]         | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
+| Ignore insecure SSL   | ![yes]      | ![yes]        | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
+| Chunked encodings     | ![yes]      | ![maybe]      | ![maybe] | ![maybe]              | ![maybe]     | ![no]                | ![yes]                | ![yes] |
+| GZIP compression      | ![yes]      | ![maybe]      | ![maybe] | ![yes]                | ![maybe]     | ![yes]               | ![maybe]              | ![no]  |
+| Cookies               | ![yes]      | ![no]         | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
+| **URL features**      |             |               |          |                       |              |                      |                       |        |
+| Relative URLs         | ![yes]      | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| [URL anchor fragments]| [![yes]][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
+| [URL text fragments]  | [![yes]][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| E-mail addresses      | [![yes]][6] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| **Other**             |             |               |          |                       |              |                      |                       |        |
+| Recursion             | ![no]       | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![no]  |
+| Amazing lychee logo   | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 
 [awesome_bot]: https://github.com/dkhamsing/awesome_bot
 [muffet]: https://github.com/raviqqe/muffet
@@ -239,6 +245,14 @@ outdated information.
 [linkchecker]: https://github.com/linkchecker/linkchecker
 [markdown-link-check]: https://github.com/tcort/markdown-link-check
 [fink]: https://github.com/dantleech/fink
+
+[1]: https://lychee.cli.rs/guides/cli/#--basic-auth
+[2]: https://lychee.cli.rs/guides/cli/#-u---user-agent
+[3]: https://lychee.cli.rs/guides/cli/#--include-fragments
+[4]: https://lychee.cli.rs/guides/cli/#-h---header
+[5]: https://lychee.cli.rs/guides/cli/#-x---method
+[6]: https://lychee.cli.rs/guides/cli/#--include-mail
+[7]: https://lychee.cli.rs/guides/cli/#-e---exclude-all-private
 
 [yes]: ./assets/yes.svg
 [no]: ./assets/no.svg

--- a/README.md
+++ b/README.md
@@ -150,8 +150,10 @@ See the lychee-action repository for usage instructions.
 
 ### Pre-built binaries
 
-We provide binaries for Linux, macOS, and Windows for every release. \
-You can download them from the [releases page](https://github.com/lycheeverse/lychee/releases).
+We provide binaries for Linux, macOS, and Windows for every release. You can
+download them from the [releases page](https://github.com/lycheeverse/lychee/releases).
+You can also use [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall#cargo-binaryinstall)
+to install these binaries.
 
 ### Cargo
 

--- a/README.md
+++ b/README.md
@@ -190,53 +190,68 @@ Please tell us if this this negatively affects you in any way.
 This comparison is made on a best-effort basis. Please create a PR to fix
 outdated information.
 
-|                       | lychee      | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| --------------------- | ----------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
-| Language              | Rust        | Ruby          | Go       | JS                    | TypeScript   | Python               | JS                    | PHP    |
-| **Basic features**    |             |               |          |                       |              |                      |                       |        |
-| Async/Parallel        | ![yes]      | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| Static binary         | ![yes]      | ![no]         | ![yes]   | ![no]                 | ![no]        | ️![no]                | ![no]                 | ![no]  |
-| Check Markdown files  | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
-| Check HTML files      | ![yes]      | ![no]         | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| Check text files      | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Check a website       | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| File globbing         | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| **User interface**    |             |               |          |                       |              |                      |                       |        |
-| Progress bar          | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![yes] |
-| Colored output        | ![yes]      | ![maybe]      | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| Summary               | ![yes]      | ![yes]        | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
-| Quiet mode            | ![yes]      | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| JSON output           | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
-| [Config file]         | ![yes]      | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![no]  |
-| [Use as library]      | ![yes]      | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| **Selecting links**   |             |               |          |                       |              |                      |                       |        |
-| Include patterns      | ![yes]️      | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Exclude patterns      | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| Filter by scheme      | ![yes]      | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+### Basics
+|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| Language              | Rust                    | Ruby          | Go       | JS                    | TypeScript   | Python               | JS                    | PHP    |
+| Async/Parallel        | ![yes]                  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Static binary         | ![yes]                  | ![no]         | ![yes]   | ![no]                 | ![no]        | ️![no]                | ![no]                 | ![no]  |
+| Check Markdown files  | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
+| Check HTML files      | ![yes]                  | ![no]         | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
+| Check text files      | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Check a website       | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| File globbing         | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
+
+### User interface
+|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| Progress bar          | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![yes] |
+| Colored output        | ![yes]                  | ![maybe]      | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| Summary               | ![yes]                  | ![yes]        | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| Quiet mode            | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| JSON output           | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
+| [Config file]         | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![no]  |
+| [Use as library]      | ![yes]                  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
+
+### Selecting links
+|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| Include patterns      | ![yes]️                  | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Exclude patterns      | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Filter by scheme      | ![yes]                  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Skip private domains  | [![yes]<sup>*</sup>][7] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| **HTTP features**     |             |               |          |                       |              |                      |                       |        |
+
+### HTTP features
+|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
 | Custom user agent     | [![yes]<sup>*</sup>][2] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Basic Auth            | [![yes]<sup>*</sup>][1] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| [Filter status code]  | ![yes]      | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
+| [Filter status code]  | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
 | [Custom headers]      | [![yes]<sup>*</sup>][4] | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
-| Custom timeout        | ![yes]      | ![yes]        | ![yes]   | ![no]                 | ![yes]       | ![yes]               | ![no]                 | ![yes] |
+| Custom timeout        | ![yes]                  | ![yes]        | ![yes]   | ![no]                 | ![yes]       | ![yes]               | ![no]                 | ![yes] |
 | `HEAD` requests       | [![yes]<sup>*</sup>][5] | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![no]  |
-| Handle redirects      | ![yes]      | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| Per-host throttling   | ![yes]      | ![no]         | ![yes]   | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| Respect rate limits   | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-| Retry and backoff     | ![yes]      | ![no]         | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
-| Ignore insecure SSL   | ![yes]      | ![yes]        | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
-| Chunked encodings     | ![yes]      | ![maybe]      | ![maybe] | ![maybe]              | ![maybe]     | ![no]                | ![yes]                | ![yes] |
-| GZIP compression      | ![yes]      | ![maybe]      | ![maybe] | ![yes]                | ![maybe]     | ![yes]               | ![maybe]              | ![no]  |
-| Cookies               | ![yes]      | ![no]         | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
-| **URL features**      |             |               |          |                       |              |                      |                       |        |
-| Relative URLs         | ![yes]      | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Handle redirects      | ![yes]                  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
+| Per-host throttling   | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
+| Respect rate limits   | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+| Retry and backoff     | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
+| Ignore insecure SSL   | ![yes]                  | ![yes]        | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
+| Chunked encodings     | ![yes]                  | ![maybe]      | ![maybe] | ![maybe]              | ![maybe]     | ![no]                | ![yes]                | ![yes] |
+| GZIP compression      | ![yes]                  | ![maybe]      | ![maybe] | ![yes]                | ![maybe]     | ![yes]               | ![maybe]              | ![no]  |
+| Cookies               | ![yes]                  | ![no]         | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
+
+### URL features
+|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| Relative URLs         | ![yes]                  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | [URL anchor fragments]| [![yes]<sup>*</sup>][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
 | [URL text fragments]  | [![yes]<sup>*</sup>][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 | E-mail addresses      | [![yes]<sup>*</sup>][6] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| **Other**             |             |               |          |                       |              |                      |                       |        |
-| Recursion             | ![no]       | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![no]  |
-| Amazing lychee logo   | ![yes]      | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
+
+### Other
+|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
+| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| Recursion             | ![no]                   | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![no]  |
+| Amazing lychee logo   | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 
 [awesome_bot]: https://github.com/dkhamsing/awesome_bot
 [muffet]: https://github.com/raviqqe/muffet

--- a/README.md
+++ b/README.md
@@ -190,7 +190,6 @@ Please tell us if this this negatively affects you in any way.
 This comparison is made on a best-effort basis. Please create a PR to fix
 outdated information.
 
-### Basics
 |                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
 | --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
 | Language              | Rust                    | Ruby          | Go       | JS                    | TypeScript   | Python               | JS                    | PHP    |
@@ -201,10 +200,7 @@ outdated information.
 | Check text files      | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 | Check a website       | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![yes] |
 | File globbing         | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![yes]       | ![no]                | ![yes]                | ![no]  |
-
-### User interface
-|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| **User interface**    |                         |               |          |                       |              |                      |                       |        |
 | Progress bar          | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![yes] |
 | Colored output        | ![yes]                  | ![maybe]      | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
 | Summary               | ![yes]                  | ![yes]        | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
@@ -212,18 +208,12 @@ outdated information.
 | JSON output           | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
 | [Config file]         | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![no]  |
 | [Use as library]      | ![yes]                  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
-
-### Selecting links
-|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| **Selecting links**   |                         |               |          |                       |              |                      |                       |        |
 | Include patterns      | ![yes]️                  | ![yes]        | ![no]    | ![yes]                | ![no]        | ![no]                | ![no]                 | ![no]  |
 | Exclude patterns      | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | Filter by scheme      | ![yes]                  | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Skip private domains  | [![yes]<sup>*</sup>][7] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
-
-### HTTP features
-|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| **HTTP features**     |                         |               |          |                       |              |                      |                       |        |
 | Custom user agent     | [![yes]<sup>*</sup>][2] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Basic Auth            | [![yes]<sup>*</sup>][1] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | [Filter status code]  | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
@@ -238,18 +228,12 @@ outdated information.
 | Chunked encodings     | ![yes]                  | ![maybe]      | ![maybe] | ![maybe]              | ![maybe]     | ![no]                | ![yes]                | ![yes] |
 | GZIP compression      | ![yes]                  | ![maybe]      | ![maybe] | ![yes]                | ![maybe]     | ![yes]               | ![maybe]              | ![no]  |
 | Cookies               | ![yes]                  | ![no]         | ![yes]   | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![yes] |
-
-### URL features
-|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| **URL features**      |                         |               |          |                       |              |                      |                       |        |
 | Relative URLs         | ![yes]                  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
 | [URL anchor fragments]| [![yes]<sup>*</sup>][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![yes]                | ![no]  |
 | [URL text fragments]  | [![yes]<sup>*</sup>][3] | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 | E-mail addresses      | [![yes]<sup>*</sup>][6] | ![no]         | ![no]    | ![no]                 | ![no]        | ![yes]               | ![no]                 | ![no]  |
-
-### Other
-|                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
-| --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |
+| **Other**             |                         |               |          |                       |              |                      |                       |        |
 | Recursion             | ![no]                   | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![no]  |
 | Amazing lychee logo   | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![no]        | ![no]                | ![no]                 | ![no]  |
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For Nix we provide a flake so you can use `nix develop` and `nix build`.
 
 ## Installation
 
-<details><summary><b>View installation instructions</b></summary>
+<details><summary><b>View package manager installation instructions</b></summary>
 
 ### Arch Linux
 
@@ -142,6 +142,11 @@ choco install lychee
 ```
 
 </details>
+
+### GitHub Actions
+
+A GitHub Action that runs lychee is available as [lycheeverse/lychee-action](https://github.com/lycheeverse/lychee-action).
+See the lychee-action repository for usage instructions.
 
 ### Pre-built binaries
 
@@ -789,11 +794,6 @@ You can use lychee as a library for your own projects!
 Take a look at the [library documentation](https://docs.rs/lychee-lib/latest/lychee_lib/).
 Also check out the [examples](examples) directory for small practical examples.
 These examples can be run with `cargo run --example <example>`.
-
-## GitHub Action Usage
-
-A GitHub Action that uses lychee is available as a separate repository: [lycheeverse/lychee-action](https://github.com/lycheeverse/lychee-action)
-which includes usage instructions.
 
 ## Pre-commit Usage
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,9 @@ apt install gcc pkg-config libc6-dev libssl-dev
 cargo install lychee
 ```
 
-#### Feature flags
+<details>
+<summary>Feature flags</summary>
+
 
 Lychee supports the following feature flags:
 
@@ -185,10 +187,16 @@ Note that in the past lychee could be configured to use either OpenSSL or Rustls
 to fully switch to Rustls and drop OpenSSL support.
 Please tell us if this this negatively affects you in any way.
 
+</details>
+
 ## Features
 
 This comparison is made on a best-effort basis. Please create a PR to fix
 outdated information.
+
+See the [lychee website](https://lychee.cli.rs/overview/) for a guide to lychee's
+features. Also see the [command-line flags](https://lychee.cli.rs/guides/cli/) for
+the options you can use to customise lychee.
 
 |                       | lychee                  | [awesome_bot] | [muffet] | [broken-link-checker] | [linkinator] | [linkchecker]        | [markdown-link-check] | [fink] |
 | --------------------- | ----------------------- | ------------- | -------- | --------------------- | ------------ | -------------------- | --------------------- | ------ |

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ the options you can use to customise lychee.
 | **HTTP features**     |                         |               |          |                       |              |                      |                       |        |
 | Custom user agent     | [![yes]<sup>*</sup>][2] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
 | Basic Auth            | [![yes]<sup>*</sup>][1] | ![no]         | ![no]    | ![yes]                | ![no]        | ![yes]               | ![no]                 | ![no]  |
-| [Filter status code]  | ![yes]                  | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
-| [Custom headers]      | [![yes]<sup>*</sup>][4] | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
+| Filter status code    | [![yes]<sup>*</sup>][8] | ![yes]        | ![no]    | ![no]                 | ![no]        | ![no]                | ![yes]                | ![no]  |
+| Custom headers        | [![yes]<sup>*</sup>][4] | ![no]         | ![yes]   | ![no]                 | ![no]        | ![no]                | ![yes]                | ![yes] |
 | Custom timeout        | ![yes]                  | ![yes]        | ![yes]   | ![no]                 | ![yes]       | ![yes]               | ![no]                 | ![yes] |
 | `HEAD` requests       | [![yes]<sup>*</sup>][5] | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![yes]               | ![no]                 | ![no]  |
 | Handle redirects      | ![yes]                  | ![yes]        | ![yes]   | ![yes]                | ![yes]       | ![yes]               | ![yes]                | ![yes] |
@@ -258,19 +258,18 @@ the options you can use to customise lychee.
 [1]: https://lychee.cli.rs/guides/cli/#--basic-auth
 [2]: https://lychee.cli.rs/guides/cli/#-u---user-agent
 [3]: https://lychee.cli.rs/guides/cli/#--include-fragments
-[4]: https://lychee.cli.rs/guides/cli/#-h---header
+[4]: https://lychee.cli.rs/troubleshooting/custom-headers/
 [5]: https://lychee.cli.rs/guides/cli/#-x---method
 [6]: https://lychee.cli.rs/guides/cli/#--include-mail
 [7]: https://lychee.cli.rs/guides/cli/#-e---exclude-all-private
+[8]: https://lychee.cli.rs/troubleshooting/status-codes/
 
 [yes]: ./assets/yes.svg
 [no]: ./assets/no.svg
 [maybe]: ./assets/maybe.svg
 
-[custom headers]: https://github.com/rust-lang/crates.io/issues/788
-[filter status code]: https://github.com/tcort/markdown-link-check/issues/94
 [use as library]: https://docs.rs/lychee-lib/latest/lychee_lib/
-[config file]: https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
+[config file]: https://lychee.cli.rs/guides/config/
 [URL anchor fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment
 [URL text fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
 

--- a/README.md
+++ b/README.md
@@ -269,8 +269,7 @@ the options you can use to customise lychee.
 
 [custom headers]: https://github.com/rust-lang/crates.io/issues/788
 [filter status code]: https://github.com/tcort/markdown-link-check/issues/94
-[skip private domains]: https://github.com/appscodelabs/liche/blob/a5102b0bf90203b467a4f3b4597d22cd83d94f99/url_checker.go
-[use as library]: https://github.com/raviqqe/liche/issues/13
+[use as library]: https://docs.rs/lychee-lib/latest/lychee_lib/
 [config file]: https://github.com/lycheeverse/lychee/blob/master/lychee.example.toml
 [URL anchor fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment
 [URL text fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ the options you can use to customise lychee.
 | Colored output        | ![yes]                  | ![maybe]      | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
 | Summary               | ![yes]                  | ![yes]        | ![yes]   | ![maybe]              | ![yes]       | ![yes]               | ![no]                 | ![yes] |
 | Quiet mode            | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![yes] |
-| JSON output           | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>1</sup> | ![yes]                | ![yes] |
+| JSON output           | ![yes]                  | ![no]         | ![yes]   | ![yes]                | ![yes]       | ![maybe]<sup>(supports CSV)</sup> | ![yes]   | ![yes] |
 | [Config file]         | ![yes]                  | ![no]         | ![no]    | ![no]                 | ![yes]       | ![yes]               | ![yes]                | ![no]  |
 | [Use as library]      | ![yes]                  | ![yes]        | ![no]    | ![yes]                | ![yes]       | ![no]                | ![yes]                | ![no]  |
 | **Selecting links**   |                         |               |          |                       |              |                      |                       |        |
@@ -274,7 +274,6 @@ the options you can use to customise lychee.
 [URL text fragments]: https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Fragment/Text_fragments
 
 <sup>*</sup> May need configuration. Click the ![yes] icon for more information.
-<sup>1</sup> Other machine-readable formats like CSV are supported.
 
 ## Commandline usage
 


### PR DESCRIPTION
I wanted to add the new text fragments feature because I think it's a real distinguishing feature (thanks @cristiklein!).

While doing this, I also made some changes which should promote the information which people want to see (and better show off lychee).

- Move Github actions section much earlier, since it's probably a very common use case.
- Hide feature flag information in a details block.
- Mention cargo binstall in pre-build binaries section.
- Add subheadings in the feature table.
- Reorder and group feature table using these subheadings.
- Hyperlinks some :heavy_check_mark: marks to lychee CLI arguments. I remember there was an issue that said they thought fragment checking was enabled by default because of the :heavy_check_mark:.

Uhh let me know what you think. I can slice and subtract things from this PR if you think they're too much.

See here for the rendered readme: https://github.com/rina-forks/lychee/tree/readme-text-frags#features