### PR TITLE
Recognize block-style heading attributes

### DIFF
--- a/fixtures/fragments/file1.md
+++ b/fixtures/fragments/file1.md
@@ -34,6 +34,11 @@ Explicit fragment links are also supported.
 
 [Custom fragment id in file2](file2.md#custom-id)
 
+{#block-heading-id}
+## Block Heading Attribute
+
+[Link to block heading attribute](#block-heading-id)
+
 # Kebab Case Fragment
 
 [Link to kebab-case fragment](#kebab-case-fragment)

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -2501,6 +2501,7 @@ The config file should contain every possible key for documentation purposes."
         let expected_successes = vec![
             "fixtures/fragments/empty_dir",
             "fixtures/fragments/empty_file#fragment", // XXX: is this a bug? a fragment in an empty file is being treated as valid
+            "fixtures/fragments/file1.md#block-heading-id",
             "fixtures/fragments/file1.md#code-heading",
             "fixtures/fragments/file1.md#explicit-fragment",
             "fixtures/fragments/file1.md#f%C3%BCnf-s%C3%9C%C3%9Fe-%C3%84pfel",

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -486,6 +486,35 @@ or inline like `https://bar.org` for instance.
     }
 
     #[test]
+    fn test_extract_fragments_from_preceding_heading_attributes_ignores_non_heading_blocks() {
+        let markdown = r"
+{#not-a-heading-id}
+
+This paragraph consumes the pending block attribute.
+
+### Heading two
+";
+
+        let actual = extract_markdown_fragments(markdown);
+
+        assert!(!actual.contains("not-a-heading-id"));
+        assert!(actual.contains("heading-two"));
+    }
+
+    #[test]
+    fn test_extract_fragments_from_preceding_heading_attributes_ignores_missing_id() {
+        let markdown = r"
+{.class key=value #}
+### Heading two
+";
+
+        let actual = extract_markdown_fragments(markdown);
+
+        assert!(!actual.contains(""));
+        assert!(actual.contains("heading-two"));
+    }
+
+    #[test]
     fn test_skip_verbatim() {
         let expected = vec![
             RawUri {

--- a/lychee-lib/src/extract/markdown.rs
+++ b/lychee-lib/src/extract/markdown.rs
@@ -279,8 +279,18 @@ fn raw_uri(dest_url: &CowStr<'_>, span: RawUriSpan) -> Vec<RawUri> {
 /// [heading attribute]: https://github.com/pulldown-cmark/pulldown-cmark/blob/94e7011a22a235e3abc5c5d6f3615192a6b1e42b/pulldown-cmark/specs/heading_attrs.txt
 pub(crate) fn extract_markdown_fragments(input: &str) -> HashSet<String> {
     let mut in_heading = false;
+    let mut in_paragraph = false;
     let mut heading_text = String::new();
+    // Explicit ID parsed from pulldown-cmark's inline heading attribute support,
+    // e.g. `## Heading {#custom-id}`.
     let mut heading_id: Option<CowStr<'_>> = None;
+    // Explicit ID parsed from a standalone attribute paragraph immediately
+    // before a heading, e.g. `{#custom-id}\n## Heading`.
+    let mut heading_block_id: Option<HeadingId> = None;
+    let mut paragraph_text: Option<String> = None;
+    // Block attributes are emitted as the paragraph before the heading they
+    // belong to, so keep one pending ID until the next block starts.
+    let mut pending_heading_block_id: Option<HeadingId> = None;
     let mut id_generator = GithubHeadingIdGenerator::new();
 
     let mut out = HashSet::new();
@@ -288,12 +298,25 @@ pub(crate) fn extract_markdown_fragments(input: &str) -> HashSet<String> {
     for event in Parser::new_ext(input, md_extensions()) {
         match event {
             Event::Start(Tag::Heading { id, .. }) => {
+                heading_block_id = pending_heading_block_id.take();
                 heading_id = id;
                 in_heading = true;
+            }
+            Event::Start(Tag::Paragraph) => {
+                pending_heading_block_id = None;
+                paragraph_text = Some(String::new());
+                in_paragraph = true;
+            }
+            Event::Start(_) if !in_heading && !in_paragraph => {
+                pending_heading_block_id = None;
             }
             Event::End(TagEnd::Heading(_)) => {
                 if let Some(frag) = heading_id.take() {
                     out.insert(frag.to_string());
+                }
+
+                if let Some(frag) = heading_block_id.take() {
+                    out.insert(frag.into_string());
                 }
 
                 if !heading_text.is_empty() {
@@ -304,12 +327,32 @@ pub(crate) fn extract_markdown_fragments(input: &str) -> HashSet<String> {
 
                 in_heading = false;
             }
+            Event::End(TagEnd::Paragraph) => {
+                pending_heading_block_id = paragraph_text
+                    .take()
+                    .and_then(|text| extract_block_heading_id(&text));
+                in_paragraph = false;
+            }
             Event::Text(text) | Event::Code(text) if in_heading => {
                 heading_text.push_str(&text);
+            }
+            Event::Text(text) | Event::Code(text) if in_paragraph => {
+                let keep_collecting = paragraph_text.as_ref().is_some_and(|text_buffer| {
+                    !text_buffer.is_empty() || text.trim_start().starts_with('{')
+                });
+
+                if keep_collecting {
+                    if let Some(paragraph_text) = &mut paragraph_text {
+                        paragraph_text.push_str(&text);
+                    }
+                } else {
+                    paragraph_text = None;
+                }
             }
 
             // An HTML node
             Event::Html(html) | Event::InlineHtml(html) => {
+                pending_heading_block_id = None;
                 out.extend(extract_html_fragments(&html));
             }
 
@@ -318,6 +361,36 @@ pub(crate) fn extract_markdown_fragments(input: &str) -> HashSet<String> {
         }
     }
     out
+}
+
+fn extract_block_heading_id(text: &str) -> Option<HeadingId> {
+    let inner = text.trim().strip_prefix('{')?.strip_suffix('}')?.trim();
+
+    inner
+        .split_whitespace()
+        .find_map(|attribute| HeadingId::try_from(attribute).ok())
+}
+
+struct HeadingId(String);
+
+impl HeadingId {
+    fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl TryFrom<&str> for HeadingId {
+    type Error = ();
+
+    fn try_from(attribute: &str) -> Result<Self, Self::Error> {
+        let id = attribute.strip_prefix('#').ok_or(())?;
+
+        if id.is_empty() {
+            return Err(());
+        }
+
+        Ok(Self(id.to_string()))
+    }
 }
 
 #[cfg(test)]
@@ -395,6 +468,21 @@ or inline like `https://bar.org` for instance.
 
         let actual = extract_markdown_fragments(&md);
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_extract_fragments_from_preceding_heading_attributes() {
+        let markdown = r"
+# Attribute-list anchor test
+
+{#block-id}
+### Heading two
+";
+
+        let actual = extract_markdown_fragments(markdown);
+
+        assert!(actual.contains("block-id"));
+        assert!(actual.contains("heading-two"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #2249.

`--include-fragments` already recognizes heading IDs written inline as `### Heading {#id}`. This adds the same fragment recognition for MyST-style preceding block attributes such as:

```markdown
{#block-id}
### Heading
```

The change is scoped to Markdown fragment extraction. A block attribute is only applied to the immediately following heading, and the normal generated heading fragment is still emitted.

## Changes

- Track a pending `{#id}` paragraph before a heading during Markdown fragment extraction.
- Add regression coverage for the block attribute form while keeping generated heading IDs intact.

## Testing

- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p lychee-lib test_extract_fragments_from_preceding_heading_attributes -- --nocapture` (failed before the fix, passed after)
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p lychee-lib extract::markdown -- --nocapture`
- `PATH="$HOME/.cargo/bin:$PATH" cargo fmt --all -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" cargo clippy -p lychee-lib --all-targets --all-features -- -D warnings`
- `PATH="$HOME/.cargo/bin:$PATH" cargo test -p lychee-lib`
- `git diff --check`

Note: I used Codex while preparing this change, reviewed the final diff, and ran the listed checks locally.