### PR TITLE
Add domains and links to the Per-host stats header

### DIFF
--- a/lychee-bin/src/formatters/host_stats/compact.rs
+++ b/lychee-bin/src/formatters/host_stats/compact.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display};
 
+use super::write_header;
 use crate::formatters::color::{DIM, NORMAL, color};
 use lychee_lib::ratelimit::HostStatsMap;
 
@@ -13,8 +14,7 @@ impl Display for CompactHostStats {
             return Ok(());
         };
 
-        writeln!(f)?;
-        writeln!(f, "📊 Per-host Statistics")?;
+        write_header(f, "📊 ", host_stats)?;
 
         let separator = "─".repeat(60);
         color!(f, DIM, "{}", separator)?;

--- a/lychee-bin/src/formatters/host_stats/compact.rs
+++ b/lychee-bin/src/formatters/host_stats/compact.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::write_header;
+use super::write_host_heading;
 use crate::formatters::color::{DIM, NORMAL, color};
 use lychee_lib::ratelimit::HostStatsMap;
 
@@ -14,7 +14,8 @@ impl Display for CompactHostStats {
             return Ok(());
         };
 
-        write_header(f, "📊 ", host_stats)?;
+        writeln!(f)?;
+        write_host_heading(f, "📊 ", host_stats)?;
 
         let separator = "─".repeat(60);
         color!(f, DIM, "{}", separator)?;

--- a/lychee-bin/src/formatters/host_stats/compact.rs
+++ b/lychee-bin/src/formatters/host_stats/compact.rs
@@ -14,8 +14,7 @@ impl Display for CompactHostStats {
             return Ok(());
         };
 
-        writeln!(f)?;
-        write_host_heading(f, "📊 ", host_stats)?;
+        write_host_heading(f, "\n📊 ", host_stats)?;
 
         let separator = "─".repeat(60);
         color!(f, DIM, "{}", separator)?;

--- a/lychee-bin/src/formatters/host_stats/detailed.rs
+++ b/lychee-bin/src/formatters/host_stats/detailed.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::write_header;
+use super::write_host_heading;
 use lychee_lib::ratelimit::HostStatsMap;
 
 pub(crate) struct DetailedHostStats {
@@ -13,7 +13,8 @@ impl Display for DetailedHostStats {
             return Ok(());
         };
 
-        write_header(f, "📊 ", host_stats)?;
+        writeln!(f)?;
+        write_host_heading(f, "📊 ", host_stats)?;
         writeln!(f, "---------------------")?;
 
         for (hostname, stats) in host_stats.sorted() {

--- a/lychee-bin/src/formatters/host_stats/detailed.rs
+++ b/lychee-bin/src/formatters/host_stats/detailed.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display};
 
+use super::write_header;
 use lychee_lib::ratelimit::HostStatsMap;
 
 pub(crate) struct DetailedHostStats {
@@ -12,7 +13,7 @@ impl Display for DetailedHostStats {
             return Ok(());
         };
 
-        writeln!(f, "\n📊 Per-host Statistics")?;
+        write_header(f, "📊 ", host_stats)?;
         writeln!(f, "---------------------")?;
 
         for (hostname, stats) in host_stats.sorted() {

--- a/lychee-bin/src/formatters/host_stats/detailed.rs
+++ b/lychee-bin/src/formatters/host_stats/detailed.rs
@@ -13,8 +13,7 @@ impl Display for DetailedHostStats {
             return Ok(());
         };
 
-        writeln!(f)?;
-        write_host_heading(f, "📊 ", host_stats)?;
+        write_host_heading(f, "\n📊 ", host_stats)?;
         writeln!(f, "---------------------")?;
 
         for (hostname, stats) in host_stats.sorted() {

--- a/lychee-bin/src/formatters/host_stats/markdown.rs
+++ b/lychee-bin/src/formatters/host_stats/markdown.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::write_header;
+use super::write_host_heading;
 use lychee_lib::ratelimit::HostStatsMap;
 use tabled::{
     Table, Tabled,
@@ -17,7 +17,8 @@ impl Display for MarkdownHostStats {
             return Ok(());
         };
 
-        write_header(f, "## ", host_stats)?;
+        writeln!(f)?;
+        write_host_heading(f, "## ", host_stats)?;
         writeln!(f)?;
         writeln!(f, "{}", host_stats_table(host_stats))?;
 

--- a/lychee-bin/src/formatters/host_stats/markdown.rs
+++ b/lychee-bin/src/formatters/host_stats/markdown.rs
@@ -1,5 +1,6 @@
 use std::fmt::{self, Display};
 
+use super::write_header;
 use lychee_lib::ratelimit::HostStatsMap;
 use tabled::{
     Table, Tabled,
@@ -16,7 +17,7 @@ impl Display for MarkdownHostStats {
             return Ok(());
         };
 
-        writeln!(f, "\n## Per-host Statistics")?;
+        write_header(f, "## ", host_stats)?;
         writeln!(f)?;
         writeln!(f, "{}", host_stats_table(host_stats))?;
 
@@ -41,9 +42,8 @@ struct HostStatsTableEntry {
 }
 
 fn host_stats_table(host_stats: &HostStatsMap) -> String {
-    let sorted_hosts = host_stats.sorted();
-
-    let entries: Vec<HostStatsTableEntry> = sorted_hosts
+    let entries: Vec<HostStatsTableEntry> = host_stats
+        .sorted()
         .into_iter()
         .map(|(hostname, stats)| {
             let median_time = stats
@@ -51,7 +51,7 @@ fn host_stats_table(host_stats: &HostStatsMap) -> String {
                 .map_or_else(|| "N/A".to_string(), |d| format!("{:.0}ms", d.as_millis()));
 
             HostStatsTableEntry {
-                host: hostname.clone(),
+                host: hostname,
                 requests: stats.total_requests,
                 success_rate: format!("{:.1}%", stats.success_rate() * 100.0),
                 network_errors: stats.network_errors,
@@ -65,9 +65,8 @@ fn host_stats_table(host_stats: &HostStatsMap) -> String {
         return String::new();
     }
 
-    let style = Style::markdown();
     Table::new(entries)
         .with(Modify::new(Segment::all()).with(Alignment::left()))
-        .with(style)
+        .with(Style::markdown())
         .to_string()
 }

--- a/lychee-bin/src/formatters/host_stats/markdown.rs
+++ b/lychee-bin/src/formatters/host_stats/markdown.rs
@@ -17,8 +17,7 @@ impl Display for MarkdownHostStats {
             return Ok(());
         };
 
-        writeln!(f)?;
-        write_host_heading(f, "## ", host_stats)?;
+        write_host_heading(f, "\n## ", host_stats)?;
         writeln!(f)?;
         writeln!(f, "{}", host_stats_table(host_stats))?;
 

--- a/lychee-bin/src/formatters/host_stats/mod.rs
+++ b/lychee-bin/src/formatters/host_stats/mod.rs
@@ -10,19 +10,15 @@ pub(crate) use compact::CompactHostStats;
 pub(crate) use detailed::DetailedHostStats;
 pub(crate) use markdown::MarkdownHostStats;
 
-/// Writes the header for a host statistics section.
-fn write_header(
+/// Writes the heading for a host statistics section.
+fn write_host_heading(
     f: &mut fmt::Formatter<'_>,
     prefix: &str,
     host_stats: &HostStatsMap,
 ) -> fmt::Result {
-    // Host stats are appended after response stats,
-    // so keep the section visually separated.
-    writeln!(f)?;
-
     writeln!(
         f,
-        "{prefix}Per-host Statistics ({hosts} domains, {requests} links checked)",
+        "{prefix}Per-host Statistics ({hosts} domains, {requests} requests)",
         hosts = host_stats.total_hosts(),
         requests = host_stats.total_requests(),
     )

--- a/lychee-bin/src/formatters/host_stats/mod.rs
+++ b/lychee-bin/src/formatters/host_stats/mod.rs
@@ -1,3 +1,7 @@
+use std::fmt;
+
+use lychee_lib::ratelimit::HostStatsMap;
+
 mod compact;
 mod detailed;
 mod markdown;
@@ -5,3 +9,21 @@ mod markdown;
 pub(crate) use compact::CompactHostStats;
 pub(crate) use detailed::DetailedHostStats;
 pub(crate) use markdown::MarkdownHostStats;
+
+/// Writes the header for a host statistics section.
+fn write_header(
+    f: &mut fmt::Formatter<'_>,
+    prefix: &str,
+    host_stats: &HostStatsMap,
+) -> fmt::Result {
+    // Host stats are appended after response stats,
+    // so keep the section visually separated.
+    writeln!(f)?;
+
+    writeln!(
+        f,
+        "{prefix}Per-host Statistics ({hosts} domains, {requests} links checked)",
+        hosts = host_stats.total_hosts(),
+        requests = host_stats.total_requests(),
+    )
+}

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -189,7 +189,7 @@ https://original.dev/ --> https://suggestion.dev/
 
 🔍 2 Total (in 0s) 🔗 2 Unique ✅ 0 OK 🚫 1 Error ⏳ 1 Timeouts 🔀 1 Redirects
 
-📊 Per-host Statistics
+📊 Per-host Statistics (1 domains, 5 links checked)
 ────────────────────────────────────────────────────────────
 example.com   │      5 reqs │   60.0% success │      N/A median │   20.0% cached
 "

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -181,17 +181,17 @@ mod tests {
             "Issues found in 2 inputs. Find details below.
 
 [https://example.com/]:
-[404] https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | 404 Not Found
+[404] https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | Rejected status code: 404 Not Found
 [TIMEOUT] https://httpbin.org/delay/2 (at 1:1) | Request timed out
 
 ℹ Suggestions
 https://original.dev/ --> https://suggestion.dev/
 
-🔍 2 Total (in 0s) 🔗 2 Unique ✅ 0 OK 🚫 1 Error ⏳ 1 Timeouts 🔀 1 Redirects
+🔍 5 Total (in 0s) 🔗 5 Unique ✅ 3 OK 🚫 1 Error ⏳ 1 Timeouts 🔀 1 Redirects
 
-📊 Per-host Statistics (1 domains, 5 links checked)
+📊 Per-host Statistics (1 domains, 5 requests)
 ────────────────────────────────────────────────────────────
-example.com   │      5 reqs │   60.0% success │      N/A median │   20.0% cached
+example.com   │      5 reqs │   60.0% success │    100ms median │   20.0% cached
 "
         );
     }

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -169,7 +169,7 @@ Redirects in https://example.com/
 https://1.dev/ --[308]--> https://2.dev/ --[308]--> http://redirected.dev/
 
 
-📊 Per-host Statistics
+📊 Per-host Statistics (1 domains, 5 links checked)
 ---------------------
 
 Host: example.com

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -147,9 +147,9 @@ mod tests {
             result,
             "📝 Summary
 ---------------------
-🔍 Total............2
-🔗 Unique...........2
-✅ Successful.......0
+🔍 Total............5
+🔗 Unique...........5
+✅ Successful.......3
 ⏳ Timeouts.........1
 🔀 Redirected.......1
 👻 Excluded.........0
@@ -158,7 +158,7 @@ mod tests {
 ⛔ Unsupported......0
 
 Errors in https://example.com/
-[404] https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | 404 Not Found
+[404] https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | Rejected status code: 404 Not Found
 [TIMEOUT] https://httpbin.org/delay/2 (at 1:1) | Request timed out
 
 Suggestions in https://example.com/
@@ -169,14 +169,15 @@ Redirects in https://example.com/
 https://1.dev/ --[308]--> https://2.dev/ --[308]--> http://redirected.dev/
 
 
-📊 Per-host Statistics (1 domains, 5 links checked)
+📊 Per-host Statistics (1 domains, 5 requests)
 ---------------------
 
 Host: example.com
   Total requests: 5
   Successful: 3 (60.0%)
-  Rate limited: 1 (429 Too Many Requests)
-  Server errors (5xx): 1
+  Client errors (4xx): 1
+  Network errors: 1
+  Median response time: 100ms
   Cache hit rate: 20.0%
   Cache hits: 1, misses: 4
 "

--- a/lychee-bin/src/formatters/stats/json.rs
+++ b/lychee-bin/src/formatters/stats/json.rs
@@ -24,9 +24,9 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     const EXPECTED_JSON: &str = r#"{
-  "total": 2,
-  "unique": 2,
-  "successful": 0,
+  "total": 5,
+  "unique": 5,
+  "successful": 3,
   "unknown": 0,
   "unsupported": 0,
   "timeouts": 1,
@@ -41,7 +41,7 @@ mod tests {
       {
         "url": "https://github.com/mre/idiomatic-rust-doesnt-exist-man",
         "status": {
-          "text": "404 Not Found",
+          "text": "Rejected status code: 404 Not Found",
           "code": 404
         },
         "span": {
@@ -111,11 +111,11 @@ mod tests {
       "total_requests": 5,
       "successful_requests": 3,
       "success_rate": 0.6,
-      "rate_limited": 1,
-      "client_errors": 0,
-      "server_errors": 1,
-      "network_errors": 0,
-      "median_request_time_ms": null,
+      "rate_limited": 0,
+      "client_errors": 1,
+      "server_errors": 0,
+      "network_errors": 1,
+      "median_request_time_ms": 100,
       "cache_hits": 1,
       "cache_misses": 4,
       "cache_hit_rate": 0.2,

--- a/lychee-bin/src/formatters/stats/junit.rs
+++ b/lychee-bin/src/formatters/stats/junit.rs
@@ -111,8 +111,8 @@ mod tests {
 <testsuites name="lychee link check results" tests="3" failures="1" errors="0">
     <testsuite name="lychee link check results" tests="3" disabled="1" errors="0" failures="1">
         <testcase name="Failed https://github.com/mre/idiomatic-rust-doesnt-exist-man" time="1.000" file="https://example.com/" line="1">
-            <failure message="https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | 404 Not Found"/>
-            <system-out>https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | 404 Not Found</system-out>
+            <failure message="https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | Rejected status code: 404 Not Found"/>
+            <system-out>https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | Rejected status code: 404 Not Found</system-out>
         </testcase>
         <testcase name="Excluded https://excluded.org/" time="0.042" file="https://example.com/">
             <skipped message="https://excluded.org/ | This is due to your &apos;exclude&apos; values"/>

--- a/lychee-bin/src/formatters/stats/markdown.rs
+++ b/lychee-bin/src/formatters/stats/markdown.rs
@@ -271,9 +271,9 @@ mod tests {
 
 | Status         | Count |
 |----------------|-------|
-| 🔍 Total       | 2     |
-| 🔗 Unique      | 2     |
-| ✅ Successful  | 0     |
+| 🔍 Total       | 5     |
+| 🔗 Unique      | 5     |
+| ✅ Successful  | 3     |
 | ⏳ Timeouts    | 1     |
 | 🔀 Redirected  | 1     |
 | 👻 Excluded    | 0     |
@@ -285,7 +285,7 @@ mod tests {
 
 ### Errors in https://example.com/
 
-* [404] <https://github.com/mre/idiomatic-rust-doesnt-exist-man> (at 1:1) | 404 Not Found
+* [404] <https://github.com/mre/idiomatic-rust-doesnt-exist-man> (at 1:1) | Rejected status code: 404 Not Found
 
 ## Timeouts per input
 

--- a/lychee-bin/src/formatters/stats/mod.rs
+++ b/lychee-bin/src/formatters/stats/mod.rs
@@ -126,12 +126,15 @@ where
     entries
 }
 
+/// Create a bunch of dummy stats for testing the formatters.
 #[cfg(test)]
 fn get_dummy_stats() -> OutputStats {
     use std::{num::NonZeroUsize, time::Duration};
 
     use http::StatusCode;
-    use lychee_lib::{RawUriSpan, Redirect, Redirects, ResponseBody, Status, ratelimit::HostStats};
+    use lychee_lib::{
+        ErrorKind, RawUriSpan, Redirect, Redirects, ResponseBody, Status, ratelimit::HostStats,
+    };
     use url::Url;
 
     use crate::formatters::suggestion::Suggestion;
@@ -149,7 +152,7 @@ fn get_dummy_stats() -> OutputStats {
             uri: "https://github.com/mre/idiomatic-rust-doesnt-exist-man"
                 .try_into()
                 .unwrap(),
-            status: Status::Ok(StatusCode::NOT_FOUND),
+            status: Status::Error(ErrorKind::RejectedStatusCode(StatusCode::NOT_FOUND)),
             redirects: None,
             remap: None,
             span: SPAN,
@@ -190,8 +193,9 @@ fn get_dummy_stats() -> OutputStats {
     let redirect_map = HashMap::from([(source.clone(), HashSet::from([redirects]))]);
 
     let response_stats = ResponseStats {
-        total: 2,
-        unique: 2,
+        total: 5,
+        unique: 5,
+        successful: 3,
         errors: 1,
         timeouts: 1,
         redirects: 1,
@@ -208,8 +212,15 @@ fn get_dummy_stats() -> OutputStats {
         HostStats {
             total_requests: 5,
             successful_requests: 3,
-            rate_limited: 1,
-            server_errors: 1,
+            client_errors: 1,
+            network_errors: 1,
+            request_times: vec![
+                Duration::from_millis(80),
+                Duration::from_millis(90),
+                Duration::from_millis(100),
+                Duration::from_millis(110),
+                Duration::from_millis(120),
+            ],
             cache_hits: 1,
             cache_misses: 4,
             ..Default::default()

--- a/lychee-lib/src/ratelimit/host/stats.rs
+++ b/lychee-lib/src/ratelimit/host/stats.rs
@@ -17,6 +17,18 @@ impl HostStatsMap {
         sorted_hosts.sort_by_key(|(_, stats)| std::cmp::Reverse(stats.total_requests));
         sorted_hosts
     }
+
+    /// Returns the number of unique hosts that have been accessed.
+    #[must_use]
+    pub fn total_hosts(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Returns the number of total requests across all hosts.
+    #[must_use]
+    pub fn total_requests(&self) -> u64 {
+        self.0.values().map(|stats| stats.total_requests).sum()
+    }
 }
 
 impl From<HashMap<String, HostStats>> for HostStatsMap {


### PR DESCRIPTION
This adds the status line discussed in https://github.com/lycheeverse/lychee/issues/1998#issuecomment-3798779520 to the host stats output.

(Admittedly, the entire code around stats formatting could be much nicer. It is very imperative at the moment. But I decided to keep the changes small and focused. A bigger refactor could be done in the future.)

Related to: #1998