### PR TITLE
fix: align docker image version to Cargo.toml

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -24,7 +24,7 @@
 - id: lychee-docker
   name: lychee-docker
   description: "Run 'lychee' docker image for fast, async, stream-based link checking (auto-installs)"
-  entry: lycheeverse/lychee:0.23.0
+  entry: lycheeverse/lychee:0.24.2
   language: docker_image
   args: ["--no-progress"]
   types: [text]


### PR DESCRIPTION
To prevent that these go out of sync in future, we could use something like [this pre-commit hook](https://github.com/hofbi/dev-tools/blob/b58fd55d9fd6619f52ec584a942ac5245d7cffc2/README.md#sync-tool-versions). If you want me to, I'll propose that change in this repo.