### PR TITLE
feat: plaintext link extraction based on GFM

### DIFF
--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -1,11 +1,8 @@
 use std::{borrow::Cow, ops::Range, sync::LazyLock};
 
-use regex::{CaptureMatches, Captures, Match, Regex};
+use regex::{Captures, Regex};
 
-use crate::{
-    types::uri::raw::{RawUri, SpanProvider},
-    utils::url,
-};
+use crate::types::uri::raw::{RawUri, SpanProvider};
 
 static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(
@@ -17,7 +14,7 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
     # https://github.github.com/gfm/#email-autolink
     | < (?P<email_autolink>
-        [a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+
+        [a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+
         @
         [a-zA-Z0-9]
         (?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
@@ -45,34 +42,34 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         [^[:space:]<]* )
 
     | (?P<extended_email_autolink>
-        [[:alnum:].-_+]+
+        [[:alnum:]._+-]+
         @
-        [[:alnum:]-_]+
+        [[:alnum:]_-]+
         (?: \. [[:alnum:]_-]+ )+ )
 
     | (?P<extended_protocol_autolink>
 
         mailto:
-        [[:alnum:].-_+]+
+        [[:alnum:]._+-]+
         @
-        [[:alnum:]-_]+
+        [[:alnum:]_-]+
         (?: \. [[:alnum:]_-]+ )+
 
         |
 
         xmpp:
-        [[:alnum:].-_+]+
+        [[:alnum:]._+-]+
         @
-        [[:alnum:]-_]+
+        [[:alnum:]_-]+
         (?: \. [[:alnum:]_-]+ )+
-        (?: / [[:alnum:]@.]+ )
+        (?: / [[:alnum:]@.]+ ) )
 
     "#,
     )
     .expect("gfm autolinks regex invalid")
 });
 
-pub enum Autolinks<'a> {
+pub enum Autolink<'a> {
     Uri(&'a str),
     Email(&'a str),
     ExtendedWww(&'a str),
@@ -81,7 +78,7 @@ pub enum Autolinks<'a> {
     ExtendedProtocol(&'a str),
 }
 
-impl<'a> Autolinks<'a> {
+impl<'a> Autolink<'a> {
     /// https://github.github.com/gfm/#extended-autolink-path-validation
     fn extended_autolink_path_validation(text: &str) -> &str {
         let mut text = text.trim_end_matches(&['?', '!', '.', ',', ':', '*', '_', '~']);
@@ -129,23 +126,23 @@ impl<'a> Autolinks<'a> {
     /// a
     pub fn raw_text(&self) -> &str {
         match self {
-            Autolinks::Uri(s)
-            | Autolinks::Email(s)
-            | Autolinks::ExtendedWww(s)
-            | Autolinks::ExtendedUrl(s)
-            | Autolinks::ExtendedEmail(s)
-            | Autolinks::ExtendedProtocol(s) => s,
+            Autolink::Uri(s)
+            | Autolink::Email(s)
+            | Autolink::ExtendedWww(s)
+            | Autolink::ExtendedUrl(s)
+            | Autolink::ExtendedEmail(s)
+            | Autolink::ExtendedProtocol(s) => s,
         }
     }
 
     /// a
     pub fn uri_text(&self) -> Cow<'a, str> {
         match self {
-            Autolinks::Uri(s) | Autolinks::ExtendedUrl(s) | Autolinks::ExtendedProtocol(s) => {
+            Autolink::Uri(s) | Autolink::ExtendedUrl(s) | Autolink::ExtendedProtocol(s) => {
                 Cow::Borrowed(s)
             }
-            Autolinks::Email(s) | Self::ExtendedEmail(s) => Cow::Owned(format!("mailto:{s}")),
-            Autolinks::ExtendedWww(s) => Cow::Owned(format!("http://{s}")),
+            Autolink::Email(s) | Self::ExtendedEmail(s) => Cow::Owned(format!("mailto:{s}")),
+            Autolink::ExtendedWww(s) => Cow::Owned(format!("http://{s}")),
         }
     }
 
@@ -184,7 +181,7 @@ pub(crate) fn extract_raw_uri_from_plaintext(
     input: &str,
     span_provider: &impl SpanProvider,
 ) -> Vec<RawUri> {
-    Autolinks::find(input)
+    Autolink::find(input)
         .map(|(autolink, range)| RawUri {
             text: autolink.uri_text().to_string(),
             element: None,
@@ -224,5 +221,19 @@ mod tests {
 
         let uris: Vec<RawUri> = extract(input);
         assert_eq!(vec![uri], uris);
+    }
+
+    #[test]
+    fn test_extract_email() {
+        let input = "foo@bar.baz\nhello@mail+xyz.example\nhello+xyz@mail.example";
+
+        let uris: Vec<String> = extract(input).into_iter().map(|x| x.text).collect();
+        assert_eq!(
+            uris,
+            vec![
+                "mailto:foo@bar.baz".to_string(),
+                "mailto:hello+xyz@mail.example".to_string()
+            ]
+        );
     }
 }

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -16,7 +16,7 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
     | < (?P<email_autolink>
         [a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+
         @
-        [^\s[:cntrl:]<>]* ) >
+        [^\s[:cntrl:]<>]+ ) >
 
     | (?P<extended_www_autolink>
         www\.
@@ -26,7 +26,7 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         (?: \. [[:alnum:]_-]+ )*
 
         # path:
-        [^ < \s [ \p{Punctuation} && [:^punct:] ] ]* )
+        [^ <> \s [ \p{Punctuation} && [:^punct:] ] ]* )
 
     | (?P<extended_url_autolink>
         https?://
@@ -36,7 +36,7 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         (?: \. [[:alnum:]_-]+ )*
 
         # path:
-        [^ < \s [ \p{Punctuation} && [:^punct:] ] ]* )
+        [^ <> \s [ \p{Punctuation} && [:^punct:] ] ]* )
 
     | (?P<extended_email_autolink>
         [[:alnum:]._+-]+

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -1,19 +1,195 @@
+use std::{borrow::Cow, ops::Range, sync::LazyLock};
+
+use regex::{CaptureMatches, Captures, Match, Regex};
+
 use crate::{
     types::uri::raw::{RawUri, SpanProvider},
     utils::url,
 };
+
+static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"(?x)(?i)
+
+    # https://github.github.com/gfm/#uri-autolink
+    < (?P<uri_autolink>
+        [a-z][a-z0-9+.-]{1,31} : [^[:space:][:cntrl:]<>]* ) >
+
+    # https://github.github.com/gfm/#email-autolink
+    | < (?P<email_autolink>
+        [a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+
+        @
+        [a-zA-Z0-9]
+        (?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
+        (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*
+        ) >
+
+    | (?P<extended_www_autolink>
+        www\.
+
+        # domain:
+        [[:alnum:]_-]+
+        (?: \. [[:alnum:]_-]+ )*
+
+        # path:
+        [^[:space:]<]* )
+
+    | (?P<extended_url_autolink>
+        https?://
+
+        # domain:
+        [[:alnum:]_-]+
+        (?: \. [[:alnum:]_-]+ )*
+
+        # path:
+        [^[:space:]<]* )
+
+    | (?P<extended_email_autolink>
+        [[:alnum:].-_+]+
+        @
+        [[:alnum:]-_]+
+        (?: \. [[:alnum:]_-]+ )+ )
+
+    | (?P<extended_protocol_autolink>
+
+        mailto:
+        [[:alnum:].-_+]+
+        @
+        [[:alnum:]-_]+
+        (?: \. [[:alnum:]_-]+ )+
+
+        |
+
+        xmpp:
+        [[:alnum:].-_+]+
+        @
+        [[:alnum:]-_]+
+        (?: \. [[:alnum:]_-]+ )+
+        (?: / [[:alnum:]@.]+ )
+
+    "#,
+    )
+    .expect("gfm autolinks regex invalid")
+});
+
+pub enum Autolinks<'a> {
+    Uri(&'a str),
+    Email(&'a str),
+    ExtendedWww(&'a str),
+    ExtendedUrl(&'a str),
+    ExtendedEmail(&'a str),
+    ExtendedProtocol(&'a str),
+}
+
+impl<'a> Autolinks<'a> {
+    /// https://github.github.com/gfm/#extended-autolink-path-validation
+    fn extended_autolink_path_validation(text: &str) -> &str {
+        let mut text = text.trim_end_matches(&['?', '!', '.', ',', ':', '*', '_', '~']);
+
+        if text.ends_with(')') {
+            let opens = text.matches('(').count();
+            let mut extra_closes = text.match_indices(')').skip(opens);
+            if let Some(first_extra_close) = extra_closes.next() {
+                text = &text[..first_extra_close.0];
+            }
+        }
+
+        if text.ends_with(';') {
+            if let Some((before, after)) = text.rsplit_once('&') {
+                if after.chars().all(|c| c.is_ascii_alphanumeric()) {
+                    text = before;
+                }
+            }
+        }
+
+        text
+    }
+
+    fn autolink_validation(autolink: Self) -> Option<Self> {
+        match autolink {
+            Self::Uri(_) | Self::Email(_) => Some(autolink),
+
+            Self::ExtendedWww(link) => Some(Self::ExtendedWww(
+                Self::extended_autolink_path_validation(link),
+            )),
+            Self::ExtendedUrl(link) => Some(Self::ExtendedUrl(
+                Self::extended_autolink_path_validation(link),
+            )),
+
+            Self::ExtendedEmail(link) | Self::ExtendedProtocol(link)
+                if link.ends_with(&['-', '_']) =>
+            {
+                None
+            }
+
+            Self::ExtendedEmail(_) | Self::ExtendedProtocol(_) => Some(autolink),
+        }
+    }
+
+    /// a
+    pub fn raw_text(&self) -> &str {
+        match self {
+            Autolinks::Uri(s)
+            | Autolinks::Email(s)
+            | Autolinks::ExtendedWww(s)
+            | Autolinks::ExtendedUrl(s)
+            | Autolinks::ExtendedEmail(s)
+            | Autolinks::ExtendedProtocol(s) => s,
+        }
+    }
+
+    /// a
+    pub fn uri_text(&self) -> Cow<'a, str> {
+        match self {
+            Autolinks::Uri(s) | Autolinks::ExtendedUrl(s) | Autolinks::ExtendedProtocol(s) => {
+                Cow::Borrowed(s)
+            }
+            Autolinks::Email(s) | Self::ExtendedEmail(s) => Cow::Owned(format!("mailto:{s}")),
+            Autolinks::ExtendedWww(s) => Cow::Owned(format!("http://{s}")),
+        }
+    }
+
+    fn from_capture(captures: Captures<'a>) -> Option<(Self, Range<usize>)> {
+        let autolink = if let Some(cap) = captures.name("uri_autolink") {
+            Self::Uri(cap.as_str())
+        } else if let Some(cap) = captures.name("email_autolink") {
+            Self::Email(cap.as_str())
+        } else if let Some(cap) = captures.name("extended_www_autolink") {
+            Self::ExtendedWww(cap.as_str())
+        } else if let Some(cap) = captures.name("extended_url_autolink") {
+            Self::ExtendedUrl(cap.as_str())
+        } else if let Some(cap) = captures.name("extended_email_autolink") {
+            Self::ExtendedEmail(cap.as_str())
+        } else if let Some(cap) = captures.name("extended_protocol_autolink") {
+            Self::ExtendedProtocol(cap.as_str())
+        } else {
+            panic!("regex had incorrect capture groups?!")
+        };
+
+        let autolink = Self::autolink_validation(autolink)?;
+        let start = captures.get_match().start();
+        let end = start + autolink.raw_text().len();
+        Some((autolink, Range { start, end }))
+    }
+
+    pub fn find(text: &'a str) -> impl Iterator<Item = (Self, Range<usize>)> {
+        GFM_AUTOLINKS_REGEX
+            .captures_iter(text)
+            .filter_map(Self::from_capture)
+    }
+}
 
 /// Extract unparsed URL strings from plaintext
 pub(crate) fn extract_raw_uri_from_plaintext(
     input: &str,
     span_provider: &impl SpanProvider,
 ) -> Vec<RawUri> {
-    url::find_links(input)
-        .map(|uri| RawUri {
-            text: uri.as_str().to_owned(),
+    Autolinks::find(input)
+        .map(|(autolink, range)| RawUri {
+            text: autolink.uri_text().to_string(),
             element: None,
             attribute: None,
-            span: span_provider.span(uri.start()),
+            span: span_provider.span(range.start),
         })
         .collect()
 }

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -80,9 +80,7 @@ pub enum Autolink<'a> {
 
 impl<'a> Autolink<'a> {
     /// https://github.github.com/gfm/#extended-autolink-path-validation
-    fn extended_autolink_path_validation(text: &str) -> &str {
-        let mut text = text.trim_end_matches(&['?', '!', '.', ',', ':', '*', '_', '~']);
-
+    fn extended_autolink_path_validation(mut text: &str) -> &str {
         if text.ends_with(')') {
             let opens = text.matches('(').count();
             let mut extra_closes = text.match_indices(')').skip(opens);
@@ -98,6 +96,8 @@ impl<'a> Autolink<'a> {
                 }
             }
         }
+
+        let text = text.trim_end_matches(&['?', '!', '.', ',', ':', '*', '_', '~']);
 
         text
     }

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -80,7 +80,11 @@ pub enum Autolink<'a> {
 
 impl<'a> Autolink<'a> {
     /// https://github.github.com/gfm/#extended-autolink-path-validation
-    fn extended_autolink_path_validation(mut text: &str) -> &str {
+    fn extended_autolink_path_validation(autolink: Self) -> Self {
+        let (Autolink::ExtendedWww(mut text) | Autolink::ExtendedUrl(mut text)) = autolink else {
+            return autolink;
+        };
+
         if text.ends_with(')') {
             let opens = text.matches('(').count();
             let mut extra_closes = text.match_indices(')').skip(opens);
@@ -99,28 +103,46 @@ impl<'a> Autolink<'a> {
 
         let text = text.trim_end_matches(&['?', '!', '.', ',', ':', '*', '_', '~']);
 
-        text
+        autolink.set_raw_text(text)
+    }
+
+    fn extended_autolink_url_domain_validation(autolink: Self) -> Option<Self> {
+        let domain_and_rest = match autolink {
+            Autolink::ExtendedWww(s) => s,
+            Autolink::ExtendedUrl(link) => link.split_once("://").map_or(link, |x| x.0),
+            _ => return Some(autolink),
+        };
+
+        let domain = domain_and_rest
+            .split_once(&['/', '&', '?', '#'])
+            .map_or(domain_and_rest, |x| x.0);
+
+        let domain_parts = domain.rsplitn(3, '.');
+        if domain_parts.take(2).any(|x| x.contains('_')) {
+            None
+        } else {
+            Some(autolink)
+        }
+    }
+
+    fn extended_autolink_email_domain_validation(autolink: Self) -> Option<Self> {
+        let (Self::ExtendedEmail(link) | Self::ExtendedProtocol(link)) = autolink else {
+            return Some(autolink);
+        };
+
+        let domain = link.split_once('/').map_or(link, |x| x.0);
+        if domain.ends_with(&['-', '_']) {
+            None
+        } else {
+            Some(autolink)
+        }
     }
 
     fn autolink_validation(autolink: Self) -> Option<Self> {
-        match autolink {
-            Self::Uri(_) | Self::Email(_) => Some(autolink),
-
-            Self::ExtendedWww(link) => Some(Self::ExtendedWww(
-                Self::extended_autolink_path_validation(link),
-            )),
-            Self::ExtendedUrl(link) => Some(Self::ExtendedUrl(
-                Self::extended_autolink_path_validation(link),
-            )),
-
-            Self::ExtendedEmail(link) | Self::ExtendedProtocol(link)
-                if link.ends_with(&['-', '_']) =>
-            {
-                None
-            }
-
-            Self::ExtendedEmail(_) | Self::ExtendedProtocol(_) => Some(autolink),
-        }
+        let autolink = Self::extended_autolink_path_validation(autolink);
+        let autolink = Self::extended_autolink_url_domain_validation(autolink)?;
+        let autolink = Self::extended_autolink_email_domain_validation(autolink)?;
+        Some(autolink)
     }
 
     /// a
@@ -132,6 +154,17 @@ impl<'a> Autolink<'a> {
             | Autolink::ExtendedUrl(s)
             | Autolink::ExtendedEmail(s)
             | Autolink::ExtendedProtocol(s) => s,
+        }
+    }
+
+    fn set_raw_text(&self, s: &'a str) -> Self {
+        match self {
+            Autolink::Uri(_) => Autolink::Uri(s),
+            Autolink::Email(_) => Autolink::Email(s),
+            Autolink::ExtendedWww(_) => Autolink::ExtendedWww(s),
+            Autolink::ExtendedUrl(_) => Autolink::ExtendedUrl(s),
+            Autolink::ExtendedEmail(_) => Autolink::ExtendedEmail(s),
+            Autolink::ExtendedProtocol(_) => Autolink::ExtendedProtocol(s),
         }
     }
 

--- a/lychee-lib/src/extract/plaintext.rs
+++ b/lychee-lib/src/extract/plaintext.rs
@@ -10,16 +10,13 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
 
     # https://github.github.com/gfm/#uri-autolink
     < (?P<uri_autolink>
-        [a-z][a-z0-9+.-]{1,31} : [^[:space:][:cntrl:]<>]* ) >
+        [a-z][a-z0-9+.-]{1,31} : [^\s[:cntrl:]<>]* ) >
 
     # https://github.github.com/gfm/#email-autolink
     | < (?P<email_autolink>
         [a-zA-Z0-9.!\#$%&'*+/=?^_`{|}~-]+
         @
-        [a-zA-Z0-9]
-        (?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?
-        (?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*
-        ) >
+        [^\s[:cntrl:]<>]* ) >
 
     | (?P<extended_www_autolink>
         www\.
@@ -29,7 +26,7 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         (?: \. [[:alnum:]_-]+ )*
 
         # path:
-        [^[:space:]<]* )
+        [^ < \s [ \p{Punctuation} && [:^punct:] ] ]* )
 
     | (?P<extended_url_autolink>
         https?://
@@ -39,7 +36,7 @@ static GFM_AUTOLINKS_REGEX: LazyLock<Regex> = LazyLock::new(|| {
         (?: \. [[:alnum:]_-]+ )*
 
         # path:
-        [^[:space:]<]* )
+        [^ < \s [ \p{Punctuation} && [:^punct:] ] ]* )
 
     | (?P<extended_email_autolink>
         [[:alnum:]._+-]+


### PR DESCRIPTION
Just putting this here to make the work more discoverable. This aims to fix https://github.com/lycheeverse/lychee/issues/2108 (and possibly other plaintext link delimiting issues).

Using GFM gives us a more rigorous foundation for plaintext link extraction. For example, it gives nice heuristics for trailing punctuation. It lets a `.` be part of a link if it is within a link (e.g., a file extension), but it trims it from the end of the link.

However, GFM is still not perfect. The [spec](https://github.github.com/gfm/#extended-email-autolink) is silent on the interaction with Unicode, but the GFM implementation on Github.com does implement some non-trivial handling. This Unicode handling still has some issues, as noted in https://github.com/lycheeverse/lychee/issues/2108#issuecomment-4229490943. Additionally, GFM is in C and its Unicode handling is mixed amongst its general tokenising so it's not easy to tease out.

We may just have to choose our own GFM-like heuristics based on some Unicode character classes. This is where I got stuck, as I don't have a good understanding of how users expect plaintext links to behave - especially in languages without spaces. There are competing forces where we want links to exclude adjacent prose text, but domains and URLs are increasingly becoming more internationalised so we must allow non-ASCII characters in links. Maybe we can just use a conservative heuristic for plaintext links, but allow _anything_ between `<...>` links?