### PR TITLE
Use hints for root-relative links error

### DIFF
--- a/lychee-bin/src/hints.rs
+++ b/lychee-bin/src/hints.rs
@@ -123,7 +123,7 @@ fn root_relative_links(stats: &ResponseStats) {
         hint!(
             "Unresolved root-relative links in local files. \
             To resolve these links to a local directory, provide a root dir with `--root-dir`. \
-            Alternatively, if the site should be relocatable, consider using locally-relative links."
+            Alternatively, if the site should be relocatable, consider using directory-relative links instead."
         );
     }
 }

--- a/lychee-bin/src/hints.rs
+++ b/lychee-bin/src/hints.rs
@@ -122,7 +122,7 @@ fn root_relative_links(stats: &ResponseStats, _config: &Config) {
     if any_root_relative_links {
         hint!(
             "Unresolved root-relative links in local files. \
-            To resolve these links to a local directory, provide a root dir. \
+            To resolve these links to a local directory, provide a root dir with `--root-dir`. \
             Alternatively, if the site should be relocatable, consider using locally-relative links."
         );
     }

--- a/lychee-bin/src/hints.rs
+++ b/lychee-bin/src/hints.rs
@@ -1,5 +1,5 @@
 use http::StatusCode;
-use lychee_lib::{ErrorKind, Status, StatusCodeSelector, hint};
+use lychee_lib::{ErrorKind, RequestError, Status, StatusCodeSelector, hint};
 
 use crate::{config::Config, formatters::stats::ResponseStats};
 
@@ -10,6 +10,7 @@ pub(crate) fn handle_stats(stats: &ResponseStats, config: &Config) {
     any_redirects(stats, config);
     rejected_status_codes(stats, config);
     unfollowed_redirects(stats, config);
+    root_relative_links(stats, config);
 }
 
 fn rate_limit(stats: &ResponseStats, config: &Config) {
@@ -106,6 +107,23 @@ fn unfollowed_redirects(stats: &ResponseStats, config: &Config) {
             "Rejected redirectional status codes. \
              This means some redirects were not followed. \
              You might want to increase the limit for `-m`/`--max-redirects`."
+        );
+    }
+}
+
+fn root_relative_links(stats: &ResponseStats, _config: &Config) {
+    let any_root_relative_links = stats.error_map.values().flatten().any(|r| match &r.status {
+        Status::RequestError(RequestError::CreateRequestItem(_, _, e)) => {
+            matches!(**e, ErrorKind::RootRelativeLinkWithoutRoot(_))
+        }
+        _ => false,
+    });
+
+    if any_root_relative_links {
+        hint!(
+            "Unresolved root-relative links in local files. \
+            To resolve these links to a local directory, provide a root dir. \
+            Alternatively, if the site should be relocatable, consider using locally-relative links."
         );
     }
 }

--- a/lychee-bin/src/hints.rs
+++ b/lychee-bin/src/hints.rs
@@ -10,7 +10,7 @@ pub(crate) fn handle_stats(stats: &ResponseStats, config: &Config) {
     any_redirects(stats, config);
     rejected_status_codes(stats, config);
     unfollowed_redirects(stats, config);
-    root_relative_links(stats, config);
+    root_relative_links(stats);
 }
 
 fn rate_limit(stats: &ResponseStats, config: &Config) {
@@ -111,7 +111,7 @@ fn unfollowed_redirects(stats: &ResponseStats, config: &Config) {
     }
 }
 
-fn root_relative_links(stats: &ResponseStats, _config: &Config) {
+fn root_relative_links(stats: &ResponseStats) {
     let any_root_relative_links = stats.error_map.values().flatten().any(|r| match &r.status {
         Status::RequestError(RequestError::CreateRequestItem(_, _, e)) => {
             matches!(**e, ErrorKind::RootRelativeLinkWithoutRoot(_))

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -4029,7 +4029,11 @@ file:///TMP/a/b/c/ROOT/server/1/up-one.html
             .write_stdin("[a](/a)")
             .assert()
             .failure()
-            .stdout(contains("Cannot resolve root-relative link '/a': To resolve root-relative links in local files, provide a root dir"));
+            .stdout(contains("Cannot resolve root-relative link '/a'"))
+            .stderr(contains(
+                "To resolve these links to a local directory, provide a root dir. \
+                Alternatively, if the site should be relocatable, consider using locally-relative links."
+            ));
 
         // with root-dir, locally-relative links can still fail because
         // there is no current base URL

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -4031,8 +4031,8 @@ file:///TMP/a/b/c/ROOT/server/1/up-one.html
             .failure()
             .stdout(contains("Cannot resolve root-relative link '/a'"))
             .stderr(contains(
-                "To resolve these links to a local directory, provide a root dir. \
-                Alternatively, if the site should be relocatable, consider using locally-relative links."
+                "To resolve these links to a local directory, provide a root dir with `--root-dir`. \
+                Alternatively, if the site should be relocatable, consider using directory-relative links instead."
             ));
 
         // with root-dir, locally-relative links can still fail because

--- a/lychee-lib/src/types/error.rs
+++ b/lychee-lib/src/types/error.rs
@@ -242,9 +242,6 @@ impl ErrorKind {
 
                 format!("{self}{detail}")
             }
-            ErrorKind::RootRelativeLinkWithoutRoot(_) => {
-                format!("{self}: To resolve root-relative links in local files, provide a root dir")
-            }
             ErrorKind::BuildRequestClient(_) => {
                 format!("{self}: Check system configuration")
             }
@@ -318,6 +315,7 @@ impl ErrorKind {
             | ErrorKind::WikilinkNotFound(_, _)
             | ErrorKind::EmptyUrl
             | ErrorKind::InvalidUrlHost
+            | ErrorKind::RootRelativeLinkWithoutRoot(_)
             | ErrorKind::PreprocessorError {
                 command: _,
                 reason: _,


### PR DESCRIPTION
Fixes https://github.com/lycheeverse/lychee/issues/2195 by moving the suggestion into a user hint and adding a sentence about possible impacts on relocatable sites.

New error looks like:
```
Issues found in 1 input. Find details below.

[a.md]:
 [ERROR] error: (at 4:1) | Cannot resolve root-relative link '/a'

🔍 3 Total (in 60ms) 🔗 3 Unique ✅ 0 OK 🚫 3 Errors

Hint: Unresolved root-relative links in local files. To resolve root-relative links to a local directory, provide a root dir. Alternatively, if the site should be relocatable, consider using locally-relative links.
```

Happy to tweak any part of the phrasing.

I've kept it as "locally-relative" (rather than @ roberth's suggestion of page-/document-relative), because I think it's more straightforward when it refers to files on disk. Page and document both need the user to think about web pages before connecting it a file path. MDN calls them [current directory relative](https://developer.mozilla.org/en-US/docs/Web/API/URL_API/Resolving_relative_references#current_directory_relative). That's a bit long but I also wouldn't mind "directory-relative".