### PR TITLE
docs: remove outdated GitHub Action TOC link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Available as command-line utility,
 - [Commandline usage](#commandline-usage)
 - [Supported file formats](#supported-file-formats)
 - [Library usage](#library-usage)
-- [GitHub Action Usage](#github-action-usage)
+- [GitHub Action Usage](#github-actions)
 - [Pre-commit Usage](#pre-commit-usage)
 - [Contributing to lychee](#contributing-to-lychee)
 - [Troubleshooting and Workarounds](#troubleshooting-and-workarounds)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Available as command-line utility,
 - [Commandline usage](#commandline-usage)
 - [Supported file formats](#supported-file-formats)
 - [Library usage](#library-usage)
-- [GitHub Action Usage](#github-actions)
 - [Pre-commit Usage](#pre-commit-usage)
 - [Contributing to lychee](#contributing-to-lychee)
 - [Troubleshooting and Workarounds](#troubleshooting-and-workarounds)


### PR DESCRIPTION
The table of contents entry **GitHub Action Usage** linked to the anchor `#github-action-usage`, but the corresponding section heading is **GitHub Actions** (anchor `#github-actions`) and is now in the "Installation" section, so the link didn't resolve. 

