### PR TITLE
Update all container images to debian trixie

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.236.0/containers/rust/.devcontainer/base.Dockerfile
-# [Choice] Debian OS version (use bookworm on local arm64/Apple Silicon): buster, bullseye, bookworm
-ARG VARIANT="bookworm"
+# See here for image contents: https://github.com/devcontainers/images/blob/v0.4.26/src/rust/.devcontainer/Dockerfile
+# [Choice] Debian OS version (use bookworm, or bullseye on local arm64/Apple Silicon): bookworm, buster, bullseye
+ARG VARIANT="trixie"
 FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,9 +5,9 @@
 	"build": {
 		"dockerfile": "Dockerfile",
 		"args": {
-			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye, bookworm
-			// Use bookworm when on local on arm64/Apple Silicon.
-			"VARIANT": "bookworm"
+			// Use the VARIANT arg to pick a Debian OS version: bookworm, buster, bullseye
+			// Use bookworm, or bullseye on local arm64/Apple Silicon.
+			"VARIANT": "trixie"
 		}
 	},
 	"runArgs": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:bookworm as builder
+FROM rust:trixie AS builder
 
 RUN USER=root cargo new --bin lychee
 WORKDIR /lychee
@@ -23,7 +23,7 @@ RUN rm ./target/release/deps/lychee* \
 
 # Our production image starts here, which uses
 # the files from the builder image above.
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/Dockerfile-CI.Dockerfile
+++ b/Dockerfile-CI.Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim AS builder
+FROM debian:trixie-slim AS builder
 WORKDIR /builder
 
 ARG LYCHEE_VERSION="latest"
@@ -21,7 +21,7 @@ RUN apt-get update \
     && wget -O - "$BASE_URL/lychee-$ARCH-unknown-linux-gnu.tar.gz" | tar -xz --strip-components 1 \
     && chmod +x lychee
 
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \


### PR DESCRIPTION
Fixes: https://github.com/lycheeverse/lychee/issues/2174

Tested locally with:

```
docker build -f Dockerfile -t lychee . && docker run -it --rm lychee
docker build -f Dockerfile-CI.Dockerfile -t lychee . && docker run -it --rm lychee
```

```
lychee on  master is 📦 v0.24.1 via 🦀 v1.94.1 
❯ docker build -f Dockerfile-CI.Dockerfile -t lychee . && docker run -it --rm lychee
[+] Building 11.6s (10/10) FINISHED                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile-CI.Dockerfile                                                                                                                       0.0s
 => => transferring dockerfile: 1.62kB                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/debian:bookworm-slim                                                                                                                  1.5s
 => [auth] library/debian:pull token for registry-1.docker.io                                                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 218B                                                                                                                                                        0.0s
 => [builder 1/3] FROM docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252                                                    3.0s
 => => resolve docker.io/library/debian:bookworm-slim@sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252                                                            0.0s
 => => sha256:f9c6a2fd2ddbc23e336b6257a5245e31f996953ef06cd13a59fa0a1df2d5c252 8.56kB / 8.56kB                                                                                           0.0s
 => => sha256:5a2a80d11944804c01b8619bc967e31801ec39bf3257ab80b91070eb23625644 1.02kB / 1.02kB                                                                                           0.0s
 => => sha256:865980b94764cc4ba2e384501e3130fb7fa648847bc42d45f5be7f71f57d5d0f 453B / 453B                                                                                               0.0s
 => => sha256:ff86ea2e5edce334d19a34fbc65d1a511aa1fc823dba1110422f991aa56b44d4 28.24MB / 28.24MB                                                                                         2.0s
 => => extracting sha256:ff86ea2e5edce334d19a34fbc65d1a511aa1fc823dba1110422f991aa56b44d4                                                                                                0.9s
 => [stage-1 2/3] RUN apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install -y     --no-install-recommends     ca-certificates     tzdata     && rm -rf /var/cache/debco  5.0s
 => [builder 2/3] WORKDIR /builder                                                                                                                                                       0.1s
 => [builder 3/3] RUN apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         ca-certificates         jq         wget     && rm -rf /va  6.7s
 => [stage-1 3/3] COPY --from=builder /builder/lychee /usr/local/bin/lychee                                                                                                              0.0s
 => exporting to image                                                                                                                                                                   0.1s 
 => => exporting layers                                                                                                                                                                  0.0s 
 => => writing image sha256:9118737979d5957a4aa565905096e5b8212bba8ac85abb81b0cef0897fe3413d                                                                                             0.0s 
 => => naming to docker.io/library/lychee                                                                                                                                                0.0s 
/usr/local/bin/lychee: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /usr/local/bin/lychee)                                                                    
/usr/local/bin/lychee: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by /usr/local/bin/lychee)                                                                    
                                                                                                                             
lychee on  update-container-base is 📦 v0.24.1 via 🦀 v1.94.1                                                                                                              
❯ docker build -f Dockerfile-CI.Dockerfile -t lychee . && docker run -it --rm lychee
[+] Building 11.4s (9/9) FINISHED                                                                                                                                              docker:default
 => [internal] load build definition from Dockerfile-CI.Dockerfile                                                                                                                       0.0s
 => => transferring dockerfile: 1.62kB                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/debian:trixie-slim                                                                                                                    0.9s
 => [internal] load .dockerignore                                                                                                                                                        0.0s
 => => transferring context: 218B                                                                                                                                                        0.0s
 => [builder 1/3] FROM docker.io/library/debian:trixie-slim@sha256:cedb1ef40439206b673ee8b33a46a03a0c9fa90bf3732f54704f99cb061d2c5a                                                      2.9s
 => => resolve docker.io/library/debian:trixie-slim@sha256:cedb1ef40439206b673ee8b33a46a03a0c9fa90bf3732f54704f99cb061d2c5a                                                              0.0s
 => => sha256:cedb1ef40439206b673ee8b33a46a03a0c9fa90bf3732f54704f99cb061d2c5a 8.97kB / 8.97kB                                                                                           0.0s
 => => sha256:e18da95f66066b7c5fa31491b524e83121271eca59a3d140f4906c8d0a090367 1.02kB / 1.02kB                                                                                           0.0s
 => => sha256:babdb8c14969eea7cb8a7f552c5f9423bf0127615e05aefaa3b25bd2db32ee3d 451B / 451B                                                                                               0.0s
 => => sha256:3531af2bc2a9c8883754652783cf96207d53189db279c9637b7157d034de7ecd 29.78MB / 29.78MB                                                                                         1.9s
 => => extracting sha256:3531af2bc2a9c8883754652783cf96207d53189db279c9637b7157d034de7ecd                                                                                                0.9s
 => [builder 2/3] WORKDIR /builder                                                                                                                                                       0.1s
 => [stage-1 2/3] RUN apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install -y     --no-install-recommends     ca-certificates     tzdata     && rm -rf /var/cache/debco  5.8s
 => [builder 3/3] RUN apt-get update     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends         ca-certificates         jq         wget     && rm -rf /va  7.4s
 => [stage-1 3/3] COPY --from=builder /builder/lychee /usr/local/bin/lychee                                                                                                              0.0s 
 => exporting to image                                                                                                                                                                   0.1s 
 => => exporting layers                                                                                                                                                                  0.0s 
 => => writing image sha256:135c6693a8b502823f75e4c0b43a5da82e0b64e96d432d51ab77e33d8e4806d8                                                                                             0.0s 
 => => naming to docker.io/library/lychee                                                                                                                                                0.0s 
A fast, async link checker                                                                                                                                                                    
                                                                                                                                                                                              
Usage: lychee [OPTIONS] [inputs]...                                                                                                                                                           
                                                                                                                                                                                              
Arguments:                                                                                                                                                                                    
  [inputs]...  Inputs for link checking (where to get links to check from).                                                                                                                   
               These can be: files (e.g. `README.md`), file globs (e.g. `'~/git/*/README.md'`),                                                                                               
               remote URLs (e.g. `https://example.com/README.md`), or standard input (`-`).
               Alternatively, use `--files-from` to read inputs from a file.

```
