### PR TITLE
ci: check lychee-docker pre-commit version matches Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,13 @@ jobs:
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+      - name: Check lychee-docker pre-commit version matches Cargo.toml
+        run: |
+          version=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name == "lychee") | .version')
+          if ! grep -q "lycheeverse/lychee:$version" .pre-commit-hooks.yaml; then
+            echo "::error::Bump the lycheeverse/lychee docker tag in .pre-commit-hooks.yaml to $version"
+            exit 1
+          fi
       - name: Run cargo fmt (check if all code is rustfmt-ed)
         run: cargo fmt --all --check
       - name: Run cargo clippy (deny warnings)


### PR DESCRIPTION
Follow-up to #2228. CI now fails if the docker tag in `.pre-commit-hooks.yaml` drifts from the `Cargo.toml` version, so the release PR catches it instead of someone noticing later.