### PR TITLE
chore(deps): bump the dependencies group across 1 directory with 7 updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -281,6 +281,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -473,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -906,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1479,7 +1488,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9efcab3c1958580ff1f25a2a41be1668f7603d849bb63af523b208a3cc1223b8"
 dependencies = [
  "cfg-if",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "futures-sink",
  "futures-timer",
  "futures-util",
@@ -2302,7 +2311,7 @@ dependencies = [
  "const_format",
  "cookie_store",
  "csv",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "env_logger",
  "futures",
  "headers",
@@ -2346,7 +2355,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "cookie_store",
- "dashmap 6.1.0",
+ "dashmap 6.2.1",
  "doc-comment",
  "email_address",
  "futures",
@@ -2369,7 +2378,7 @@ dependencies = [
  "percent-encoding",
  "pretty_assertions",
  "pulldown-cmark",
- "quick-xml 0.39.2",
+ "quick-xml 0.40.1",
  "regex",
  "reqwest",
  "reqwest_cookie_store",
@@ -2599,9 +2608,9 @@ checksum = "f2dcb6053ab98da45585315f79932c5c9821fab8efa4301c0d7b637c91630eb7"
 
 [[package]]
 name = "octocrab"
-version = "0.49.9"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddbc3bb87e8c680febf16f56855bbd8b44a38e18c913334213ab34908e71a09"
+checksum = "eb2ad8abffe4e2b05f9cdc7e061de63d305a6dca0af81ca1064a7d98e0b78267"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -2610,7 +2619,6 @@ dependencies = [
  "cargo_metadata",
  "cfg-if",
  "chrono",
- "either",
  "futures",
  "futures-util",
  "getrandom 0.2.17",
@@ -2641,9 +2649,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -3119,9 +3127,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
 ]
@@ -3808,11 +3816,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3827,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4349,9 +4358,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 [dependencies]
 lychee-lib = { path = "../lychee-lib", default-features = false }
 criterion = "0.8.2"
-tokio = "1.52.2"
+tokio = "1.52.3"
 
 [features]
 email-check = ["lychee-lib/email-check"]

--- a/examples/archive/Cargo.toml
+++ b/examples/archive/Cargo.toml
@@ -9,7 +9,7 @@ path = "archive.rs"
 
 [dependencies]
 lychee-lib = { path = "../../lychee-lib", default-features = false }
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 url = "2.5.8"
 
 [features]

--- a/examples/builder/Cargo.toml
+++ b/examples/builder/Cargo.toml
@@ -9,7 +9,7 @@ path = "builder.rs"
 
 [dependencies]
 lychee-lib = { path = "../../lychee-lib", default-features = false }
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 regex = "1.12.2"
 http = "1.4.0"
 reqwest = "0.13.3"

--- a/examples/chain/Cargo.toml
+++ b/examples/chain/Cargo.toml
@@ -11,7 +11,7 @@ path = "chain.rs"
 async-trait = "0.1.88"
 lychee-lib = { path = "../../lychee-lib", default-features = false }
 reqwest = "0.13.3"
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 
 [features]
 email-check = ["lychee-lib/email-check"]

--- a/examples/client_pool/Cargo.toml
+++ b/examples/client_pool/Cargo.toml
@@ -11,7 +11,7 @@ path = "client_pool.rs"
 futures = "0.3.32"
 tokio-stream = "0.1.18"
 lychee-lib = { path = "../../lychee-lib", default-features = false }
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 
 [features]
 email-check = ["lychee-lib/email-check"]

--- a/examples/collect_links/Cargo.toml
+++ b/examples/collect_links/Cargo.toml
@@ -9,7 +9,7 @@ path = "collect_links.rs"
 
 [dependencies]
 lychee-lib = { path = "../../lychee-lib",  default-features = false }
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 regex = "1.12.2"
 http = "1.4.0"
 tokio-stream = "0.1.18"

--- a/examples/extract/Cargo.toml
+++ b/examples/extract/Cargo.toml
@@ -9,7 +9,7 @@ path = "extract.rs"
 
 [dependencies]
 lychee-lib = { path = "../../lychee-lib", default-features = false }
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 
 [features]
 email-check = ["lychee-lib/email-check"]

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -9,7 +9,7 @@ path = "simple.rs"
 
 [dependencies]
 lychee-lib = { path = "../../lychee-lib", default-features = false }
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 
 [features]
 email-check = ["lychee-lib/email-check"]

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -20,12 +20,12 @@ lychee-lib = { path = "../lychee-lib", version = "0.24.2", default-features = fa
 anyhow = "1.0.102"
 assert-json-diff = "2.0.2"
 clap = { version = "4.6.1", features = ["env", "derive", "cargo", "string"] }
-clap_complete = "4.6.3"
+clap_complete = "4.6.5"
 clap_mangen = "0.3.0"
 console = "0.16.3"
 const_format = "0.2.36"
 csv = "1.4.0"
-dashmap = { version = "6.1.0", features = ["serde"] }
+dashmap = { version = "6.2.1", features = ["serde"] }
 env_logger = "0.11.10"
 futures = "0.3.32"
 headers = "0.4.1"
@@ -51,14 +51,14 @@ serde_json = "1.0.149"
 strum = { version = "0.28.0", features = ["derive"] }
 supports-color = "3.0.2"
 tabled = "0.20.0"
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 tokio-stream = "0.1.18"
 toml = "1.1.2"
 url = "2.5.8"
 quick-junit = "0.6.0"
 
 [dev-dependencies]
-assert_cmd = "2.2.1"
+assert_cmd = "2.2.2"
 cookie_store = "0.22.1"
 predicates = "3.1.4"
 pretty_assertions = "1.4.1"

--- a/lychee-lib/Cargo.toml
+++ b/lychee-lib/Cargo.toml
@@ -16,7 +16,7 @@ rust-version = "1.88.0"
 async-stream = "0.3.6"
 async-trait = "0.1.88"
 cookie_store = "0.22.1"
-dashmap = { version = "6.1.0" }
+dashmap = { version = "6.2.1" }
 email_address = "0.2.9"
 futures = "0.3.32"
 glob = "0.3.3"
@@ -33,7 +33,7 @@ ip_network = "0.4.1"
 linkify = "0.11.0"
 log = "0.4.28"
 mailify-lib = { version = "0.2.0", optional = true }
-octocrab = { version = "0.49.9", default-features = false, features = [
+octocrab = { version = "0.51.0", default-features = false, features = [
     "default-client",
     "follow-redirect",
     "jwt-rust-crypto",
@@ -47,7 +47,7 @@ octocrab = { version = "0.49.9", default-features = false, features = [
 ] }
 percent-encoding = "2.3.1"
 pulldown-cmark = "0.13.3"
-quick-xml = "0.39.2"
+quick-xml = "0.40.1"
 regex = "1.12.2"
 reqwest = { version = "0.13.3", features = ["json", "gzip"] }
 reqwest_cookie_store = { version = "0.10.0", features = ["serde"] }
@@ -58,11 +58,11 @@ reqwest_cookie_store = { version = "0.10.0", features = ["serde"] }
 ring = "0.17.14"
 secrecy = "0.10.3"
 serde = { version = "1.0.228", features = ["derive"] }
-serde_with = "3.19.0"
+serde_with = "3.20.0"
 shellexpand = "3.1.2"
 strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.18"
-tokio = { version = "1.52.2", features = ["full"] }
+tokio = { version = "1.52.3", features = ["full"] }
 toml = "1.1.2"
 typed-builder = "0.23.2"
 url = { version = "2.5.8", features = ["serde"] }

--- a/lychee-lib/src/extract/xml.rs
+++ b/lychee-lib/src/extract/xml.rs
@@ -1,4 +1,6 @@
 //! Extract links from XML documents. Currently supports sitemaps, RSS and Atom feeds.
+use std::borrow::Cow;
+
 use log::warn;
 use quick_xml::Reader;
 use quick_xml::events::Event;
@@ -17,12 +19,15 @@ pub(crate) fn extract_xml<S: SpanProvider>(input: &str, span_provider: &S) -> Ve
                 b"loc" /* sitemap */ | b"link" /* RSS */ => {
                     let start_of_text_offset: usize = reader.buffer_position().try_into().unwrap_or_default();
                     let element = String::from_utf8(e.name().as_ref().to_vec()).unwrap_or_default();
-                    let text = reader.read_text(e.name()).unwrap_or_default().as_ref().to_string();
+                    let text = match reader.read_text(e.name()) {
+                        Ok(bytes_text) => bytes_text.decode().unwrap_or_default(),
+                        Err(_) => Cow::default(),
+                    };
                     let span = span_provider.span(start_of_text_offset);
 
                     if !text.is_empty() && !element.is_empty() {
                         uris.push(RawUri {
-                            text,
+                            text: text.into_owned(),
                             element: Some(element),
                             attribute: None,
                             span


### PR DESCRIPTION
manually     fix quick_xml `BytesText` decoding
    
previously, `read_text` returned a `Result<Cow<_>>`, but now it returns a `Result<BytesText<_>>`. we just add a pattern match to deal with this.

Fixes https://github.com/lycheeverse/lychee/pull/2199

https://github.com/tafia/quick-xml/releases/tag/v0.40.0
```
#944: read_text() now returns BytesText which allows you to get the
content with properly normalized EOLs. To get the previous behavior
use .read_text().decode()?.
```


-----------



Bumps the dependencies group with 7 updates in the / directory:

| Package | From | To |
| --- | --- | --- |
| [clap_complete](https://github.com/clap-rs/clap) | `4.6.3` | `4.6.5` |
| [dashmap](https://github.com/xacrimon/dashmap) | `6.1.0` | `6.2.1` |
| [tokio](https://github.com/tokio-rs/tokio) | `1.52.2` | `1.52.3` |
| [assert_cmd](https://github.com/assert-rs/assert_cmd) | `2.2.1` | `2.2.2` |
| [octocrab](https://github.com/XAMPPRocky/octocrab) | `0.49.9` | `0.51.0` |
| [quick-xml](https://github.com/tafia/quick-xml) | `0.39.2` | `0.40.1` |
| [serde_with](https://github.com/jonasbb/serde_with) | `3.19.0` | `3.20.0` |



Updates `clap_complete` from 4.6.3 to 4.6.5
- [Release notes](https://github.com/clap-rs/clap/releases)
- [Changelog](https://github.com/clap-rs/clap/blob/master/CHANGELOG.md)
- [Commits](clap-rs/clap@clap_complete-v4.6.3...clap_complete-v4.6.5)

Updates `dashmap` from 6.1.0 to 6.2.1
- [Release notes](https://github.com/xacrimon/dashmap/releases)
- [Commits](xacrimon/dashmap@v6.1.0...v6.2.1)

Updates `tokio` from 1.52.2 to 1.52.3
- [Release notes](https://github.com/tokio-rs/tokio/releases)
- [Commits](tokio-rs/tokio@tokio-1.52.2...tokio-1.52.3)

Updates `assert_cmd` from 2.2.1 to 2.2.2
- [Changelog](https://github.com/assert-rs/assert_cmd/blob/master/CHANGELOG.md)
- [Commits](assert-rs/assert_cmd@v2.2.1...v2.2.2)

Updates `octocrab` from 0.49.9 to 0.51.0
- [Release notes](https://github.com/XAMPPRocky/octocrab/releases)
- [Changelog](https://github.com/XAMPPRocky/octocrab/blob/main/CHANGELOG.md)
- [Commits](XAMPPRocky/octocrab@v0.49.9...v0.51.0)

Updates `quick-xml` from 0.39.2 to 0.40.1
- [Release notes](https://github.com/tafia/quick-xml/releases)
- [Changelog](https://github.com/tafia/quick-xml/blob/master/Changelog.md)
- [Commits](tafia/quick-xml@v0.39.2...v0.40.1)

Updates `serde_with` from 3.19.0 to 3.20.0
- [Release notes](https://github.com/jonasbb/serde_with/releases)
- [Commits](jonasbb/serde_with@v3.19.0...v3.20.0)

---
updated-dependencies:
- dependency-name: clap_complete
  dependency-version: 4.6.5
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: dependencies
- dependency-name: dashmap
  dependency-version: 6.2.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: dependencies
- dependency-name: tokio
  dependency-version: 1.52.3
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: dependencies
- dependency-name: assert_cmd
  dependency-version: 2.2.2
  dependency-type: direct:production
  update-type: version-update:semver-patch
  dependency-group: dependencies
- dependency-name: octocrab
  dependency-version: 0.51.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: dependencies
- dependency-name: quick-xml
  dependency-version: 0.40.1
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: dependencies
- dependency-name: serde_with
  dependency-version: 3.20.0
  dependency-type: direct:production
  update-type: version-update:semver-minor
  dependency-group: dependencies
...

Signed-off-by: dependabot[bot] <support@github.com>