### PR TITLE
feat: list ignored (IGNORED) links in the run summary

### DIFF
--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -30,6 +30,7 @@ impl Display for CompactResponseStats {
             .error_map
             .iter()
             .chain(stats.timeout_map.iter())
+            .chain(stats.unsupported_map.iter())
             .count();
 
         if issues > 0 {
@@ -44,9 +45,13 @@ impl Display for CompactResponseStats {
 
         let response_formatter = get_response_formatter(&self.mode);
 
-        for (source, responses) in
-            super::sort_stats_iter(stats.error_map.iter().chain(stats.timeout_map.iter()))
-        {
+        for (source, responses) in super::sort_stats_iter(
+            stats
+                .error_map
+                .iter()
+                .chain(stats.timeout_map.iter())
+                .chain(stats.unsupported_map.iter()),
+        ) {
             color!(f, BOLD_YELLOW, "[{}]:\n", source)?;
             write_responses(f, &*response_formatter, responses)?;
             write_suggestions(f, stats, source)?;
@@ -188,6 +193,57 @@ https://original.dev/ --> https://suggestion.dev/
 ────────────────────────────────────────────────────────────
 example.com   │      5 reqs │   60.0% success │      N/A median │   20.0% cached
 "
+        );
+    }
+
+    #[test]
+    fn test_formatter_lists_ignored_only_input() {
+        use std::collections::{HashMap, HashSet};
+        use std::time::Duration;
+
+        use lychee_lib::{ErrorKind, InputSource, ResponseBody, Status, Uri};
+        use url::Url;
+
+        // An input whose *only* problem is an ignored link (no errors/timeouts)
+        // should still list that link, not just bump the Unsupported count.
+        let source = InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
+        let unsupported_map = HashMap::from([(
+            source,
+            HashSet::from([ResponseBody {
+                uri: Uri::try_from("https://example.com/ignored").unwrap(),
+                status: Status::Unsupported(ErrorKind::InvalidUrlHost),
+                redirects: None,
+                remap: None,
+                span: None,
+                duration: Some(Duration::from_secs(1)),
+            }]),
+        )]);
+
+        let stats = ResponseStats {
+            total: 1,
+            unique: 1,
+            unsupported: 1,
+            unsupported_map,
+            ..Default::default()
+        };
+
+        let response_stats = CompactResponseStats {
+            stats,
+            mode: OutputMode::Plain,
+        };
+        let without_color_codes = Regex::new(r"\u{1b}\[[0-9;]*m")
+            .unwrap()
+            .replace_all(&response_stats.to_string(), "")
+            .to_string();
+
+        assert_eq!(
+            without_color_codes,
+            "Issues found in 1 input. Find details below.
+
+[https://example.com/]:
+[IGNORED] https://example.com/ignored | Unsupported: URL is missing a hostname
+
+🔍 1 Total (in 0s) 🔗 1 Unique ✅ 0 OK 🚫 0 Errors ⛔ 1 Unsupported"
         );
     }
 }

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -53,7 +53,7 @@ impl Display for DetailedResponseStats {
         write_stat(f, "👻 Excluded", stats.excludes, true)?;
         write_stat(f, "❓ Unknown", stats.unknown, true)?;
         write_stat(f, "🚫 Errors", stats.errors, true)?;
-        write_stat(f, "⛔ Unsupported", stats.errors, false)?;
+        write_stat(f, "⛔ Unsupported", stats.unsupported, false)?;
 
         let response_formatter = get_response_formatter(&self.mode);
 
@@ -155,7 +155,7 @@ mod tests {
 👻 Excluded.........0
 ❓ Unknown..........0
 🚫 Errors...........1
-⛔ Unsupported......1
+⛔ Unsupported......0
 
 Errors in https://example.com/
 [404] https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | 404 Not Found
@@ -231,7 +231,7 @@ Host: example.com
 👻 Excluded.........0
 ❓ Unknown..........0
 🚫 Errors...........0
-⛔ Unsupported......0
+⛔ Unsupported......1
 
 Ignored in https://example.com/
 [IGNORED] https://example.com/ignored | Unsupported: URL is missing a hostname"

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -72,6 +72,17 @@ impl Display for DetailedResponseStats {
             write_stats(f, "Redirects", source, stats.redirect_map.get(source))?;
         }
 
+        // Ignored (unsupported) links get their own section so they are not
+        // mislabeled as errors, and so inputs whose only finding is an ignored
+        // link are still listed.
+        for (source, responses) in super::sort_stats_iter(stats.unsupported_map.iter()) {
+            write!(f, "\n\nIgnored in {source}")?;
+
+            for response in responses {
+                write!(f, "\n{}", response_formatter.format_response(response))?;
+            }
+        }
+
         Ok(())
     }
 }
@@ -169,6 +180,61 @@ Host: example.com
   Cache hit rate: 20.0%
   Cache hits: 1, misses: 4
 "
+        );
+    }
+
+    #[test]
+    fn test_detailed_formatter_lists_ignored_only_input() {
+        use std::collections::{HashMap, HashSet};
+        use std::time::Duration;
+
+        use lychee_lib::{ErrorKind, InputSource, ResponseBody, Status, Uri};
+        use url::Url;
+
+        // An input whose only problem is an ignored link should get its own
+        // "Ignored in <source>" section, not be mislabeled under "Errors".
+        let source = InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
+        let unsupported_map = HashMap::from([(
+            source,
+            HashSet::from([ResponseBody {
+                uri: Uri::try_from("https://example.com/ignored").unwrap(),
+                status: Status::Unsupported(ErrorKind::InvalidUrlHost),
+                redirects: None,
+                remap: None,
+                span: None,
+                duration: Some(Duration::from_secs(1)),
+            }]),
+        )]);
+
+        let stats = ResponseStats {
+            total: 1,
+            unique: 1,
+            unsupported: 1,
+            unsupported_map,
+            ..Default::default()
+        };
+
+        let response_stats = DetailedResponseStats {
+            stats,
+            mode: OutputMode::Plain,
+        };
+
+        assert_eq!(
+            response_stats.to_string(),
+            "📝 Summary
+---------------------
+🔍 Total............1
+🔗 Unique...........1
+✅ Successful.......0
+⏳ Timeouts.........0
+🔀 Redirected.......0
+👻 Excluded.........0
+❓ Unknown..........0
+🚫 Errors...........0
+⛔ Unsupported......0
+
+Ignored in https://example.com/
+[IGNORED] https://example.com/ignored | Unsupported: URL is missing a hostname"
         );
     }
 }

--- a/lychee-bin/src/formatters/stats/json.rs
+++ b/lychee-bin/src/formatters/stats/json.rs
@@ -100,6 +100,7 @@ mod tests {
     ]
   },
   "excluded_map": {},
+  "unsupported_map": {},
   "duration": {
     "secs": 0,
     "nanos": 0

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -120,6 +120,10 @@ impl Display for MarkdownResponseStats {
             markdown_response(response).map_err(|_| fmt::Error)
         })?;
 
+        write_stats_per_input(f, "Ignored", &stats.unsupported_map, |response| {
+            markdown_response(response).map_err(|_| fmt::Error)
+        })?;
+
         write_stats_per_input(f, "Redirects", &stats.redirect_map, |redirects| {
             Ok(format!("* {redirects}"))
         })?;
@@ -300,6 +304,56 @@ mod tests {
 ### Suggestions in https://example.com/
 
 * https://original.dev/ --> https://suggestion.dev/
+";
+        assert_eq!(summary.to_string(), expected.to_string());
+    }
+
+    #[test]
+    fn test_render_summary_with_ignored() {
+        use lychee_lib::ErrorKind;
+        use url::Url;
+
+        let source = InputSource::RemoteUrl(Box::new(Url::parse("https://example.com").unwrap()));
+        let unsupported_map = HashMap::from([(
+            source,
+            HashSet::from([ResponseBody {
+                uri: Uri::try_from("https://example.com/ignored").unwrap(),
+                status: Status::Unsupported(ErrorKind::InvalidUrlHost),
+                redirects: None,
+                remap: None,
+                span: SPAN,
+                duration: DURATION,
+            }]),
+        )]);
+
+        let stats = ResponseStats {
+            total: 1,
+            unique: 1,
+            unsupported: 1,
+            unsupported_map,
+            ..Default::default()
+        };
+
+        let summary = MarkdownResponseStats(stats);
+        let expected = "# Summary
+
+| Status         | Count |
+|----------------|-------|
+| 🔍 Total       | 1     |
+| 🔗 Unique      | 1     |
+| ✅ Successful  | 0     |
+| ⏳ Timeouts    | 0     |
+| 🔀 Redirected  | 0     |
+| 👻 Excluded    | 0     |
+| ❓ Unknown     | 0     |
+| 🚫 Errors      | 0     |
+| ⛔ Unsupported | 1     |
+
+## Ignored per input
+
+### Ignored in https://example.com/
+
+* [IGNORED] <https://example.com/ignored> (at 1:1) | Unsupported: URL is missing a hostname
 ";
         assert_eq!(summary.to_string(), expected.to_string());
     }

--- a/lychee-bin/src/formatters/stats/response.rs
+++ b/lychee-bin/src/formatters/stats/response.rs
@@ -56,6 +56,9 @@ pub(crate) struct ResponseStats {
     pub(crate) redirect_map: HashMap<InputSource, HashSet<Redirects>>,
     /// Excluded responses (if `detailed_stats` is enabled)
     pub(crate) excluded_map: HashMap<InputSource, HashSet<ResponseBody>>,
+    /// Unsupported responses (shown as `IGNORED`), e.g. malformed URLs or
+    /// unsupported URI schemes that could not be turned into a request
+    pub(crate) unsupported_map: HashMap<InputSource, HashSet<ResponseBody>>,
     /// The time it took to perform the full run
     pub(crate) duration: Duration,
     /// Also track successful and excluded responses
@@ -121,6 +124,8 @@ impl ResponseStats {
             self.error_map.entry(source).or_default()
         } else if status.is_excluded() {
             self.excluded_map.entry(source).or_default()
+        } else if status.is_unsupported() {
+            self.unsupported_map.entry(source).or_default()
         } else if status.is_success() && self.detailed_stats {
             self.success_map.entry(source).or_default()
         } else {
@@ -202,6 +207,10 @@ mod tests {
         mock_response(Status::Excluded)
     }
 
+    fn dummy_unsupported() -> Response {
+        mock_response(Status::Unsupported(ErrorKind::InvalidUrlHost))
+    }
+
     #[tokio::test]
     async fn test_stats_is_empty() {
         let mut stats = ResponseStats::default();
@@ -230,6 +239,26 @@ mod tests {
         assert_eq!(stats.error_map, expected_error_map);
 
         assert!(stats.success_map.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_unsupported_stats() {
+        let mut stats = ResponseStats::default();
+        assert!(stats.unsupported_map.is_empty());
+
+        stats.add(dummy_unsupported());
+
+        // Unsupported (ignored) responses are counted
+        assert_eq!(stats.unsupported, 1);
+
+        // Stored so they can be listed in the summary
+        let response = dummy_unsupported();
+        let expected_unsupported_map: HashMap<InputSource, HashSet<ResponseBody>> =
+            HashMap::from_iter([(
+                response.source().clone(),
+                HashSet::from_iter([response.into_body()]),
+            )]);
+        assert_eq!(stats.unsupported_map, expected_unsupported_map);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #997.

When lychee can't turn a URL into a request (e.g. a malformed scheme like `hhttps://` or an unsupported scheme like `slack://`), it records the response as `Unsupported` and displays it as `IGNORED`. Until now, these links were counted in the summary but never listed, so the only hint that something was ignored was that `Total` didn't equal the sum of the visible categories (easy to miss in a repo with thousands of links).

This PR lists ignored links per input, mirroring how Errors, Timeouts, Redirects and Suggestions are already broken out.

## What changed

The root cause was in the data layer, not just formatting. `ResponseStats` counted unsupported responses but never stored them (so they fell through `add_response_status`'s final `else { return; }`), thus the formatters had no data to list. So here's what I changed:

- **`response.rs`** - adds an `unsupported_map` to `ResponseStats`, populated alongside the existing error/timeout/excluded maps (via `Status::is_unsupported()`).
- **`markdown.rs`** - adds an `## Ignored per input` section.
- **`compact.rs`** - lists ignored links per input, including inputs whose only finding is ignored links.
- **`detailed.rs`** - adds an `Ignored in <source>` section.
- **`json.rs`** - the new field is serialized, so JSON output now includes `unsupported_map` (snapshot updated).

### Example (markdown)

Before, the report said `⛔ Unsupported | 2` but listed none of them. After:

    ## Ignored per input

    ### Ignored in README.md

    * [IGNORED] <hhttps://example.com> (at 6:1) | Unsupported: ...

## Also included: a small related fix

While in `detailed.rs` I noticed the `⛔ Unsupported` summary row printed `stats.errors` instead of `stats.unsupported`, so it showed the error count under the Unsupported label. Fixed as a **separate commit** (`fix(stats): use the unsupported count in the detailed summary`) since it's on-topic for #997. Happy to split it into its own PR if you'd prefer or exclude it.

## A design choice worth flagging

In the compact formatter I included ignored links in the `Issues found in N inputs` count so the header matches the number of detail blocks shown. Ignored links don't affect the exit code (`is_success()` is unchanged). If we'd rather keep "Issues" strictly for errors/timeouts, I can drop them from that count while still listing them.

## Testing

- New unit tests: ignored responses are counted and stored (`response.rs`), plus per-formatter render tests in `markdown.rs` / `compact.rs` / `detailed.rs`, including the "only ignored links" case.
- All existing stats tests still pass; full `cargo test --bin lychee` is green and `cargo clippy` is clean.