### PR TITLE
Treat .qmd and .Rmd files as Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ Options:
           This is useful when the default extensions are not enough and you don't
           want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
 
-          [default: md,mkd,mdx,mdown,mdwn,mkdn,mkdown,markdown,html,htm,css,txt,xml]
+          [default: md,markdown,mdx,qmd,rmd,mkd,mkdn,mdwn,mdown,mkdown,html,htm,css,txt,xml]
 
   -f, --format <FORMAT>
           Output format of final status report

--- a/fixtures/TEST_QUARTO.qmd
+++ b/fixtures/TEST_QUARTO.qmd
@@ -1,0 +1,11 @@
+---
+title: Sample
+---
+
+Real link: <https://example.com>.
+
+```{.bash}
+curl -O https://cdn.posit.co/r/rhel-10/pkgs/R-${R_VERSION}-1-1.$(arch).rpm
+```
+
+Inline `https://inline.example.com/code` should also be excluded.

--- a/fixtures/TEST_RMARKDOWN.Rmd
+++ b/fixtures/TEST_RMARKDOWN.Rmd
@@ -1,0 +1,13 @@
+---
+title: Sample R Markdown
+output: html_document
+---
+
+Real link: <https://example.com>.
+
+```{r setup, include=FALSE}
+# This URL should be ignored because it's inside a fenced code block
+download.file("https://cdn.posit.co/r/rhel-10/pkgs/R-${R_VERSION}-1-1.rpm")
+```
+
+Inline `https://inline.example.com/rmd` should also be excluded.

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -224,7 +224,7 @@ pub(crate) struct Config {
     /// This is useful when the default extensions are not enough and you don't
     /// want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
     ///
-    /// [default: rmd,qmd,md,mkd,mdx,mdown,mdwn,mkdn,mkdown,markdown,html,htm,css,txt,xml]
+    /// [default: md,markdown,mdx,qmd,rmd,mkd,mkdn,mdwn,mdown,mkdown,html,htm,css,txt,xml]
     #[arg(long, verbatim_doc_comment)]
     extensions: Option<FileExtensions>,
 

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -224,7 +224,7 @@ pub(crate) struct Config {
     /// This is useful when the default extensions are not enough and you don't
     /// want to provide a long list of inputs (e.g. file1.html, file2.md, etc.)
     ///
-    /// [default: md,mkd,mdx,mdown,mdwn,mkdn,mkdown,markdown,html,htm,css,txt,xml]
+    /// [default: rmd,qmd,md,mkd,mdx,mdown,mdwn,mkdn,mkdown,markdown,html,htm,css,txt,xml]
     #[arg(long, verbatim_doc_comment)]
     extensions: Option<FileExtensions>,
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1801,6 +1801,35 @@ The config file should contain every possible key for documentation purposes."
             .stdout(contains("http://127.0.0.1/inline"))
             .stdout(contains("http://127.0.0.1/bash"));
     }
+
+    #[test]
+    fn test_quarto_treated_as_markdown() {
+        let input = fixtures_path!().join("TEST_QUARTO.qmd");
+
+        cargo_bin_cmd!()
+            .arg(input)
+            .arg("--dump")
+            .assert()
+            .success()
+            .stdout(contains("https://example.com"))
+            .stdout(contains("cdn.posit.co").not())
+            .stdout(contains("inline.example.com").not());
+    }
+
+    #[test]
+    fn test_rmarkdown_treated_as_markdown() {
+        let input = fixtures_path!().join("TEST_RMARKDOWN.Rmd");
+
+        cargo_bin_cmd!()
+            .arg(input)
+            .arg("--dump")
+            .assert()
+            .success()
+            .stdout(contains("https://example.com"))
+            .stdout(contains("cdn.posit.co").not())
+            .stdout(contains("inline.example.com").not());
+    }
+
     #[tokio::test]
     async fn test_verbatim_skipped_by_default_via_file() {
         let file = fixtures_path!().join("TEST_VERBATIM.html");

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -141,7 +141,7 @@ impl std::fmt::Display for FileType {
 impl FileType {
     /// All known Markdown extensions
     const MARKDOWN_EXTENSIONS: &'static [&'static str] = &[
-        "markdown", "mkdown", "mkdn", "mdwn", "mdown", "mdx", "mkd", "md",
+        "markdown", "mkdown", "mkdn", "mdwn", "mdown", "mdx", "mkd", "md", "qmd", "rmd",
     ];
 
     /// All known HTML extensions
@@ -266,6 +266,9 @@ mod tests {
         assert_eq!(FileType::from("foo.md"), FileType::Markdown);
         assert_eq!(FileType::from("foo.MD"), FileType::Markdown);
         assert_eq!(FileType::from("foo.mdx"), FileType::Markdown);
+        assert_eq!(FileType::from("foo.qmd"), FileType::Markdown);
+        assert_eq!(FileType::from("foo.Rmd"), FileType::Markdown);
+        assert_eq!(FileType::from("foo.rmd"), FileType::Markdown);
 
         // Test that a file without an extension is considered plaintext
         assert_eq!(FileType::from("README"), FileType::Plaintext);

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -140,8 +140,10 @@ impl std::fmt::Display for FileType {
 
 impl FileType {
     /// All known Markdown extensions
+    // NOTE: Stored in reverse-popularity order because the `Iterator` impl for
+    // `FileExtensions` pops from the end
     const MARKDOWN_EXTENSIONS: &'static [&'static str] = &[
-        "markdown", "mkdown", "mkdn", "mdwn", "mdown", "mdx", "mkd", "md", "qmd", "rmd",
+        "mkdown", "mdown", "mdwn", "mkdn", "mkd", "rmd", "qmd", "mdx", "markdown", "md",
     ];
 
     /// All known HTML extensions

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -37,9 +37,10 @@ impl FileExtensions {
         Self(vec![])
     }
 
-    /// Extend the list of existing extensions by the values from the iterator
-    pub fn extend<I: IntoIterator<Item = String>>(&mut self, iter: I) {
-        self.0.extend(iter);
+    /// Returns an iterator of file extensions as strings.
+    #[must_use]
+    pub fn iter(&self) -> <&Self as IntoIterator>::IntoIter {
+        <&Self as IntoIterator>::into_iter(self)
     }
 
     /// Check if the list of file extensions contains the given file extension
@@ -94,11 +95,27 @@ impl FromIterator<String> for FileExtensions {
     }
 }
 
-impl Iterator for FileExtensions {
-    type Item = String;
+impl Extend<String> for FileExtensions {
+    fn extend<I: IntoIterator<Item = String>>(&mut self, iter: I) {
+        self.0.extend(iter);
+    }
+}
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.0.pop()
+impl<'a> IntoIterator for &'a FileExtensions {
+    type Item = &'a String;
+    type IntoIter = Box<dyn Iterator<Item = Self::Item> + 'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.0.iter())
+    }
+}
+
+impl IntoIterator for FileExtensions {
+    type Item = String;
+    type IntoIter = Box<dyn Iterator<Item = Self::Item>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Box::new(self.0.into_iter())
     }
 }
 

--- a/lychee-lib/src/types/file.rs
+++ b/lychee-lib/src/types/file.rs
@@ -156,15 +156,13 @@ impl std::fmt::Display for FileType {
 }
 
 impl FileType {
-    /// All known Markdown extensions
-    // NOTE: Stored in reverse-popularity order because the `Iterator` impl for
-    // `FileExtensions` pops from the end
+    /// All known Markdown extensions, ordered by popularity
     const MARKDOWN_EXTENSIONS: &'static [&'static str] = &[
-        "mkdown", "mdown", "mdwn", "mkdn", "mkd", "rmd", "qmd", "mdx", "markdown", "md",
+        "md", "markdown", "mdx", "qmd", "rmd", "mkd", "mkdn", "mdwn", "mdown", "mkdown",
     ];
 
     /// All known HTML extensions
-    const HTML_EXTENSIONS: &'static [&'static str] = &["htm", "html"];
+    const HTML_EXTENSIONS: &'static [&'static str] = &["html", "htm"];
 
     /// All known CSS extensions
     const CSS_EXTENSIONS: &'static [&'static str] = &["css"];


### PR DESCRIPTION
Quarto (.qmd) and R Markdown (.Rmd) are popular Markdown variants. Lychee was parsing them as plaintext, so URLs inside fenced code blocks were extracted as links, including ones with shell substitutions like $(arch) that fail link checks.

This adds qmd and rmd to the list of Markdown extensions. Case-insensitive lookup already handles .Rmd.

Includes fixtures reproducing the example from the issue and CLI tests confirming that real links are extracted while code-block URLs are skipped by default.

Closes #2157