### PR TITLE
fix: hide "cannot send response to queue: SendError" message

### DIFF
--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -230,10 +230,7 @@ async fn request_channel_task(
             )
             .await;
 
-            send_resp
-                .send((guard, response))
-                .await
-                .expect("cannot send response to queue");
+            send_resp.send((guard, response)).await.unwrap_or_default();
         },
     )
     .await;


### PR DESCRIPTION
Fixes https://github.com/lycheeverse/lychee/issues/2189

The SendError message was just a distracting panic that was printed alongside a genuine error in another input URL.

It should be okay to just silence the warning. If sending has failed, then the channel has dropped which means we are heading towards a main thread exit which would print any necessary messages.