### PR TITLE
Make auto-merge more conservative

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -9,10 +9,18 @@ jobs:
   auto-merge:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'lycheeverse/lychee'
+    # Note that this workflow is additionally restricted by the
+    # "Require status checks to pass before merging" GitHub setting.
+    # This means that auto-merges do not happen when tests fail.
     steps:
-      - name: Enable auto-merge for Dependabot PRs
-        # Merge all updates as long as they pass CI
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Auto-merge for Dependabot PRs
+        run: |
+          author_count=$(gh pr view "$PR_URL" --json commits --jq '[.commits[].authors[]] | length')
+          if [[ "$author_count" = "1" ]]; then
+            gh pr merge --auto --merge "$PR_URL"
+          else
+            echo PR seems to have been manually modified. Skipping auto merge!
+          fi
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Only do auto-merges when the pull-request contains exactly one commit author. This prevents pull-requests which are manually amended from being merged automatically.

This prevents me and others from redoing the mistake done in https://github.com/lycheeverse/lychee/pull/2199#issuecomment-4507063631