### PR TITLE
Add built-in host config defaults

### DIFF
--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -367,14 +367,15 @@ impl ClientBuilder {
             .build()
             .map_err(ErrorKind::BuildRequestClient)?;
 
-        let client_map = self.build_host_clients(&redirect_history)?;
+        // User-specified host configuration takes precedence over the built-in
+        // defaults, which in turn take precedence over the global defaults.
+        // This must happen before building the host clients, since host headers
+        // are baked into the per-host reqwest client.
+        let hosts = self.hosts.clone().merge(HostConfigs::builtin_defaults());
 
-        let host_pool = HostPool::new(
-            self.rate_limit_config,
-            self.hosts,
-            reqwest_client,
-            client_map,
-        );
+        let client_map = self.build_host_clients(&hosts, &redirect_history)?;
+
+        let host_pool = HostPool::new(self.rate_limit_config, hosts, reqwest_client, client_map);
 
         let github_client = match self.github_token.as_ref().map(ExposeSecret::expose_secret) {
             Some(token) if !token.is_empty() => Some(
@@ -430,8 +431,12 @@ impl ClientBuilder {
     }
 
     /// Build the host-specific clients with their host-specific headers
-    fn build_host_clients(&self, redirect_history: &RedirectHistory) -> Result<ClientMap> {
-        self.hosts
+    fn build_host_clients(
+        &self,
+        hosts: &HostConfigs,
+        redirect_history: &RedirectHistory,
+    ) -> Result<ClientMap> {
+        hosts
             .iter()
             .map(|(host, config)| {
                 let mut headers = self.default_headers()?;
@@ -799,6 +804,48 @@ mod tests {
             .check("https://crates.io/crates/lychee")
             .await
             .unwrap();
+        assert!(res.status().is_success());
+    }
+
+    #[tokio::test]
+    async fn test_per_host_header_is_sent() {
+        use crate::ratelimit::{HostConfig, HostConfigs, HostKey};
+        use url::Url;
+        use wiremock::{
+            MockServer, ResponseTemplate,
+            matchers::{header, method},
+        };
+
+        // The mock only responds with 200 if the request carries the
+        // host-specific user-agent. Any other request yields a 404.
+        let mock_server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(header("user-agent", "my-host-agent"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&mock_server)
+            .await;
+
+        let url = Url::parse(&mock_server.uri()).unwrap();
+        let host_key = HostKey::try_from(&url).unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert(header::USER_AGENT, "my-host-agent".parse().unwrap());
+        let hosts = HostConfigs::from([(
+            host_key,
+            HostConfig {
+                headers,
+                ..HostConfig::default()
+            },
+        )]);
+
+        let res = ClientBuilder::builder()
+            .hosts(hosts)
+            .build()
+            .client()
+            .unwrap()
+            .check(mock_server.uri())
+            .await
+            .unwrap();
+
         assert!(res.status().is_success());
     }
 

--- a/lychee-lib/src/ratelimit/config.rs
+++ b/lychee-lib/src/ratelimit/config.rs
@@ -59,6 +59,50 @@ impl RateLimitConfig {
 pub struct HostConfigs(HashMap<HostKey, HostConfig>);
 
 impl HostConfigs {
+    /// Built-in, host-specific configuration defaults.
+    ///
+    /// These are real-world overrides that improve lychee's out-of-the-box
+    /// behaviour for hosts that are known to behave unexpectedly with the
+    /// default settings (for example, hosts that reject the default
+    /// user-agent). This is comparable to [`quirks`](crate::quirks), but for
+    /// [`HostConfig`]s.
+    ///
+    /// These defaults take precedence over the user's *global* defaults, but
+    /// not over the user's *per-host* configuration (see [`HostConfigs::merge`]).
+    ///
+    /// Note that host keys are matched against the exact, lowercased hostname,
+    /// so `www.gnu.org` does not cover `gnu.org` (and vice versa).
+    ///
+    /// To add a new default, insert another entry below. Additions of
+    /// real-world host configurations are welcome.
+    #[must_use]
+    pub fn builtin_defaults() -> HostConfigs {
+        // Hosts that only respond as expected to a browser- or curl-like
+        // user-agent. See https://github.com/lycheeverse/lychee/issues/1960.
+        let host_user_agents = [
+            ("www.gnu.org", "Mozilla/5.0"),
+            ("developers.redhat.com", "curl/8.4.0"),
+        ];
+
+        let mut configs = HashMap::new();
+        for (host, user_agent) in host_user_agents {
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                HeaderName::from_static("user-agent"),
+                HeaderValue::from_static(user_agent),
+            );
+            configs.insert(
+                HostKey::from(host),
+                HostConfig {
+                    headers,
+                    ..HostConfig::default()
+                },
+            );
+        }
+
+        HostConfigs(configs)
+    }
+
     /// Get a reference to the [`HostConfig`] associated to the [`HostKey`]
     pub(crate) fn get(&self, key: &HostKey) -> Option<&HostConfig> {
         self.0.get(key)
@@ -81,7 +125,10 @@ impl HostConfigs {
         self.0.iter()
     }
 
-    /// Merge `self` with another `HostConfigs`
+    /// Merge `self` with another `HostConfigs`.
+    ///
+    /// `self` takes precedence over `other` on a per-field and per-header-key
+    /// basis (see [`HostConfig::merge`]).
     #[must_use]
     pub fn merge(mut self, other: HostConfigs) -> HostConfigs {
         for (key, value) in other.0 {
@@ -154,18 +201,32 @@ impl HostConfig {
             .unwrap_or(global_config.request_interval)
     }
 
+    /// Merge `self` with `other`, where `self` takes precedence.
+    ///
+    /// Scalar fields (`concurrency`, `request_interval`) use `self`'s value if
+    /// set, otherwise fall back to `other`'s.
+    ///
+    /// Headers are merged per key: a header key present in `self` fully
+    /// replaces the same key in `other` (rather than appending), while header
+    /// keys only present in `other` are kept.
     #[must_use]
-    pub(crate) fn merge(mut self, other: Self) -> Self {
-        for (k, v) in other.headers {
-            if let Some(k) = k {
-                self.headers.append(k, v);
+    pub(crate) fn merge(self, other: Self) -> Self {
+        // Start from the lower-precedence headers, then let `self`'s headers
+        // override on a per-key basis.
+        let mut headers = other.headers;
+        for key in self.headers.keys() {
+            headers.remove(key);
+        }
+        for (key, value) in self.headers {
+            if let Some(key) = key {
+                headers.append(key, value);
             }
         }
 
         Self {
             concurrency: self.concurrency.or(other.concurrency),
             request_interval: self.request_interval.or(other.request_interval),
-            headers: self.headers,
+            headers,
         }
     }
 }
@@ -205,6 +266,87 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_builtin_defaults_present() {
+        let defaults = HostConfigs::builtin_defaults();
+
+        let gnu = defaults
+            .get(&HostKey::from("www.gnu.org"))
+            .expect("www.gnu.org default should exist");
+        assert_eq!(
+            gnu.headers.get("user-agent").map(|v| v.to_str().unwrap()),
+            Some("Mozilla/5.0")
+        );
+
+        let redhat = defaults
+            .get(&HostKey::from("developers.redhat.com"))
+            .expect("developers.redhat.com default should exist");
+        assert_eq!(
+            redhat
+                .headers
+                .get("user-agent")
+                .map(|v| v.to_str().unwrap()),
+            Some("curl/8.4.0")
+        );
+    }
+
+    #[test]
+    fn test_merge_headers_override_by_key() {
+        // The higher-precedence side (`self`) replaces same-key headers from
+        // the lower-precedence side (`other`), while disjoint keys are kept.
+        let mut high = HeaderMap::new();
+        high.insert("user-agent", "high".parse().unwrap());
+        high.insert("x-only-high", "1".parse().unwrap());
+        let high = HostConfig {
+            headers: high,
+            ..HostConfig::default()
+        };
+
+        let mut low = HeaderMap::new();
+        low.insert("user-agent", "low".parse().unwrap());
+        low.insert("x-only-low", "2".parse().unwrap());
+        let low = HostConfig {
+            headers: low,
+            ..HostConfig::default()
+        };
+
+        let merged = high.merge(low);
+
+        // Same-key header: high wins, low's value is dropped (not appended).
+        let user_agents: Vec<_> = merged.headers.get_all("user-agent").iter().collect();
+        assert_eq!(user_agents.len(), 1);
+        assert_eq!(user_agents[0], "high");
+
+        // Disjoint keys from both sides are preserved.
+        assert_eq!(merged.headers.get("x-only-high").unwrap(), "1");
+        assert_eq!(merged.headers.get("x-only-low").unwrap(), "2");
+    }
+
+    #[test]
+    fn test_merge_user_overrides_builtin_default() {
+        let key = HostKey::from("www.gnu.org");
+
+        let mut user_headers = HeaderMap::new();
+        user_headers.insert("user-agent", "my-agent".parse().unwrap());
+        let user = HostConfigs::from([(
+            key.clone(),
+            HostConfig {
+                concurrency: Some(3),
+                headers: user_headers,
+                ..HostConfig::default()
+            },
+        )]);
+
+        // User config takes precedence over the built-in defaults.
+        let merged = user.merge(HostConfigs::builtin_defaults());
+        let config = merged.get(&key).unwrap();
+
+        assert_eq!(config.concurrency, Some(3));
+        let user_agents: Vec<_> = config.headers.get_all("user-agent").iter().collect();
+        assert_eq!(user_agents.len(), 1);
+        assert_eq!(user_agents[0], "my-agent");
+    }
 
     #[test]
     fn test_default_rate_limit_config() {


### PR DESCRIPTION
Adds built-in host-specific config defaults (like quirks, but for `HostConfig`s). Seeds two hosts that reject lychee's default user-agent:

| Host | User-Agent |
|------|-----------|
| `www.gnu.org` | `Mozilla/5.0` |
| `developers.redhat.com` | `curl/8.4.0` |

Adding more is a one-liner in `HostConfigs::builtin_defaults()`.

**Precedence:** user host config > built-in defaults > user global defaults. Built-ins are merged underneath user host config, and `effective_*` already falls back to the global config, so this works for free.

**Also:** `HostConfig::merge` now overrides headers by key instead of appending (no more duplicate `User-Agent`s). The existing `test_merge_hosts` only merged disjoint keys, so it's unaffected.

**Note:** `HostKey` matches exact hostnames, so `www.gnu.org` doesn't cover `gnu.org`. No opt-out flag, matching quirks.

Closes #1960.