### PR TITLE
Remove deprecated flags from codebase.

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,9 +377,6 @@ Options:
           The provided base URL value must either be a URL (with scheme) or an absolute path.
           Note that certain URL schemes cannot be used as a base, e.g., `data` and `mailto`.
 
-      --base <BASE>
-          Deprecated; use `--base-url` instead
-
       --basic-auth <BASIC_AUTH>
           Basic authentication support. E.g. `http://example.com username:password`
 
@@ -437,9 +434,6 @@ Options:
 
       --exclude <EXCLUDE>
           Exclude URLs and mail addresses from checking. The values are treated as regular expressions
-
-      --exclude-file <EXCLUDE_FILE>
-          Deprecated; use `--exclude-path` instead
 
       --exclude-link-local[=<false|true>]
           Exclude link-local IP address range from checking

--- a/fixtures/lycheeignore/normal-exclude-file
+++ b/fixtures/lycheeignore/normal-exclude-file
@@ -1,1 +1,0 @@
-https://example.com/bar

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -380,11 +380,6 @@ pub(crate) struct Config {
     #[serde(default)]
     pub(crate) exclude: Vec<String>,
 
-    /// Deprecated; use `--exclude-path` instead
-    #[arg(long)]
-    #[serde(default)]
-    pub(crate) exclude_file: Vec<String>,
-
     /// Exclude paths from getting checked.
     /// The values are treated as regular expressions.
     #[arg(long)]
@@ -545,11 +540,6 @@ pub(crate) struct Config {
     // Using `-X` as a short param similar to curl
     #[arg(short = 'X', long)]
     method: Option<String>,
-
-    /// Deprecated; use `--base-url` instead
-    #[arg(long, value_parser = parse_base_info)]
-    #[serde(skip)]
-    pub(crate) base: Option<BaseInfo>,
 
     /// Base URL to use when resolving relative URLs in local files. If specified,
     /// relative links in local files are interpreted as being relative to the given
@@ -926,7 +916,6 @@ impl Config {
                 accept,
                 accept_timeouts,
                 archive,
-                base,
                 base_url,
                 basic_auth,
                 cache,
@@ -979,7 +968,6 @@ impl Config {
             },
             chain {
                 exclude,
-                exclude_file,
                 exclude_path,
                 include,
                 fallback_extensions,

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -197,26 +197,6 @@ fn load_config() -> Result<LycheeOptions> {
         opts.config.exclude.append(&mut read_lines(&lycheeignore)?);
     }
 
-    // TODO: Remove this warning and the parameter with 1.0
-    if !&opts.config.exclude_file.is_empty() {
-        warn!(
-            "WARNING: `--exclude-file` is deprecated and will soon be removed; use the `{LYCHEE_IGNORE_FILE}` file to ignore URL patterns instead. To exclude paths of files and directories, use `--exclude-path`."
-        );
-    }
-
-    // TODO: Remove this warning and the parameter with 1.0
-    if opts.config.base.is_some() {
-        warn!(
-            "WARNING: `--base` is deprecated and will soon be removed; use `--base-url` instead."
-        );
-    }
-
-    // Load excludes from file
-    for path in &opts.config.exclude_file {
-        let file = File::open(path)?;
-        opts.config.exclude.append(&mut read_lines(&file)?);
-    }
-
     handle_fd_limits(&mut opts);
 
     Ok(opts)
@@ -372,17 +352,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
             .any(|input| matches!(input.source, lychee_lib::InputSource::Stdin))
         && stdin().is_terminal();
 
-    // TODO: Remove this section after `--base` got removed with 1.0
-    let base = match (opts.config.base.clone(), opts.config.base_url.clone()) {
-        (None, base_url) => base_url,
-        (base, None) => base,
-        (_base, base_url) => {
-            warn!(
-                "WARNING: Both, `--base` and `--base-url` are set. Using `base-url` and ignoring `--base` (as it's deprecated)."
-            );
-            base_url
-        }
-    };
+    let base = opts.config.base_url.clone();
 
     if opts.config.dump_inputs() {
         let exit_code = commands::dump_inputs(

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1210,12 +1210,10 @@ mod cli {
 
         let regex = test_utils::arg_regex_help!()?;
         let excluded = [
-            "base",         // deprecated
-            "exclude_file", // deprecated
-            "config",       // not part of config
-            "quiet",        // not part of config
-            "help",         // special clap argument
-            "version",      // special clap argument
+            "config",  // not part of config
+            "quiet",   // not part of config
+            "help",    // special clap argument
+            "version", // special clap argument
         ];
 
         let arguments: Vec<String> = help_text
@@ -1301,25 +1299,6 @@ The config file should contain every possible key for documentation purposes."
         let output = cmd.get_output();
         let output = std::str::from_utf8(&output.stdout).unwrap();
         assert_eq!(output.lines().count(), 3);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_lycheeignore_and_exclude_file() -> Result<()> {
-        let test_path = fixtures_path!().join("lycheeignore");
-        let excludes_path = test_path.join("normal-exclude-file");
-
-        cargo_bin_cmd!()
-            .current_dir(test_path)
-            .arg("--insecure")
-            .arg("TEST.md")
-            .arg("--exclude-file")
-            .arg(excludes_path)
-            .assert()
-            .success()
-            .stdout(contains("8 Total"))
-            .stdout(contains("6 Excluded"));
 
         Ok(())
     }


### PR DESCRIPTION
Eventually we have to get rid of the long-deprecated flags in lychee. And I believe now is as good of a time as ever. We don't have to wait for 1.0 to hit (I believe). 

This affects the following flags:
- `--exclude-file`, which got replaced by `.lycheeignore`
- `--base`, superceded by `--base-url`.

Wdyt about merging this in and announcing the removal with the next release?

If we decide to do that, I can prepare a PR to update the lychee docs and the lychee action.