### PR TITLE
chore: generate artifact attestations for release assets

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -339,6 +339,12 @@ jobs:
           # uploads idempotent across reruns or overlapping triggers.
           gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }} --clobber
 
+      - name: Upload release asset digest
+        uses: actions/upload-artifact@v7
+        with:
+          path: ${{ env.ASSET_SUM }}
+          archive: false
+
   binstall-check:
     needs: [build-release]
     runs-on: ubuntu-latest
@@ -356,3 +362,26 @@ jobs:
       # Use `--manifest-path .` so binstall validates the in-tree binstall metadata.
       - run: cargo binstall --manifest-path . --strategies crate-meta-data lychee --no-confirm --verbose
 
+  attest:
+    name: attest
+    needs: [build-release]
+    runs-on: ubuntu-latest
+    permissions:
+      attestations: write # to write attestations
+      id-token: write # to sign attestations
+    steps:
+      - name: Download release asset digests
+        uses: actions/download-artifact@v8
+        with:
+          path: release-asset-digests/
+          merge-multiple: true
+
+      - name: Combine release asset digests
+        shell: bash
+        run: |
+          cat release-asset-digests/*.sha256 >release-asset-digests.sha256
+
+      - name: Generate release asset artifact attestations
+        uses: actions/attest@v4
+        with:
+          subject-checksums: release-asset-digests.sha256

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -378,7 +378,9 @@ jobs:
     permissions:
       attestations: write # to write attestations
       id-token: write # to sign attestations
-      artifact-metadata: write # required by actions/attest@v4
+      # artifact-metadata: write is documented as required by actions/attest@v4.
+      # However, it does not actually seem to be required in our use of the action,
+      # and the documentation around it is quite terse, so omitting for now.
     steps:
       - name: Download release asset digests
         uses: actions/download-artifact@v8

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -294,7 +294,11 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         run: |
           7z a "$ARCHIVE.zip" "$ARCHIVE"
-          certutil -hashfile "$ARCHIVE.zip" SHA256 > "$ARCHIVE.zip.sha256"
+          # Use shasum (bundled with Git for Windows) instead of certutil so the
+          # checksum file matches the shasum format that the attest job feeds to
+          # `subject-checksums`. certutil's multi-line, filename-less output is
+          # not a valid checksums file.
+          shasum -a 256 "$ARCHIVE.zip" > "$ARCHIVE.zip.sha256"
           echo "ASSET=$ARCHIVE.zip" >> $GITHUB_ENV
           echo "ASSET_SUM=$ARCHIVE.zip.sha256" >> $GITHUB_ENV
 
@@ -339,11 +343,16 @@ jobs:
           # uploads idempotent across reruns or overlapping triggers.
           gh release upload "$version" ${{ env.ASSET }} ${{ env.ASSET_SUM }} --clobber
 
-      - name: Upload release asset digest
+      - name: Upload release asset digests
         uses: actions/upload-artifact@v7
         with:
-          path: ${{ env.ASSET_SUM }}
-          archive: false
+          # Artifact names must be unique within a run, so key it on the target.
+          # Glob every *.sha256 instead of a single file because the aarch64-macos
+          # job produces two digests (tar.gz + dmg); `archive: false` only allows
+          # one file and would silently drop them.
+          name: release-asset-digests-${{ matrix.target }}
+          path: "*.sha256"
+          if-no-files-found: error
 
   binstall-check:
     needs: [build-release]
@@ -369,6 +378,7 @@ jobs:
     permissions:
       attestations: write # to write attestations
       id-token: write # to sign attestations
+      artifact-metadata: write # required by actions/attest@v4
     steps:
       - name: Download release asset digests
         uses: actions/download-artifact@v8


### PR DESCRIPTION
https://docs.github.com/en/actions/concepts/security/artifact-attestations

This makes use of workflow artifacts to accomplish generating a single combined attestation for all release assets. Generating one per asset is kind of an antipattern, could at present generate one for successful matrix entries even when some others in it fail, as well as require id-token and attestations permission for the build process. Doing it this way with workflow artifacts is a bit clunky, but it currently serves as a widely used workaround for inability to nicely set and consume multiple outputs from matrix builds.

Python wheel builds already have the attestations, per the maturin generated workflow.

Caveat: untested, but I suppose it could work. Anyway as the asset job is a separate one after release builds, a failure in it should not prevent GitHub release from succeeding.