### PR TITLE
ci: auto-sync lychee-docker pre-commit version with Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,8 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: Check lychee-docker pre-commit version is in sync
+        run: ./scripts/sync_docker_pre_commit_version.sh --check
       - name: Run cargo fmt (check if all code is rustfmt-ed)
         run: cargo fmt --all --check
       - name: Run cargo clippy (deny warnings)

--- a/.github/workflows/sync-pre-commit-version.yml
+++ b/.github/workflows/sync-pre-commit-version.yml
@@ -1,0 +1,49 @@
+# Keep the pinned `lychee-docker` pre-commit hook version in sync with the
+# workspace version that release-plz bumps.
+#
+# release-plz opens (and updates) a release PR on a `release-plz-*` branch that
+# bumps `[workspace.package] version` in `Cargo.toml`. This workflow reacts to
+# those pushes, rewrites the pinned image tag in `.pre-commit-hooks.yaml`, and
+# commits the change back onto the same release branch.
+#
+# Doing it here (rather than after the tag is published) is important: pre-commit
+# reads `.pre-commit-hooks.yaml` from the *tagged* commit, so the docker tag must
+# already be correct by the time the release is tagged.
+
+name: Sync pre-commit docker version
+
+on:
+  push:
+    branches:
+      - release-plz-master
+      - release-plz-main
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    name: Sync lychee-docker version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+          # Use the release-plz token so the resulting commit can trigger the
+          # usual CI checks on the release PR.
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
+
+      - name: Sync docker version into pre-commit hooks
+        run: ./scripts/sync_docker_pre_commit_version.sh
+
+      - name: Commit and push if changed
+        run: |
+          if git diff --quiet; then
+            echo "Nothing to sync."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -am "chore: sync lychee-docker pre-commit version"
+          git push

--- a/scripts/sync_docker_pre_commit_version.sh
+++ b/scripts/sync_docker_pre_commit_version.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Keep the `lychee-docker` pre-commit hook in sync with the workspace version.
+#
+# The `lychee` and `lychee-system` hooks derive their version dynamically (from
+# the checked-out git tag or the system install), but `lychee-docker` has to
+# pin a concrete image tag in `.pre-commit-hooks.yaml`. This script rewrites
+# that pinned tag to match `[workspace.package] version` in `Cargo.toml`.
+#
+# Usage:
+#   scripts/sync_docker_pre_commit_version.sh           # update the file in place
+#   scripts/sync_docker_pre_commit_version.sh --check   # fail if out of sync (no writes)
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+HOOKS_FILE=".pre-commit-hooks.yaml"
+CARGO_FILE="Cargo.toml"
+
+# Extract the workspace version, i.e. the first `version = "x.y.z"` under
+# `[workspace.package]`.
+version="$(
+    awk '
+        /^\[workspace\.package\]/ { in_section = 1; next }
+        /^\[/                     { in_section = 0 }
+        in_section && /^version[[:space:]]*=/ {
+            gsub(/[^0-9.]/, "", $0)
+            print
+            exit
+        }
+    ' "$CARGO_FILE"
+)"
+
+if [[ -z "$version" ]]; then
+    echo "error: could not determine workspace version from $CARGO_FILE" >&2
+    exit 1
+fi
+
+current="$(sed -n 's/.*entry:[[:space:]]*lycheeverse\/lychee:\([0-9.]*\).*/\1/p' "$HOOKS_FILE")"
+
+if [[ -z "$current" ]]; then
+    echo "error: could not find pinned 'lycheeverse/lychee:<version>' entry in $HOOKS_FILE" >&2
+    exit 1
+fi
+
+if [[ "$current" == "$version" ]]; then
+    echo "lychee-docker pre-commit version already in sync ($version)."
+    exit 0
+fi
+
+if [[ "${1:-}" == "--check" ]]; then
+    echo "error: lychee-docker pre-commit version is out of sync." >&2
+    echo "  $HOOKS_FILE pins: $current" >&2
+    echo "  $CARGO_FILE expects: $version" >&2
+    echo "Run scripts/sync_docker_pre_commit_version.sh to fix." >&2
+    exit 1
+fi
+
+sed -i.bak "s|\(entry:[[:space:]]*lycheeverse/lychee:\)[0-9.]*|\1${version}|" "$HOOKS_FILE"
+rm -f "${HOOKS_FILE}.bak"
+
+echo "Updated lychee-docker pre-commit version: $current -> $version"


### PR DESCRIPTION
Follow-up to #2228 (see [this discussion](https://github.com/lycheeverse/lychee/pull/2228#issuecomment-4618769937)).
This was a dead-end experiment. Sorry for the noise.