### PR TITLE
fix: count transport-layer failures in per-host statistics

### DIFF
--- a/lychee-bin/src/formatters/host_stats/detailed.rs
+++ b/lychee-bin/src/formatters/host_stats/detailed.rs
@@ -38,6 +38,9 @@ impl Display for DetailedHostStats {
             if stats.server_errors > 0 {
                 writeln!(f, "  Server errors (5xx): {}", stats.server_errors)?;
             }
+            if stats.network_errors > 0 {
+                writeln!(f, "  Network errors: {}", stats.network_errors)?;
+            }
 
             if let Some(median_time) = stats.median_request_time() {
                 writeln!(

--- a/lychee-bin/src/formatters/host_stats/markdown.rs
+++ b/lychee-bin/src/formatters/host_stats/markdown.rs
@@ -32,6 +32,8 @@ struct HostStatsTableEntry {
     requests: u64,
     #[tabled(rename = "Success Rate")]
     success_rate: String,
+    #[tabled(rename = "Network Errors")]
+    network_errors: u64,
     #[tabled(rename = "Median Time")]
     median_time: String,
     #[tabled(rename = "Cache Hit Rate")]
@@ -52,6 +54,7 @@ fn host_stats_table(host_stats: &HostStatsMap) -> String {
                 host: hostname.clone(),
                 requests: stats.total_requests,
                 success_rate: format!("{:.1}%", stats.success_rate() * 100.0),
+                network_errors: stats.network_errors,
                 median_time,
                 cache_hit_rate: format!("{:.1}%", stats.cache_hit_rate() * 100.0),
             }

--- a/lychee-bin/src/formatters/stats/json.rs
+++ b/lychee-bin/src/formatters/stats/json.rs
@@ -113,6 +113,7 @@ mod tests {
       "rate_limited": 1,
       "client_errors": 0,
       "server_errors": 1,
+      "network_errors": 0,
       "median_request_time_ms": null,
       "cache_hits": 1,
       "cache_misses": 4,

--- a/lychee-lib/src/ratelimit/host/host.rs
+++ b/lychee-lib/src/ratelimit/host/host.rs
@@ -182,6 +182,11 @@ impl Host {
         let response = match self.client.execute(request).await {
             Ok(response) => response,
             Err(e) => {
+                // Record the network error in the per-host totals.
+                self.stats
+                    .lock()
+                    .unwrap()
+                    .record_network_error(start_time.elapsed());
                 // Wrap network/HTTP errors to preserve the original error
                 return Err(ErrorKind::NetworkRequest(e));
             }

--- a/lychee-lib/src/ratelimit/host/stats.rs
+++ b/lychee-lib/src/ratelimit/host/stats.rs
@@ -38,6 +38,8 @@ pub struct HostStats {
     pub server_errors: u64,
     /// Number of client error responses (4xx, excluding 429)
     pub client_errors: u64,
+    /// Number of network errors (DNS, TCP, TLS, connection reset, no HTTP response received)
+    pub network_errors: u64,
     /// Timestamp of the last successful request
     pub last_success: Option<Instant>,
     /// Timestamp of the last rate limit response
@@ -53,6 +55,13 @@ pub struct HostStats {
 }
 
 impl HostStats {
+    /// Record a network error (DNS, TCP, TLS, connection reset, no HTTP response received)
+    pub fn record_network_error(&mut self, request_time: Duration) {
+        self.total_requests += 1;
+        self.network_errors += 1;
+        self.request_times.push(request_time);
+    }
+
     /// Record a response with status code and request duration
     pub fn record_response(&mut self, status_code: u16, request_time: Duration) {
         self.total_requests += 1;
@@ -107,7 +116,8 @@ impl HostStats {
         if self.total_requests == 0 {
             return 0.0;
         }
-        let errors = self.rate_limited + self.client_errors + self.server_errors;
+        let errors =
+            self.rate_limited + self.client_errors + self.server_errors + self.network_errors;
         #[allow(clippy::cast_precision_loss)]
         let error_rate = errors as f64 / self.total_requests as f64;
         error_rate * 100.0
@@ -209,13 +219,14 @@ impl Serialize for HostStats {
     {
         let median_request_time_ms = self.median_request_time().map(|d| d.as_millis());
 
-        let mut s = serializer.serialize_struct("HostStats", 11)?;
+        let mut s = serializer.serialize_struct("HostStats", 12)?;
         s.serialize_field("total_requests", &self.total_requests)?;
         s.serialize_field("successful_requests", &self.successful_requests)?;
         s.serialize_field("success_rate", &self.success_rate())?;
         s.serialize_field("rate_limited", &self.rate_limited)?;
         s.serialize_field("client_errors", &self.client_errors)?;
         s.serialize_field("server_errors", &self.server_errors)?;
+        s.serialize_field("network_errors", &self.network_errors)?;
         s.serialize_field("median_request_time_ms", &median_request_time_ms)?;
         s.serialize_field("cache_hits", &self.cache_hits)?;
         s.serialize_field("cache_misses", &self.cache_misses)?;
@@ -283,6 +294,30 @@ mod tests {
             stats.median_request_time(),
             Some(Duration::from_millis(150))
         );
+    }
+
+    #[test]
+    fn test_record_network_error_affects_totals_and_success_rate() {
+        let mut stats = HostStats::default();
+
+        // Two successful requests
+        stats.record_response(200, Duration::from_millis(100));
+        stats.record_response(200, Duration::from_millis(150));
+
+        // One network error (no HTTP status available)
+        stats.record_network_error(Duration::from_secs(30));
+
+        assert_eq!(stats.total_requests, 3);
+        assert_eq!(stats.successful_requests, 2);
+        assert_eq!(stats.network_errors, 1);
+        // Other error buckets must be untouched
+        assert_eq!(stats.client_errors, 0);
+        assert_eq!(stats.server_errors, 0);
+        assert_eq!(stats.rate_limited, 0);
+        // 2 successes out of 3 total -> success rate is 2/3
+        assert!((stats.success_rate() - (2.0 / 3.0)).abs() < 0.001);
+        // error_rate counts the network error too
+        assert!((stats.error_rate() - (1.0 / 3.0 * 100.0)).abs() < 0.001);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2202.

## Problem

The per-host statistics table reports an inaccurate success rate for hosts whose links fail at the transport layer (DNS lookup, TCP connect, TLS handshake, connection reset, etc.). Those failures returned early from `Host::perform_request` and never reached `update_stats`, so they were invisible to `total_requests` and to every error bucket. In a real run the top-of-report `ResponseStats` flagged two `kubernetes.io` errors while the per-host table reported `kubernetes.io | 74 requests | 100.0% success` for the same host.

Full root-cause analysis with code references in #2202.

## Change

Add a `network_errors` counter on `HostStats` and a corresponding `record_network_error` method, then call it from the `Err` arm of `Host::perform_request`. The failed request now contributes to `total_requests` (so the success-rate denominator is correct) and to a dedicated `network_errors` bucket (so the failure mode is visible in the output).

Surfaces touched:

- `HostStats` field + recording method + updated `error_rate`.
- `Serialize` impl: adds `network_errors` to the JSON output.
- Markdown formatter: new `Network Errors` column on the per-host table.
- Detailed text formatter: new line shown when `network_errors > 0` (mirrors the existing pattern for `client_errors` / `server_errors`).
- Compact formatter: intentionally unchanged. Its `% success` column already reflects the corrected math, and adding a column to its rigid one-line layout would be intrusive. Happy to add it if you'd prefer consistency across all three formatters.

Before (current):

```
| Host          | Requests | Success Rate | Median Time | Cache Hit Rate |
| kubernetes.io | 74       | 100.0%       | 109ms       | 41.2%          |
```

After:

```
| Host          | Requests | Success Rate | Network Errors | Median Time | Cache Hit Rate |
| kubernetes.io | 76       | 97.4%        | 2              | 109ms       | 41.2%          |
```

## Tests

- New unit test `test_record_network_error_affects_totals_and_success_rate` in `lychee-lib/src/ratelimit/host/stats.rs` asserts that a network error increments `total_requests` and `network_errors`, leaves the HTTP-status buckets untouched, and lowers the success rate accordingly.
- Existing JSON snapshot in `lychee-bin/src/formatters/stats/json.rs` updated to include the new field.

## Verification

- `cargo test --workspace --all-targets`: 534 passed, 0 failed.
- `make lint` (workspace clippy): clean.
- `cargo clippy --workspace --no-deps -- -D warnings`: clean.