### PR TITLE
Add short per-domain statistics

### DIFF
--- a/lychee-bin/src/formatters/host_stats/compact.rs
+++ b/lychee-bin/src/formatters/host_stats/compact.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::{status_summary, write_host_heading};
+use super::{host_heading, status_summary};
 use crate::formatters::color::{NORMAL, color};
 use lychee_lib::ratelimit::HostStatsMap;
 
@@ -14,7 +14,7 @@ impl Display for CompactHostStats {
             return Ok(());
         };
 
-        write_host_heading(f, "\n📊 ", host_stats)?;
+        writeln!(f, "{}", host_heading("\n📊 ", host_stats))?;
 
         let sorted_hosts = host_stats.sorted();
         let hostname_width = sorted_hosts
@@ -25,12 +25,14 @@ impl Display for CompactHostStats {
             .max(10);
 
         for (hostname, stats) in sorted_hosts {
+            let status_summary = status_summary(&stats);
+            let cache_summary = stats.cache_summary();
+
             color!(
                 f,
                 NORMAL,
-                "  {hostname:<width$}  {:>6} reqs  {}",
+                "  {hostname:<width$}  {:>6} reqs  {cache_summary:>12}    {status_summary}",
                 stats.total_requests,
-                status_summary(&stats),
                 width = hostname_width,
             )?;
             writeln!(f)?;

--- a/lychee-bin/src/formatters/host_stats/compact.rs
+++ b/lychee-bin/src/formatters/host_stats/compact.rs
@@ -1,7 +1,7 @@
 use std::fmt::{self, Display};
 
-use super::write_host_heading;
-use crate::formatters::color::{DIM, NORMAL, color};
+use super::{status_summary, write_host_heading};
+use crate::formatters::color::{NORMAL, color};
 use lychee_lib::ratelimit::HostStatsMap;
 
 pub(crate) struct CompactHostStats {
@@ -16,37 +16,22 @@ impl Display for CompactHostStats {
 
         write_host_heading(f, "\n📊 ", host_stats)?;
 
-        let separator = "─".repeat(60);
-        color!(f, DIM, "{}", separator)?;
-        writeln!(f)?;
-
         let sorted_hosts = host_stats.sorted();
-
-        // Calculate optimal hostname width based on longest hostname
-        let max_hostname_len = sorted_hosts
+        let hostname_width = sorted_hosts
             .iter()
             .map(|(hostname, _)| hostname.len())
             .max()
-            .unwrap_or(0);
-        let hostname_width = (max_hostname_len + 2).max(10); // At least 10 chars with padding
+            .unwrap_or(0)
+            .max(10);
 
         for (hostname, stats) in sorted_hosts {
-            let median_time = stats
-                .median_request_time()
-                .map_or_else(|| "N/A".to_string(), |d| format!("{:.0}ms", d.as_millis()));
-
-            let cache_hit_rate = stats.cache_hit_rate() * 100.0;
-
             color!(
                 f,
                 NORMAL,
-                "{:<width$} │ {:>6} reqs │ {:>6.1}% success │ {:>8} median │ {:>6.1}% cached",
-                hostname,
+                "  {hostname:<width$}  {:>6} reqs  {}",
                 stats.total_requests,
-                stats.success_rate() * 100.0,
-                median_time,
-                cache_hit_rate,
-                width = hostname_width
+                status_summary(&stats),
+                width = hostname_width,
             )?;
             writeln!(f)?;
         }

--- a/lychee-bin/src/formatters/host_stats/detailed.rs
+++ b/lychee-bin/src/formatters/host_stats/detailed.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::write_host_heading;
+use super::host_heading;
 use lychee_lib::ratelimit::HostStatsMap;
 
 pub(crate) struct DetailedHostStats {
@@ -13,8 +13,9 @@ impl Display for DetailedHostStats {
             return Ok(());
         };
 
-        write_host_heading(f, "\n📊 ", host_stats)?;
-        writeln!(f, "---------------------")?;
+        let heading = host_heading("📊 ", host_stats);
+        writeln!(f, "\n{heading}")?;
+        writeln!(f, "{}", "-".repeat(heading.chars().count()))?;
 
         for (hostname, stats) in host_stats.sorted() {
             writeln!(f, "\nHost: {hostname}")?;

--- a/lychee-bin/src/formatters/host_stats/markdown.rs
+++ b/lychee-bin/src/formatters/host_stats/markdown.rs
@@ -1,6 +1,6 @@
 use std::fmt::{self, Display};
 
-use super::write_host_heading;
+use super::host_heading;
 use lychee_lib::ratelimit::HostStatsMap;
 use tabled::{
     Table, Tabled,
@@ -17,7 +17,7 @@ impl Display for MarkdownHostStats {
             return Ok(());
         };
 
-        write_host_heading(f, "\n## ", host_stats)?;
+        writeln!(f, "{}", host_heading("\n## ", host_stats))?;
         writeln!(f)?;
         writeln!(f, "{}", host_stats_table(host_stats))?;
 

--- a/lychee-bin/src/formatters/host_stats/mod.rs
+++ b/lychee-bin/src/formatters/host_stats/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt;
-
 use lychee_lib::ratelimit::{HostStats, HostStatsMap};
 
 mod compact;
@@ -16,15 +14,6 @@ fn host_heading(prefix: &str, host_stats: &HostStatsMap) -> String {
         hosts = host_stats.total_hosts(),
         requests = host_stats.total_requests(),
     )
-}
-
-/// Writes the heading for a host statistics section.
-fn write_host_heading(
-    f: &mut fmt::Formatter<'_>,
-    prefix: &str,
-    host_stats: &HostStatsMap,
-) -> fmt::Result {
-    writeln!(f, "{}", host_heading(prefix, host_stats))
 }
 
 /// Returns a compact representation of the number of successful, failed, and

--- a/lychee-bin/src/formatters/host_stats/mod.rs
+++ b/lychee-bin/src/formatters/host_stats/mod.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use lychee_lib::ratelimit::HostStatsMap;
+use lychee_lib::ratelimit::{HostStats, HostStatsMap};
 
 mod compact;
 mod detailed;
@@ -10,16 +10,67 @@ pub(crate) use compact::CompactHostStats;
 pub(crate) use detailed::DetailedHostStats;
 pub(crate) use markdown::MarkdownHostStats;
 
+fn host_heading(prefix: &str, host_stats: &HostStatsMap) -> String {
+    format!(
+        "{prefix}Per-host Statistics ({hosts} domains, {requests} requests)",
+        hosts = host_stats.total_hosts(),
+        requests = host_stats.total_requests(),
+    )
+}
+
 /// Writes the heading for a host statistics section.
 fn write_host_heading(
     f: &mut fmt::Formatter<'_>,
     prefix: &str,
     host_stats: &HostStatsMap,
 ) -> fmt::Result {
-    writeln!(
-        f,
-        "{prefix}Per-host Statistics ({hosts} domains, {requests} requests)",
-        hosts = host_stats.total_hosts(),
-        requests = host_stats.total_requests(),
-    )
+    writeln!(f, "{}", host_heading(prefix, host_stats))
+}
+
+/// Returns a compact representation of the number of successful, failed, and
+/// unknown requests.
+///
+/// # Example output
+///
+/// `[✓ 65, ✗ 2, ? 1]`
+/// where
+/// - `✓` indicates successful requests,
+/// - `✗` indicates failed requests,
+/// - `?` indicates unknown requests.
+fn status_summary(stats: &HostStats) -> String {
+    let failed_requests = stats.rate_limited + stats.client_errors + stats.server_errors;
+    let unknown_requests = stats
+        .total_requests
+        .saturating_sub(stats.successful_requests + failed_requests);
+
+    let mut parts = Vec::new();
+    if stats.successful_requests > 0 {
+        parts.push(format!("✓ {}", stats.successful_requests));
+    }
+    if failed_requests > 0 {
+        parts.push(format!("✗ {failed_requests}"));
+    }
+    if unknown_requests > 0 {
+        parts.push(format!("? {unknown_requests}"));
+    }
+
+    format!("[{}]", parts.join(", "))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_status_summary_omits_zero_counts() {
+        let stats = HostStats {
+            total_requests: 68,
+            successful_requests: 65,
+            client_errors: 2,
+            network_errors: 1,
+            ..HostStats::default()
+        };
+
+        assert_eq!(status_summary(&stats), "[✓ 65, ✗ 2, ? 1]");
+    }
 }

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -190,8 +190,7 @@ https://original.dev/ --> https://suggestion.dev/
 🔍 5 Total (in 0s) 🔗 5 Unique ✅ 3 OK 🚫 1 Error ⏳ 1 Timeouts 🔀 1 Redirects
 
 📊 Per-host Statistics (1 domains, 5 requests)
-────────────────────────────────────────────────────────────
-example.com   │      5 reqs │   60.0% success │    100ms median │   20.0% cached
+  example.com       5 reqs  [✓ 3, ✗ 1, ? 1]
 "
         );
     }

--- a/lychee-bin/src/formatters/stats/compact.rs
+++ b/lychee-bin/src/formatters/stats/compact.rs
@@ -190,7 +190,7 @@ https://original.dev/ --> https://suggestion.dev/
 🔍 5 Total (in 0s) 🔗 5 Unique ✅ 3 OK 🚫 1 Error ⏳ 1 Timeouts 🔀 1 Redirects
 
 📊 Per-host Statistics (1 domains, 5 requests)
-  example.com       5 reqs  [✓ 3, ✗ 1, ? 1]
+  example.com       5 reqs  (20% cached)    [✓ 3, ✗ 1, ? 1]
 "
         );
     }

--- a/lychee-bin/src/formatters/stats/detailed.rs
+++ b/lychee-bin/src/formatters/stats/detailed.rs
@@ -170,7 +170,7 @@ https://1.dev/ --[308]--> https://2.dev/ --[308]--> http://redirected.dev/
 
 
 📊 Per-host Statistics (1 domains, 5 requests)
----------------------
+---------------------------------------------
 
 Host: example.com
   Total requests: 5

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1731,9 +1731,9 @@ The config file should contain every possible key for documentation purposes."
             // Per-host statistics
             // 2 rate limited + 8 OK
             .stdout(contains("10 reqs"))
-            .stdout(contains("80.0% success"))
+            .stdout(contains("[✓ 8, ✗ 2]"))
             // 2 rate limited, 1 OK, 7 cached
-            .stdout(contains("70.0% cached"));
+            .stdout(contains("(70% cached)"));
 
         server.verify().await;
         Ok(())

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1666,7 +1666,7 @@ The config file should contain every possible key for documentation purposes."
     async fn test_no_duplicate_requests() {
         let server = wiremock::MockServer::start().await;
         let count = 100; // given 100 duplicate URLs
-        let cached = "99.0%"; // we expect 99 out of 100 to be cached
+        let cached = "99%"; // we expect 99 out of 100 to be cached
 
         wiremock::Mock::given(wiremock::matchers::method("GET"))
             .respond_with(|_: &_| {
@@ -1687,8 +1687,9 @@ The config file should contain every possible key for documentation purposes."
             .arg("--host-request-interval=1s")
             .assert()
             .success()
-            .stdout(contains("100.0% success"))
-            .stdout(contains(format!("{cached} cached")));
+            .stdout(contains("100 reqs"))
+            .stdout(contains(format!("({cached} cached)")))
+            .stdout(contains("[✓ 100]"));
     }
 
     #[tokio::test]

--- a/lychee-lib/src/ratelimit/host/stats.rs
+++ b/lychee-lib/src/ratelimit/host/stats.rs
@@ -205,6 +205,12 @@ impl HostStats {
         }
     }
 
+    /// Get human-readable cache summary
+    #[must_use]
+    pub fn cache_summary(&self) -> String {
+        format!("({:.0}% cached)", self.cache_hit_rate() * 100.0)
+    }
+
     /// Get human-readable summary of the stats
     #[must_use]
     pub fn summary(&self) -> String {


### PR DESCRIPTION
This is the second part of #1998, where we show per-domain short statistics like so if `--host-stats` is enabled:

```
📊 Per-host Statistics (23 domains, 116 links checked)
  github.com                     67 links  [✓ 67]
  lychee.cli.rs                  17 links  [✓ 17]
  img.shields.io                  4 links  [✓ 4]
  docs.rs                         4 links  [✓ 4]
  ngi.eu                          4 links  [? 4]
  developer.mozilla.org           2 links  [✓ 2]
  nlnet.nl                        2 links  [✓ 2]
  chocolatey.org                  1 links  [✓ 1]
  opensource.org                  1 links  [✓ 1]
  pre-commit.com                  1 links  [✓ 1]
  doc.rust-lang.org               1 links  [✓ 1]
  raw.githubusercontent.com       1 links  [✓ 1]
  gitlab.torproject.org           1 links  [✓ 1]
  nixos.org                       1 links  [✓ 1]
  hub.docker.com                  1 links  [✓ 1]
  www.apache.org                  1 links  [✓ 1]
  docs.github.com                 1 links  [✓ 1]
  rust-lang.org                   1 links  [✓ 1]
  hello-rust.github.io            1 links  [✓ 1]
  crates.io                       1 links  [✓ 1]
  scoop.sh                        1 links  [✓ 1]
  brew.sh                         1 links  [✓ 1]
  www.macports.org                1 links  [✓ 1]
```

It's a follow-up of #2252. Once both PRs are merged, #1998 is considered done.

