### PR TITLE
chore: release v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2299,7 +2299,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4230,7 +4230,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.24.2"
+version = "0.25.0"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.2"
+version = "0.25.0"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Available as command-line utility,
 - [Commandline usage](#commandline-usage)
 - [Supported file formats](#supported-file-formats)
 - [Library usage](#library-usage)
-- [GitHub Action Usage](#github-action-usage)
 - [Pre-commit Usage](#pre-commit-usage)
 - [Contributing to lychee](#contributing-to-lychee)
 - [Troubleshooting and Workarounds](#troubleshooting-and-workarounds)

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.2...lychee-v0.25.0) - 2026-05-29
+
+### Fixed
+
+- hide "cannot send response to queue: SendError" message ([#2209](https://github.com/lycheeverse/lychee/pull/2209))
+
+### Other
+
+- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
+- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
+- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
+- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
+- *(deps)* bump the dependencies group across 1 directory with 7 updates
+- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
+- *(deps)* bump the dependencies group with 2 updates
+- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
+
 ## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.1...lychee-v0.24.2) - 2026-04-30
 
 ### Added

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.24.2", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.25.0", default-features = false }
 
 anyhow = "1.0.102"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.2...lychee-lib-v0.25.0) - 2026-05-29
+
+### Other
+
+- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
+- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
+- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
+- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
+- Don't unwrap events
+- Extract methods & better error handling
+- *(deps)* bump the dependencies group across 1 directory with 7 updates
+- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
+- *(deps)* bump the dependencies group with 2 updates
+- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
+
 ## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.1...lychee-lib-v0.24.2) - 2026-04-30
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.24.2 -> 0.25.0 (⚠ API breaking changes)
* `lychee`: 0.24.2 -> 0.25.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/inherent_method_missing.ron

Failed in:
  Request::with_credentials, previously in file /tmp/.tmpTiA8EM/lychee-lib/src/types/request.rs:72

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lychee_lib::Client::check_website takes 2 parameters in /tmp/.tmpTiA8EM/lychee-lib/src/client.rs:622, but now takes 1 parameters in /tmp/.tmpvEbVzv/lychee/lychee-lib/src/client.rs:625

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field credentials of struct Request, previously in file /tmp/.tmpTiA8EM/lychee-lib/src/types/request.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.2...lychee-lib-v0.25.0) - 2026-05-29

### Other

- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
- Don't unwrap events
- Extract methods & better error handling
- *(deps)* bump the dependencies group across 1 directory with 7 updates
- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
- *(deps)* bump the dependencies group with 2 updates
- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
</blockquote>

## `lychee`

<blockquote>

## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.2...lychee-v0.25.0) - 2026-05-29

### Fixed

- hide "cannot send response to queue: SendError" message ([#2209](https://github.com/lycheeverse/lychee/pull/2209))

### Other

- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
- *(deps)* bump the dependencies group across 1 directory with 7 updates
- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
- *(deps)* bump the dependencies group with 2 updates
- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).