### PR TITLE
ci: move binstall-check to on release and use `/nightly/` URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,24 +68,6 @@ jobs:
       - name: Verify the MSRV
         run: make verify
 
-  binstall-check:
-    runs-on: ubuntu-latest
-    # Skip on release-plz PRs: those bump the version to one that has not been
-    # published yet, so binstall cannot find a matching release. We still want
-    # PR coverage on regular PRs to catch regressions in the binstall metadata.
-    if: ${{ !startsWith(github.head_ref, 'release-plz-') }}
-    env:
-      # Authenticate against api.github.com to avoid 403 rate-limit failures
-      # when binstall queries GitHub releases.
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v6
-      - uses: cargo-bins/cargo-binstall@main
-      # Use `--manifest-path .` so binstall validates the in-tree binstall
-      # metadata. Resolving against the latest published version would mask
-      # metadata fixes (e.g. #2165) until after the next release ships.
-      - run: cargo binstall --manifest-path . --strategies crate-meta-data lychee --no-confirm
-
   publish-check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -326,3 +326,21 @@ jobs:
         run: |
           version="${{ needs.create-release.outputs.tag_name }}"
           gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }}
+
+  binstall-check:
+    needs: [build-release]
+    runs-on: ubuntu-latest
+    env:
+      # Avoid 403 rate-limit failures when binstall queries GitHub releases.
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cargo-bins/cargo-binstall@main
+
+      # Uses nightly to preview upcoming release archive changes.
+      - run: sed -i.bak 's|/{ name }-v{ version }/|/nightly/|' lychee-bin/Cargo.toml
+        if: github.event.release.prerelease
+
+      # Use `--manifest-path .` so binstall validates the in-tree binstall metadata.
+      - run: cargo binstall --manifest-path . --strategies crate-meta-data lychee --no-confirm --verbose
+


### PR DESCRIPTION
running in the release-binary workflow and after the build-release step means that the release binaries will always be available when the binstall check runs.

for nightly releases, we also change the URL to `/nightly/` which lets us preview upcoming archive structure changes in the next version.



should fix https://github.com/lycheeverse/lychee/pull/2170#issuecomment-4360450732, but i can't test it.

moving the check into release-binary might make a failing check less visible, but maybe that's okay. we should keep an eye on https://github.com/lycheeverse/lychee/actions?query=event%3Aschedule+event%3Arelease or add the badges somewhere visible, maybe in the release PR text.