### PR TITLE
fix: default-extension not applied to local files, and tweak help

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,18 +458,19 @@ Options:
           and existing cookies will be updated.
 
       --default-extension <EXTENSION>
-          Treat input sources without a recognised extension as if they had the
-          given extension.
+          Parse input sources without a recognised file type by using the given
+          file extension.
 
-          The extension will be used to determine the file format for link
-          extraction. This is useful for stdin inputs, files without extensions,
-          and files with unknown extensions.
+          This affects how links are extracted from certain input sources. This
+          is useful for stdin inputs, files without extensions, and files with
+          unknown extensions.
 
           Examples:
             --default-extension md
             --default-extension html
 
-          To automatically append file extensions to links, see `--fallback-extensions`.
+          To automatically append file extensions when locating files, see
+          `--fallback-extensions`.
 
       --dump[=<false|true>]
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked

--- a/README.md
+++ b/README.md
@@ -469,6 +469,8 @@ Options:
             --default-extension md
             --default-extension html
 
+          See also: `--fallback-extensions`.
+
       --dump[=<false|true>]
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked
 

--- a/README.md
+++ b/README.md
@@ -458,10 +458,12 @@ Options:
           and existing cookies will be updated.
 
       --default-extension <EXTENSION>
-          This is the default file extension that is applied to files without an extension.
+          Treat input sources without a recognised extension (or Content-Type
+          header) as if they had the given extension.
 
-          This is useful for files without extensions or with unknown extensions.
-          The extension will be used to determine the file type for processing.
+          The extension will be used to determine the file format for link
+          extraction. This is useful for stdin inputs, files without extensions,
+          and files with unknown extensions.
 
           Examples:
             --default-extension md

--- a/README.md
+++ b/README.md
@@ -458,8 +458,8 @@ Options:
           and existing cookies will be updated.
 
       --default-extension <EXTENSION>
-          Treat input sources without a recognised extension (or Content-Type
-          header) as if they had the given extension.
+          Treat input sources without a recognised extension as if they had the
+          given extension.
 
           The extension will be used to determine the file format for link
           extraction. This is useful for stdin inputs, files without extensions,

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Options:
             --default-extension md
             --default-extension html
 
-          See also: `--fallback-extensions`.
+          To automatically append file extensions to links, see `--fallback-extensions`.
 
       --dump[=<false|true>]
           Don't perform any link checking. Instead, dump all the links extracted from inputs that would be checked

--- a/benches/src/extract.rs
+++ b/benches/src/extract.rs
@@ -42,10 +42,10 @@ fn benchmark(c: &mut Criterion) {
 
     runtime.block_on(async {
         inputs = vec![
-            Input::path_content("../fixtures/bench/elvis.html", None)
+            Input::path_content("../fixtures/bench/elvis.html", None, None)
                 .await
                 .unwrap(),
-            Input::path_content("../fixtures/bench/arch.html", None)
+            Input::path_content("../fixtures/bench/arch.html", None, None)
                 .await
                 .unwrap(),
         ];

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -241,7 +241,7 @@ pub(crate) struct Config {
     ///   --default-extension md
     ///   --default-extension html
     ///
-    /// See also: `--fallback-extensions`.
+    /// To automatically append file extensions to links, see `--fallback-extensions`.
     #[arg(long, value_name = "EXTENSION", verbatim_doc_comment)]
     default_extension: Option<String>,
 

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -230,10 +230,12 @@ pub(crate) struct Config {
     #[arg(long, verbatim_doc_comment)]
     extensions: Option<FileExtensions>,
 
-    /// This is the default file extension that is applied to files without an extension.
+    /// Treat input sources without a recognised extension (or Content-Type
+    /// header) as if they had the given extension.
     ///
-    /// This is useful for files without extensions or with unknown extensions.
-    /// The extension will be used to determine the file type for processing.
+    /// The extension will be used to determine the file format for link
+    /// extraction. This is useful for stdin inputs, files without extensions,
+    /// and files with unknown extensions.
     ///
     /// Examples:
     ///   --default-extension md

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -230,8 +230,8 @@ pub(crate) struct Config {
     #[arg(long, verbatim_doc_comment)]
     extensions: Option<FileExtensions>,
 
-    /// Treat input sources without a recognised extension (or Content-Type
-    /// header) as if they had the given extension.
+    /// Treat input sources without a recognised extension as if they had the
+    /// given extension.
     ///
     /// The extension will be used to determine the file format for link
     /// extraction. This is useful for stdin inputs, files without extensions,

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -240,6 +240,8 @@ pub(crate) struct Config {
     /// Examples:
     ///   --default-extension md
     ///   --default-extension html
+    ///
+    /// See also: `--fallback-extensions`.
     #[arg(long, value_name = "EXTENSION", verbatim_doc_comment)]
     default_extension: Option<String>,
 

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -230,18 +230,19 @@ pub(crate) struct Config {
     #[arg(long, verbatim_doc_comment)]
     extensions: Option<FileExtensions>,
 
-    /// Treat input sources without a recognised extension as if they had the
-    /// given extension.
+    /// Parse input sources without a recognised file type by using the given
+    /// file extension.
     ///
-    /// The extension will be used to determine the file format for link
-    /// extraction. This is useful for stdin inputs, files without extensions,
-    /// and files with unknown extensions.
+    /// This affects how links are extracted from certain input sources. This
+    /// is useful for stdin inputs, files without extensions, and files with
+    /// unknown extensions.
     ///
     /// Examples:
     ///   --default-extension md
     ///   --default-extension html
     ///
-    /// To automatically append file extensions to links, see `--fallback-extensions`.
+    /// To automatically append file extensions when locating files, see
+    /// `--fallback-extensions`.
     #[arg(long, value_name = "EXTENSION", verbatim_doc_comment)]
     default_extension: Option<String>,
 

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -3514,14 +3514,16 @@ The config file should contain every possible key for documentation purposes."
             .arg(file_without_ext.path())
             .assert()
             .success()
-            .stdout(contains("https://example.com"));
+            .stdout(contains("https://example.com"))
+            .stdout(contains("local.md"));
 
         let mut html_file_without_ext = NamedTempFile::new()?;
         // Create HTML content but with no file extension
         writeln!(html_file_without_ext, "<html><body>")?;
         writeln!(
             html_file_without_ext,
-            "<a href=\"https://html-example.com\">HTML Link</a>"
+            "<a href=\"https://html-example.com\">HTML Link</a>
+             <a href=\"relative-html-link\">HTML Link</a>"
         )?;
         writeln!(html_file_without_ext, "</body></html>")?;
 
@@ -3533,7 +3535,8 @@ The config file should contain every possible key for documentation purposes."
             .arg(html_file_without_ext.path())
             .assert()
             .success()
-            .stdout(contains("https://html-example.com"));
+            .stdout(contains("https://html-example.com"))
+            .stdout(contains("relative-html-link"));
 
         Ok(())
     }

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -13,6 +13,7 @@ use crate::{ErrorKind, LycheeResult};
 use async_stream::try_stream;
 use futures::stream::{Stream, StreamExt};
 use log::debug;
+use std::ffi::OsStr;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use tokio::io::{AsyncReadExt, stdin};
@@ -257,17 +258,11 @@ impl Input {
         let path = path.into();
         let content = Self::get_content(&path, preprocessor).await?;
 
-        // This implementation is not the best. Any plaintext file is changed
-        // to the default extension, but a file could genuinely be plaintext.
-        // To do this properly would need something like a TryFrom for FileType,
-        // but this conflicts with the From which is heavily used.
-        //
-        // It's not a big deal right now because the HTML and markdown extractors
-        // also perform plaintext extraction.
-        let file_type = match (FileType::from(&path), file_type_hint) {
-            (FileType::Plaintext, Some(default)) => default,
-            (file_type, _) => file_type,
-        };
+        let ext = path.extension().and_then(OsStr::to_str);
+        let file_type = ext
+            .and_then(FileType::from_extension)
+            .or(file_type_hint)
+            .unwrap_or_default();
 
         Ok(InputContent {
             file_type,

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -165,7 +165,7 @@ impl Input {
                     Ok(source) => {
                         let content_result = match source {
                             ResolvedInputSource::FsPath(path) => {
-                                Self::path_content(&path, preprocessor.as_ref()).await
+                                Self::path_content(&path, preprocessor.as_ref(), self.file_type_hint).await
                             },
                             ResolvedInputSource::RemoteUrl(url) => {
                                 resolver.url_contents(*url).await
@@ -252,12 +252,18 @@ impl Input {
     pub async fn path_content<P: Into<PathBuf> + AsRef<Path> + Clone>(
         path: P,
         preprocessor: Option<&Preprocessor>,
+        file_type_hint: Option<FileType>,
     ) -> LycheeResult<InputContent> {
         let path = path.into();
         let content = Self::get_content(&path, preprocessor).await?;
 
+        let file_type = match (FileType::from(&path), file_type_hint) {
+            (FileType::Plaintext, Some(default)) => default,
+            (file_type, _) => file_type,
+        };
+
         Ok(InputContent {
-            file_type: FileType::from(&path),
+            file_type,
             source: ResolvedInputSource::FsPath(path),
             content,
         })

--- a/lychee-lib/src/types/input/input.rs
+++ b/lychee-lib/src/types/input/input.rs
@@ -257,6 +257,13 @@ impl Input {
         let path = path.into();
         let content = Self::get_content(&path, preprocessor).await?;
 
+        // This implementation is not the best. Any plaintext file is changed
+        // to the default extension, but a file could genuinely be plaintext.
+        // To do this properly would need something like a TryFrom for FileType,
+        // but this conflicts with the From which is heavily used.
+        //
+        // It's not a big deal right now because the HTML and markdown extractors
+        // also perform plaintext extraction.
         let file_type = match (FileType::from(&path), file_type_hint) {
             (FileType::Plaintext, Some(default)) => default,
             (file_type, _) => file_type,


### PR DESCRIPTION
This implementation is not the best because any plaintext file is changed to the default extension, but a file could genuinely be a plaintext file. To do this properly would need something like a TryFrom for FileType, but this conflicts with the From which is heavily used. It's probably not a big deal right now because the HTML and markdown extractors also perform plaintext extraction.

Also tries to improve the CLI help text based on suggestions in issue.

Fixes https://github.com/lycheeverse/lychee/issues/2244