### PR TITLE
Fix broken links

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -15,7 +15,11 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@master
         with:
-          args: --verbose --exclude-path benches --exclude-path fixtures --root-dir . .
+          # Only the input path is passed here.
+          #
+          # All other options live in `lychee.toml` (which lychee-action
+          # auto-loads from the repo root).
+          args: .
 
       - name: Create Issue From File
         if: github.repository_owner == 'lycheeverse' && env.lychee_exit_code != 0

--- a/README.md
+++ b/README.md
@@ -937,7 +937,7 @@ great contributors who have since made this project more mature.
   <img src="/assets/nlnet.svg" alt="NLnet logo" width="100" height="75" />
 </a>
 
-lychee received financial support through the [NGI0 Core Fund](https://nlnet.nl/core),
+lychee received financial support through the [NGI0 Core Fund](https://nlnet.nl/core/),
 established by NLnet with financial support from the European Commission's
 [Next Generation Internet](https://ngi.eu) programme.
 NLnet is supporting the open internet since 1997.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -37,7 +37,7 @@ You have two options:
 
 Some websites don't respond with a `200` (OK) status code. \
 Instead they might send `204` (No Content), `206` (Partial Content), or
-[something else entirely](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/418).
+[something else entirely](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/418).
 
 If you run into such issues you can work around that by providing a custom \
 list of accepted status codes, such as `--accept 200,204,206`.
@@ -53,7 +53,7 @@ You can use that argument multiple times to add more headers. \
 Or, you can accept all content/MIME types: `--header "Accept: */*"`.
 
 See more info about the Accept header
-[over at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept).
+[over at MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept).
 
 ## Unreachable Mail Address
 

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prevent 0 value for max-concurrency and threads ([#2145](https://github.com/lycheeverse/lychee/pull/2145))
-- Use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/pull/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
+- Use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/issues/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
 - *(cli)* bump open files limit on macOS and Linux ([#2106](https://github.com/lycheeverse/lychee/pull/2106))
 - Fix matching logic for glob hidden files ([#2130](https://github.com/lycheeverse/lychee/pull/2130))
 - Fix output path not validated before the run ([#2148](https://github.com/lycheeverse/lychee/pull/2148))
@@ -282,7 +282,7 @@ Most notably with this release the deprecated `--exclude-mail` flag was removed 
 
 ### Other
 
-- Fix Porgressbar rendering Checkbox (Fixes [#1626](https://github.com/lycheeverse/lychee/pull/1626)) ([#1627](https://github.com/lycheeverse/lychee/pull/1627))
+- Fix Porgressbar rendering Checkbox (Fixes [#1626](https://github.com/lycheeverse/lychee/issues/1626)) ([#1627](https://github.com/lycheeverse/lychee/pull/1627))
 - Add Checkbox Formatting Option for Markdown Reports ([#1623](https://github.com/lycheeverse/lychee/pull/1623))
 - Fix new clippy lints ([#1625](https://github.com/lycheeverse/lychee/pull/1625))
 - Bump the dependencies group with 3 updates ([#1604](https://github.com/lycheeverse/lychee/pull/1604))

--- a/lychee-lib/CHANGELOG.md
+++ b/lychee-lib/CHANGELOG.md
@@ -50,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent autolink duplication ([#2151](https://github.com/lycheeverse/lychee/pull/2151))
 - Prevent 0 value for max-concurrency and threads ([#2145](https://github.com/lycheeverse/lychee/pull/2145))
 - Quirk: remove line number fragments from github URLs ([#2116](https://github.com/lycheeverse/lychee/pull/2116))
-- Use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/pull/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
+- Use the remapped URI for the cache key ([#1818](https://github.com/lycheeverse/lychee/issues/1818)) ([#2109](https://github.com/lycheeverse/lychee/pull/2109))
 - Fix matching logic for glob hidden files ([#2130](https://github.com/lycheeverse/lychee/pull/2130))
 - Fix toc action ([#2055](https://github.com/lycheeverse/lychee/pull/2055))
 - Prevent duplicate requests to the same URLs ([#2067](https://github.com/lycheeverse/lychee/pull/2067))

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,19 @@
+# Configuration for checking this repository's own links.
+# Used by the scheduled link check in .github/workflows/links.yml.
+# See lychee.example.toml for all available options.
+
+# Show info-level output (equivalent to a single `--verbose`).
+verbose = "info"
+
+# Root path for resolving absolute local links (resolved relative to the
+# working directory, i.e. the repository root).
+root_dir = "."
+
+# Paths to skip when collecting inputs.
+exclude_path = ["benches", "fixtures"]
+
+# gitlab.torproject.org rejects lychee's default User-Agent with a 403, even
+# though the page is reachable. Override the User-Agent for just this host so we
+# don't have to change the global one (which other hosts, e.g. crates.io, reject).
+[hosts."gitlab.torproject.org"]
+headers = { "User-Agent" = "curl/8.7.1" }


### PR DESCRIPTION
A few links regressed over time and we have some redirects that can be replaced with their canonical replacement.

The Tor-Project link was a bit of a gnarly one, as they don't accept our lychee user agent.  They do, however, accept curl, which is why I opted to use that on a per-host basis.  In order to do that, I've created a `lychee.toml` now, and decided to move all other settings there as well. I think it's cleaner this way.