### PR TITLE
chore: release v0.25.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2316,7 +2316,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lychee"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "lychee-lib"
-version = "0.24.2"
+version = "0.25.0"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4266,7 +4266,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-utils"
-version = "0.24.2"
+version = "0.25.0"
 
 [[package]]
 name = "testing_table"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,4 @@ members = ["lychee-bin", "lychee-lib", "examples/*", "benches", "test-utils"]
 resolver = "2"
 
 [workspace.package]
-version = "0.24.2"
+version = "0.25.0"

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,50 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.2...lychee-v0.25.0) - 2026-09-07
+
+### Added
+
+- match github's markdown fragment generation ([#2153](https://github.com/lycheeverse/lychee/pull/2153))
+- list ignored (IGNORED) links in the run summary ([#2243](https://github.com/lycheeverse/lychee/pull/2243))
+
+### Fixed
+
+- default-extension not applied to local files, and tweak help ([#2245](https://github.com/lycheeverse/lychee/pull/2245))
+- count network errors in per-host statistics ([#2203](https://github.com/lycheeverse/lychee/pull/2203))
+- hide "cannot send response to queue: SendError" message ([#2209](https://github.com/lycheeverse/lychee/pull/2209))
+
+### Other
+
+- Extend --include-fragments docu #2278 ([#2281](https://github.com/lycheeverse/lychee/pull/2281))
+- Add MegaLinter to users list ([#2277](https://github.com/lycheeverse/lychee/pull/2277))
+- *(deps)* bump dependencies and fix rustls feature flag  ([#2269](https://github.com/lycheeverse/lychee/pull/2269))
+- add missing `cfg(test)` and fix new 1.97 warnings ([#2266](https://github.com/lycheeverse/lychee/pull/2266))
+- Add short per-domain statistics ([#2253](https://github.com/lycheeverse/lychee/pull/2253))
+- Add domains and links to the Per-host stats header ([#2252](https://github.com/lycheeverse/lychee/pull/2252))
+- Append fallback extensions when the pre-existing extension has a space ([#2236](https://github.com/lycheeverse/lychee/pull/2236))
+- add generic Cache to deduplicate in-progress tasks ([#2188](https://github.com/lycheeverse/lychee/pull/2188))
+- pipeline flow in `check.rs` (streams and fewer queues) ([#2136](https://github.com/lycheeverse/lychee/pull/2136))
+- Fix broken links ([#2227](https://github.com/lycheeverse/lychee/pull/2227))
+- Fix/rustdoc warnings#2045 ([#2084](https://github.com/lycheeverse/lychee/pull/2084))
+- *(deps)* bump the dependencies group with 5 updates
+- Replace Wayback Availability API with direct snapshot URLs ([#2167](https://github.com/lycheeverse/lychee/pull/2167))
+- Add binstall in docs ([#2222](https://github.com/lycheeverse/lychee/pull/2222))
+- Support HTTP request method fallback ([#2218](https://github.com/lycheeverse/lychee/pull/2218))
+- Make `lychee::latest` track the latest stable release, add `nightly` tag ([#2219](https://github.com/lycheeverse/lychee/pull/2219))
+- Treat .qmd and .Rmd files as Markdown ([#2172](https://github.com/lycheeverse/lychee/pull/2172))
+- Replace custom rate limit header parsing with rate-limits crate ([#2135](https://github.com/lycheeverse/lychee/pull/2135))
+- remove broken GitHub Action TOC link in README ([#2216](https://github.com/lycheeverse/lychee/pull/2216))
+- Remove deprecated flags from codebase. ([#2208](https://github.com/lycheeverse/lychee/pull/2208))
+- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
+- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
+- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
+- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
+- *(deps)* bump the dependencies group across 1 directory with 7 updates
+- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
+- *(deps)* bump the dependencies group with 2 updates
+- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
+
 ## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.1...lychee-v0.24.2) - 2026-04-30
 
 ### Added

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.88.0"
 [dependencies]
 # NOTE: We need to specify the version of lychee-lib here because crates.io
 # requires all dependencies to have a version number.
-lychee-lib = { path = "../lychee-lib", version = "0.24.2", default-features = false }
+lychee-lib = { path = "../lychee-lib", version = "0.25.0", default-features = false }
 
 anyhow = "1.0.102"
 assert-json-diff = "2.0.2"

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -7,6 +7,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.2...lychee-lib-v0.25.0) - 2026-09-07
+
+### Added
+
+- match github's markdown fragment generation ([#2153](https://github.com/lycheeverse/lychee/pull/2153))
+
+### Fixed
+
+- extract issues due to not switching HTML parser states ([#2288](https://github.com/lycheeverse/lychee/pull/2288))
+- default-extension not applied to local files, and tweak help ([#2245](https://github.com/lycheeverse/lychee/pull/2245))
+- count network errors in per-host statistics ([#2203](https://github.com/lycheeverse/lychee/pull/2203))
+
+### Other
+
+- Extend --include-fragments docu #2278 ([#2281](https://github.com/lycheeverse/lychee/pull/2281))
+- Add MegaLinter to users list ([#2277](https://github.com/lycheeverse/lychee/pull/2277))
+- Revert "Wayback reinstate network test ([#2226](https://github.com/lycheeverse/lychee/pull/2226))" ([#2270](https://github.com/lycheeverse/lychee/pull/2270))
+- *(deps)* bump dependencies and fix rustls feature flag  ([#2269](https://github.com/lycheeverse/lychee/pull/2269))
+- add missing `cfg(test)` and fix new 1.97 warnings ([#2266](https://github.com/lycheeverse/lychee/pull/2266))
+- Add short per-domain statistics ([#2253](https://github.com/lycheeverse/lychee/pull/2253))
+- Add domains and links to the Per-host stats header ([#2252](https://github.com/lycheeverse/lychee/pull/2252))
+- *(deps)* bump the dependencies group with 7 updates
+- Append fallback extensions when the pre-existing extension has a space ([#2236](https://github.com/lycheeverse/lychee/pull/2236))
+- add generic Cache to deduplicate in-progress tasks ([#2188](https://github.com/lycheeverse/lychee/pull/2188))
+- pipeline flow in `check.rs` (streams and fewer queues) ([#2136](https://github.com/lycheeverse/lychee/pull/2136))
+- *(deps)* bump the dependencies group with 7 updates
+- Fix broken links ([#2227](https://github.com/lycheeverse/lychee/pull/2227))
+- Wayback reinstate network test ([#2226](https://github.com/lycheeverse/lychee/pull/2226))
+- Fix/rustdoc warnings#2045 ([#2084](https://github.com/lycheeverse/lychee/pull/2084))
+- *(deps)* bump the dependencies group with 5 updates
+- Replace Wayback Availability API with direct snapshot URLs ([#2167](https://github.com/lycheeverse/lychee/pull/2167))
+- Add binstall in docs ([#2222](https://github.com/lycheeverse/lychee/pull/2222))
+- Support HTTP request method fallback ([#2218](https://github.com/lycheeverse/lychee/pull/2218))
+- Make `lychee::latest` track the latest stable release, add `nightly` tag ([#2219](https://github.com/lycheeverse/lychee/pull/2219))
+- Treat .qmd and .Rmd files as Markdown ([#2172](https://github.com/lycheeverse/lychee/pull/2172))
+- Replace custom rate limit header parsing with rate-limits crate ([#2135](https://github.com/lycheeverse/lychee/pull/2135))
+- Remove deprecated legacy cookie format support ([#2215](https://github.com/lycheeverse/lychee/pull/2215))
+- remove broken GitHub Action TOC link in README ([#2216](https://github.com/lycheeverse/lychee/pull/2216))
+- Remove deprecated flags from codebase. ([#2208](https://github.com/lycheeverse/lychee/pull/2208))
+- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
+- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
+- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
+- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
+- Don't unwrap events
+- Extract methods & better error handling
+- *(deps)* bump the dependencies group across 1 directory with 7 updates
+- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
+- *(deps)* bump the dependencies group with 2 updates
+- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
+
 ## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.1...lychee-lib-v0.24.2) - 2026-04-30
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `lychee-lib`: 0.24.2 -> 0.25.0 (⚠ API breaking changes)
* `lychee`: 0.24.2 -> 0.25.0

### ⚠ `lychee-lib` breaking changes

```text
--- failure constructible_struct_adds_field: struct exhaustively constructible through public API adds field ---

Description:
A pub struct that could be exhaustively constructed with a literal using only public API has a new pub field, breaking existing exhaustive literals.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field HostConfig.accept in /tmp/.tmpcWVhaQ/lychee/lychee-lib/src/ratelimit/config.rs:139
  field HostStats.network_errors in /tmp/.tmpcWVhaQ/lychee/lychee-lib/src/ratelimit/host/stats.rs:54

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/inherent_method_missing.ron

Failed in:
  Request::with_credentials, previously in file /tmp/.tmpzzTANS/lychee-lib/src/types/request.rs:72

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/method_parameter_count_changed.ron

Failed in:
  lychee_lib::Client::check_website takes 2 parameters in /tmp/.tmpzzTANS/lychee-lib/src/client.rs:622, but now takes 1 parameters in /tmp/.tmpcWVhaQ/lychee/lychee-lib/src/client.rs:628
  lychee_lib::Input::path_content takes 2 parameters in /tmp/.tmpzzTANS/lychee-lib/src/types/input/input.rs:252, but now takes 3 parameters in /tmp/.tmpcWVhaQ/lychee/lychee-lib/src/types/input/input.rs:253

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/module_missing.ron

Failed in:
  mod lychee_lib::waiter, previously in file /tmp/.tmpzzTANS/lychee-lib/src/waiter.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_missing.ron

Failed in:
  struct lychee_lib::waiter::WaitGuard, previously in file /tmp/.tmpzzTANS/lychee-lib/src/waiter.rs:137
  struct lychee_lib::waiter::WaitGroup, previously in file /tmp/.tmpzzTANS/lychee-lib/src/waiter.rs:122

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.50.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field credentials of struct Request, previously in file /tmp/.tmpzzTANS/lychee-lib/src/types/request.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `lychee-lib`

<blockquote>

## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-lib-v0.24.2...lychee-lib-v0.25.0) - 2026-09-20

### Added

- *(config)* support per-host accept status codes ([#2223](https://github.com/lycheeverse/lychee/pull/2223))
- add --cache-location to configure the request cache path ([#2285](https://github.com/lycheeverse/lychee/pull/2285))
- match github's markdown fragment generation ([#2153](https://github.com/lycheeverse/lychee/pull/2153))

### Fixed

- append fallback extensions past a pre-existing extension
- fix markdown block heading anchors
- default-extension not applied to local files, and tweak help ([#2245](https://github.com/lycheeverse/lychee/pull/2245))
- count network errors in per-host statistics ([#2203](https://github.com/lycheeverse/lychee/pull/2203))

### Other

- Parameterize accepted status code tests with rstest
- Remove unnecessary comment annotations and emphasis markup
- Reevaluate cached status codes and simplify host accept lookup
- fix clippy 1.97 warnings (useless_borrows, dead_code)
- *(config)* cover per-host accept on checker, merge, and cache-key host ([#2223](https://github.com/lycheeverse/lychee/pull/2223))
- Adapt XML extraction to quick-xml 0.42
- *(deps)* bump the dependencies group across 1 directory with 11 updates
- Merge pull request #2250 from sjh9714/fix-myst-block-heading-anchors
- Refactor heading ID attribute extraction
- Align Markdown attribute parsing with MyST behavior
- Allow Syntax Characters in Quoted Heading Attributes
- Handle MyST heading attributes
- Fix Markdown fragment attribute parsing
- address block heading anchor review
- add generic Cache to deduplicate in-progress tasks ([#2188](https://github.com/lycheeverse/lychee/pull/2188))
- pipeline flow in `check.rs` (streams and fewer queues) ([#2136](https://github.com/lycheeverse/lychee/pull/2136))
- *(deps)* bump the dependencies group with 7 updates
- Fix broken links ([#2227](https://github.com/lycheeverse/lychee/pull/2227))
- Wayback reinstate network test ([#2226](https://github.com/lycheeverse/lychee/pull/2226))
- Fix/rustdoc warnings#2045 ([#2084](https://github.com/lycheeverse/lychee/pull/2084))
- *(deps)* bump the dependencies group with 5 updates
- Replace Wayback Availability API with direct snapshot URLs ([#2167](https://github.com/lycheeverse/lychee/pull/2167))
- Add binstall in docs ([#2222](https://github.com/lycheeverse/lychee/pull/2222))
- Support HTTP request method fallback ([#2218](https://github.com/lycheeverse/lychee/pull/2218))
- Make `lychee::latest` track the latest stable release, add `nightly` tag ([#2219](https://github.com/lycheeverse/lychee/pull/2219))
- Treat .qmd and .Rmd files as Markdown ([#2172](https://github.com/lycheeverse/lychee/pull/2172))
- Replace custom rate limit header parsing with rate-limits crate ([#2135](https://github.com/lycheeverse/lychee/pull/2135))
- Remove deprecated legacy cookie format support ([#2215](https://github.com/lycheeverse/lychee/pull/2215))
- remove broken GitHub Action TOC link in README ([#2216](https://github.com/lycheeverse/lychee/pull/2216))
- Remove deprecated flags from codebase. ([#2208](https://github.com/lycheeverse/lychee/pull/2208))
- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
- Don't unwrap events
- Extract methods & better error handling
- *(deps)* bump the dependencies group across 1 directory with 7 updates
- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
- *(deps)* bump the dependencies group with 2 updates
- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
</blockquote>

## `lychee`

<blockquote>

## [0.25.0](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.2...lychee-v0.25.0) - 2026-09-20

### Added

- *(config)* support per-host accept status codes ([#2223](https://github.com/lycheeverse/lychee/pull/2223))
- add --cache-location to configure the request cache path ([#2285](https://github.com/lycheeverse/lychee/pull/2285))
- match github's markdown fragment generation ([#2153](https://github.com/lycheeverse/lychee/pull/2153))
- list ignored (IGNORED) links in the run summary ([#2243](https://github.com/lycheeverse/lychee/pull/2243))

### Fixed

- append fallback extensions past a pre-existing extension
- default-extension not applied to local files, and tweak help ([#2245](https://github.com/lycheeverse/lychee/pull/2245))
- count network errors in per-host statistics ([#2203](https://github.com/lycheeverse/lychee/pull/2203))
- hide "cannot send response to queue: SendError" message ([#2209](https://github.com/lycheeverse/lychee/pull/2209))

### Other

- Reject cached responses with invalid status codes
- Remove unnecessary comment annotations and emphasis markup
- Reevaluate cached status codes and simplify host accept lookup
- *(config)* cover per-host accept on checker, merge, and cache-key host ([#2223](https://github.com/lycheeverse/lychee/pull/2223))
- *(deps)* bump the dependencies group across 1 directory with 11 updates
- Merge pull request #2294 from lycheeverse/fix/local-large-file-test
- Merge pull request #2250 from sjh9714/fix-myst-block-heading-anchors
- Align Markdown attribute parsing with MyST behavior
- Handle MyST heading attributes
- Fix Markdown fragment attribute parsing
- address block heading anchor review
- add generic Cache to deduplicate in-progress tasks ([#2188](https://github.com/lycheeverse/lychee/pull/2188))
- pipeline flow in `check.rs` (streams and fewer queues) ([#2136](https://github.com/lycheeverse/lychee/pull/2136))
- Fix broken links ([#2227](https://github.com/lycheeverse/lychee/pull/2227))
- Fix/rustdoc warnings#2045 ([#2084](https://github.com/lycheeverse/lychee/pull/2084))
- *(deps)* bump the dependencies group with 5 updates
- Replace Wayback Availability API with direct snapshot URLs ([#2167](https://github.com/lycheeverse/lychee/pull/2167))
- Add binstall in docs ([#2222](https://github.com/lycheeverse/lychee/pull/2222))
- Support HTTP request method fallback ([#2218](https://github.com/lycheeverse/lychee/pull/2218))
- Make `lychee::latest` track the latest stable release, add `nightly` tag ([#2219](https://github.com/lycheeverse/lychee/pull/2219))
- Treat .qmd and .Rmd files as Markdown ([#2172](https://github.com/lycheeverse/lychee/pull/2172))
- Replace custom rate limit header parsing with rate-limits crate ([#2135](https://github.com/lycheeverse/lychee/pull/2135))
- remove broken GitHub Action TOC link in README ([#2216](https://github.com/lycheeverse/lychee/pull/2216))
- Remove deprecated flags from codebase. ([#2208](https://github.com/lycheeverse/lychee/pull/2208))
- tweaks features table in readme ([#2171](https://github.com/lycheeverse/lychee/pull/2171))
- Use hints for root-relative links error ([#2197](https://github.com/lycheeverse/lychee/pull/2197))
- Merge pull request #2207 from lycheeverse/dependabot/cargo/dependencies-db312993ac
- Credit NLnet ([#2200](https://github.com/lycheeverse/lychee/pull/2200))
- *(deps)* bump the dependencies group across 1 directory with 7 updates
- move basic auth credentials out of Request  ([#2164](https://github.com/lycheeverse/lychee/pull/2164))
- *(deps)* bump the dependencies group with 2 updates
- Update changelogs for v0.24.2 ([#2180](https://github.com/lycheeverse/lychee/pull/2180))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).