### PR TITLE
feat(config): support per-host accept status codes

### DIFF
--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -271,6 +271,68 @@ mod tests {
         }
     }
 
+    /// The per-host `accept` override on a cache hit must be resolved from the
+    /// *cache-key* host (post-remap), not the original request host. Here the
+    /// request host (`request-host.com`) has no override and remaps to a
+    /// different cache-key host (`accepted-host.com`) which accepts 429. The
+    /// cached 429 is judged by the cache-key host's override, so it succeeds.
+    /// If resolution keyed off the request URL instead, this would fail.
+    #[tokio::test]
+    async fn test_cache_hit_resolves_accept_from_cache_key_host() {
+        use lychee_lib::remap::Remaps;
+
+        let host_cfg = HostConfig {
+            accept: Some(StatusCodeSelector::from_str("429").unwrap()),
+            ..HostConfig::default()
+        };
+        let hosts = HostConfigs::from([(HostKey::from("accepted-host.com".to_string()), host_cfg)]);
+
+        let accept: HashSet<StatusCode> = StatusCodeSelector::default_accepted().into();
+
+        let client = ClientBuilder::builder()
+            .accepted(accept.clone())
+            .hosts(hosts)
+            .remaps(Remaps::new(vec![(
+                regex::Regex::new("https://request-host.com").unwrap(),
+                "https://accepted-host.com".to_string(),
+            )]))
+            .build()
+            .client()
+            .unwrap();
+
+        let request = Request::try_from("https://request-host.com/").unwrap();
+
+        // Derive the cache key exactly as `handle` does (post-remap) so the
+        // inserted entry matches, and confirm the remap really crossed hosts.
+        let mut cache_key = request.uri.clone();
+        client.remap(&mut cache_key).unwrap();
+        assert_eq!(
+            cache_key.domain(),
+            Some("accepted-host.com"),
+            "remap must move the cache key to the override host"
+        );
+
+        let cache = Cache::new();
+        cache.insert(
+            cache_key,
+            CacheValue {
+                status: CacheStatus::Error(Some(StatusCode::TOO_MANY_REQUESTS)),
+                timestamp: timestamp(),
+            },
+        );
+
+        let never = |_req: Request| async move { unreachable!("cache hit; network must not run") };
+        let response = cache
+            .handle(&client, &HashSet::new(), &accept, request, never)
+            .await;
+
+        assert!(
+            response.status().is_success(),
+            "cached 429 must be judged by the cache-key host's override, got {:?}",
+            response.status()
+        );
+    }
+
     #[test]
     fn test_excluded_status_not_reused_from_cache() {
         let uri: Uri = "https://example.com".try_into().unwrap();

--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -157,7 +157,12 @@ fn cache_hit(
         // and they may have an impact on the interpretation of the status
         // code.
         client.host_pool().record_persistent_cache_hit(cache_key);
-        Status::from_cache_status(value.status, accept)
+        // Reinterpret the cached status against the accept set for the
+        // cache-key host. A per-host `accept` override replaces the global set;
+        // resolving from the cache-key (post-remap) `Uri` ensures a cross-host
+        // cache hit is judged by that host's codes, not the global ones.
+        let accept = client.host_pool().effective_accept(cache_key, accept);
+        Status::from_cache_status(value.status, &accept)
     };
 
     Response::new(
@@ -194,13 +199,77 @@ fn should_ignore(uri: &Uri, status: &Status, cache_exclude_status: &HashSet<Stat
 mod tests {
     use std::collections::HashSet;
 
+    use std::str::FromStr;
+
     use http::StatusCode;
-    use lychee_lib::{CacheStatus, ErrorKind, Status, StatusCodeSelector, StatusRange, Uri};
+    use lychee_lib::{
+        CacheStatus, ClientBuilder, ErrorKind, Request, Status, StatusCodeSelector, StatusRange,
+        Uri,
+        ratelimit::{HostConfig, HostConfigs, HostKey},
+    };
 
     use crate::{
         cache::{Cache, CacheValue, should_ignore},
         time::timestamp,
     };
+
+    /// A per-host `accept` override must be applied when reinterpreting a cached
+    /// status, and it must be resolved from the *cache-key host* so a cross-host
+    /// cache hit is judged by that host's codes, not the global set.
+    #[tokio::test]
+    async fn test_cache_hit_uses_per_host_accept() {
+        // Global default accepts 200..=299 only. `accepted-host.com` overrides
+        // accept to include 429; `other-host.com` has no override.
+        // (Avoid RFC 2606 example domains, which are excluded by default.)
+        let host_cfg = HostConfig {
+            accept: Some(StatusCodeSelector::from_str("429").unwrap()),
+            ..HostConfig::default()
+        };
+        let hosts = HostConfigs::from([(HostKey::from("accepted-host.com".to_string()), host_cfg)]);
+
+        let accept: HashSet<StatusCode> = StatusCodeSelector::default_accepted().into();
+
+        let client = ClientBuilder::builder()
+            .accepted(accept.clone())
+            .hosts(hosts)
+            .build()
+            .client()
+            .unwrap();
+        let never = |_req: Request| async move { unreachable!("cache hit; network must not run") };
+
+        // A previously-failing 429 is cached for both hosts.
+        for host in ["https://accepted-host.com/", "https://other-host.com/"] {
+            let request = Request::try_from(host).unwrap();
+            let cache = Cache::new();
+            cache.insert(
+                request.uri.clone(),
+                CacheValue {
+                    status: CacheStatus::Error(Some(StatusCode::TOO_MANY_REQUESTS)),
+                    timestamp: timestamp(),
+                },
+            );
+
+            let response = cache
+                .handle(&client, &HashSet::new(), &accept, request, never)
+                .await;
+
+            if host.contains("accepted-host") {
+                // Per-host override accepts 429 -> success.
+                assert!(
+                    response.status().is_success(),
+                    "accepted-host.com should accept cached 429, got {:?}",
+                    response.status()
+                );
+            } else {
+                // No override -> global set rejects 429 -> error.
+                assert!(
+                    response.status().is_error(),
+                    "other-host.com should reject cached 429, got {:?}",
+                    response.status()
+                );
+            }
+        }
+    }
 
     #[test]
     fn test_excluded_status_not_reused_from_cache() {

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -1244,6 +1244,7 @@ This convention also simplifies our default value testing."
                         "very secret".into(),
                     )]))
                     .unwrap(),
+                    accept: None,
                 },
             )]),
             ..Default::default()
@@ -1260,6 +1261,7 @@ This convention also simplifies our default value testing."
                         "there".into(),
                     )]))
                     .unwrap(),
+                    accept: None,
                 },
             )]),
             ..Default::default()
@@ -1277,7 +1279,8 @@ This convention also simplifies our default value testing."
                         ("password".into(), "very secret".into()),
                         ("hi".into(), "there".into()),
                     ]))
-                    .unwrap()
+                    .unwrap(),
+                    accept: None,
                 }
             )])
         );

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -176,9 +176,9 @@ mod cli {
         let bad_gateway = mock_server!(StatusCode::BAD_GATEWAY);
         let contents = format!(
             "{} {} {}",
-            &not_found.uri(),
-            &internal_server_error.uri(),
-            &bad_gateway.uri(),
+            not_found.uri(),
+            internal_server_error.uri(),
+            bad_gateway.uri(),
         );
 
         let mut cmd = cargo_bin_cmd!();

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -240,6 +240,7 @@ mod test {
     #[derive(Debug)]
     struct Add(usize);
 
+    #[allow(dead_code)] // work-around
     #[derive(Debug, PartialEq, Eq)]
     struct Result(usize);
 

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -400,10 +400,10 @@ mod tests {
     use wiremock::{Mock, MockServer, ResponseTemplate, matchers::method as method_matcher};
 
     use crate::{
-        BasicAuthExtractor, FragmentCheckerOptions, Uri,
+        BasicAuthExtractor, FragmentCheckerOptions, StatusCodeSelector, Uri,
         chain::RequestChain,
         checker::website::WebsiteChecker,
-        ratelimit::{HostConfigs, HostPool, RateLimitConfig},
+        ratelimit::{HostConfig, HostConfigs, HostKey, HostPool, RateLimitConfig},
         types::{
             DEFAULT_ACCEPTED_STATUS_CODES, Methods, redirect_history::RedirectHistory,
             uri::github::GithubUri,
@@ -412,11 +412,15 @@ mod tests {
 
     /// Build a checker for the given methods, routing requests through a
     /// `HostPool` that uses the supplied `reqwest::Client` (so tests can control
-    /// e.g. the request timeout).
-    fn checker_with(methods: Methods, client: reqwest::Client) -> WebsiteChecker {
+    /// e.g. the request timeout) and the supplied per-host overrides.
+    fn checker_with(
+        methods: Methods,
+        client: reqwest::Client,
+        host_configs: HostConfigs,
+    ) -> WebsiteChecker {
         let host_pool = HostPool::new(
             RateLimitConfig::default(),
-            HostConfigs::default(),
+            host_configs,
             client,
             std::collections::HashMap::new(),
         );
@@ -466,7 +470,7 @@ mod tests {
             .await;
 
         let methods = Methods::from_str("head,get").unwrap();
-        let checker = checker_with(methods, reqwest::Client::new());
+        let checker = checker_with(methods, reqwest::Client::new(), HostConfigs::default());
         let uri = Uri::try_from(server.uri().as_str()).unwrap();
 
         let (status, _) = checker.check_website(&uri).await;
@@ -500,7 +504,7 @@ mod tests {
             .build()
             .unwrap();
         let methods = Methods::from_str("head,get").unwrap();
-        let checker = checker_with(methods, client);
+        let checker = checker_with(methods, client, HostConfigs::default());
         let uri = Uri::try_from(server.uri().as_str()).unwrap();
 
         let (status, _) = checker.check_website(&uri).await;
@@ -508,6 +512,46 @@ mod tests {
         assert!(
             status.is_timeout(),
             "expected timeout to short-circuit fallback, got {status:?}"
+        );
+    }
+
+    /// A per-host `accept` override is applied on the live-check path: a host
+    /// configured to accept 429 treats a 429 response as success, while a host
+    /// without the override treats the same 429 as an error.
+    #[tokio::test]
+    async fn test_per_host_accept_override_on_live_check() {
+        let server = MockServer::start().await;
+        Mock::given(method_matcher("GET"))
+            .respond_with(ResponseTemplate::new(429))
+            .mount(&server)
+            .await;
+
+        let uri = Uri::try_from(server.uri().as_str()).unwrap();
+        let host = uri.url.host_str().unwrap().to_string();
+        let methods = Methods::from_str("get").unwrap();
+
+        // With a per-host `accept` override for the server's host, 429 is
+        // accepted and the check succeeds.
+        let hosts = HostConfigs::from([(
+            HostKey::from(host),
+            HostConfig {
+                accept: Some(StatusCodeSelector::from_str("429").unwrap()),
+                ..HostConfig::default()
+            },
+        )]);
+        let checker = checker_with(methods.clone(), reqwest::Client::new(), hosts);
+        let (status, _) = checker.check_website(&uri).await;
+        assert!(
+            status.is_success(),
+            "per-host accept override should treat 429 as success, got {status:?}"
+        );
+
+        // Without the override, the same 429 is an error.
+        let checker = checker_with(methods, reqwest::Client::new(), HostConfigs::default());
+        let (status, _) = checker.check_website(&uri).await;
+        assert!(
+            status.is_error(),
+            "without a per-host override, 429 should be an error, got {status:?}"
         );
     }
 

--- a/lychee-lib/src/checker/website.rs
+++ b/lychee-lib/src/checker/website.rs
@@ -143,7 +143,12 @@ impl WebsiteChecker {
             .await
         {
             Ok(response) => {
-                let status = Status::new(&response, &self.accepted);
+                // Resolve the accepted status codes for this host: a per-host
+                // `accept` override fully replaces the global set.
+                let accepted = self
+                    .host_pool
+                    .effective_accept(&request_url, &self.accepted);
+                let status = Status::new(&response, &accepted);
                 // when `accept=200,429`, `status_code=429` will be treated as success
                 // but we are not able the check the fragment since it's inapplicable.
                 if let Some(content) = response.text

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -962,7 +962,7 @@ mod tests {
     async fn test_max_redirects() {
         let mock_server = wiremock::MockServer::start().await;
 
-        let redirect_uri = format!("{}/redirect", &mock_server.uri());
+        let redirect_uri = format!("{}/redirect", mock_server.uri());
         let redirect = wiremock::ResponseTemplate::new(StatusCode::PERMANENT_REDIRECT)
             .insert_header("Location", redirect_uri.as_str());
 

--- a/lychee-lib/src/ratelimit/config.rs
+++ b/lychee-lib/src/ratelimit/config.rs
@@ -283,6 +283,34 @@ mod tests {
     }
 
     #[test]
+    fn test_host_config_merge_accept_precedence() {
+        let a = StatusCodeSelector::from_str("200").unwrap();
+        let b = StatusCodeSelector::from_str("429").unwrap();
+
+        // self=Some + other=Some -> self wins.
+        let merged = HostConfig {
+            accept: Some(a.clone()),
+            ..HostConfig::default()
+        }
+        .merge(HostConfig {
+            accept: Some(b.clone()),
+            ..HostConfig::default()
+        });
+        assert_eq!(merged.accept, Some(a));
+
+        // self=None + other=Some -> other fills in.
+        let merged = HostConfig::default().merge(HostConfig {
+            accept: Some(b.clone()),
+            ..HostConfig::default()
+        });
+        assert_eq!(merged.accept, Some(b));
+
+        // both None -> None.
+        let merged = HostConfig::default().merge(HostConfig::default());
+        assert_eq!(merged.accept, None);
+    }
+
+    #[test]
     fn test_config_serialization() {
         let config = RateLimitConfig {
             concurrency: 15,

--- a/lychee-lib/src/ratelimit/config.rs
+++ b/lychee-lib/src/ratelimit/config.rs
@@ -1,9 +1,10 @@
-use http::{HeaderMap, HeaderName, HeaderValue};
+use http::{HeaderMap, HeaderName, HeaderValue, StatusCode};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 use std::collections::hash_map::Iter;
+use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
+use crate::StatusCodeSelector;
 use crate::ratelimit::HostKey;
 
 /// Default number of concurrent requests per host
@@ -128,6 +129,14 @@ pub struct HostConfig {
     #[serde(deserialize_with = "deserialize_headers")]
     #[serde(serialize_with = "serialize_headers")]
     pub headers: HeaderMap,
+
+    /// Accepted status codes for this host.
+    ///
+    /// When set, this fully **replaces** the global `accept` set for this host
+    /// (it is not merged with it), consistent with how `concurrency` and
+    /// `request_interval` override their global defaults.
+    #[serde(default)]
+    pub accept: Option<StatusCodeSelector>,
 }
 
 impl Default for HostConfig {
@@ -136,6 +145,7 @@ impl Default for HostConfig {
             concurrency: None,
             request_interval: None,
             headers: HeaderMap::new(),
+            accept: None,
         }
     }
 }
@@ -154,6 +164,18 @@ impl HostConfig {
             .unwrap_or(global_config.request_interval)
     }
 
+    /// Get the effective set of accepted status codes.
+    ///
+    /// If this host defines its own `accept`, it fully **replaces** the global
+    /// set (no union). Otherwise the global set is used.
+    #[must_use]
+    pub fn effective_accept(&self, global: &HashSet<StatusCode>) -> HashSet<StatusCode> {
+        match &self.accept {
+            Some(selector) => selector.clone().into(),
+            None => global.clone(),
+        }
+    }
+
     #[must_use]
     pub(crate) fn merge(mut self, other: Self) -> Self {
         for (k, v) in other.headers {
@@ -166,6 +188,7 @@ impl HostConfig {
             concurrency: self.concurrency.or(other.concurrency),
             request_interval: self.request_interval.or(other.request_interval),
             headers: self.headers,
+            accept: self.accept.or(other.accept),
         }
     }
 }
@@ -205,6 +228,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::str::FromStr;
 
     #[test]
     fn test_default_rate_limit_config() {
@@ -230,12 +254,32 @@ mod tests {
             concurrency: Some(5),
             request_interval: Some(Duration::from_millis(500)),
             headers: HeaderMap::new(),
+            accept: None,
         };
         assert_eq!(host_config.effective_concurrency(&global_config), 5);
         assert_eq!(
             host_config.effective_request_interval(&global_config),
             Duration::from_millis(500)
         );
+    }
+
+    #[test]
+    fn test_host_config_effective_accept() {
+        let global: HashSet<StatusCode> = StatusCodeSelector::default_accepted().into();
+
+        // No per-host override: falls back to the global set.
+        let host_config = HostConfig::default();
+        assert_eq!(host_config.effective_accept(&global), global);
+
+        // Per-host override fully REPLACES the global set (no union).
+        let host_config = HostConfig {
+            accept: Some(StatusCodeSelector::from_str("429").unwrap()),
+            ..HostConfig::default()
+        };
+        let effective = host_config.effective_accept(&global);
+        assert_eq!(effective, HashSet::from([StatusCode::TOO_MANY_REQUESTS]));
+        // The global 200 is no longer accepted for this host.
+        assert!(!effective.contains(&StatusCode::OK));
     }
 
     #[test]
@@ -262,6 +306,7 @@ mod tests {
             concurrency: Some(5),
             request_interval: Some(Duration::from_millis(500)),
             headers,
+            accept: None,
         };
 
         let toml = toml::to_string(&host_config).unwrap();
@@ -275,5 +320,28 @@ mod tests {
         assert_eq!(deserialized.headers.len(), 2);
         assert!(deserialized.headers.contains_key("authorization"));
         assert!(deserialized.headers.contains_key("user-agent"));
+    }
+
+    #[test]
+    fn test_accept_deserialization() {
+        // Mirrors the per-host TOML shape: `[hosts."example.com"] accept = [200, 429]`
+        let host_config: HostConfig = toml::from_str("accept = [200, 429]").unwrap();
+        let selector = host_config.accept.expect("accept should be set");
+        assert!(selector.contains(200));
+        assert!(selector.contains(429));
+        assert!(!selector.contains(404));
+    }
+
+    #[test]
+    fn test_accept_serialization_round_trip() {
+        let host_config = HostConfig {
+            accept: Some(StatusCodeSelector::from_str("200..=204,429").unwrap()),
+            ..HostConfig::default()
+        };
+
+        let toml = toml::to_string(&host_config).unwrap();
+        let deserialized: HostConfig = toml::from_str(&toml).unwrap();
+
+        assert_eq!(deserialized.accept, host_config.accept);
     }
 }

--- a/lychee-lib/src/ratelimit/pool.rs
+++ b/lychee-lib/src/ratelimit/pool.rs
@@ -1,7 +1,7 @@
 use dashmap::DashMap;
-use http::Method;
+use http::{Method, StatusCode};
 use reqwest::{Client, Request};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use crate::ratelimit::{
@@ -92,6 +92,26 @@ impl HostPool {
             .request(method, uri.url.clone())
             .build()
             .map_err(ErrorKind::BuildRequestClient)
+    }
+
+    /// Resolve the effective set of accepted status codes for the host of
+    /// `key` (a URL or URI).
+    ///
+    /// If the host has its own `accept` override it fully **replaces** the
+    /// `global` set; otherwise `global` is returned unchanged. Falls back to
+    /// `global` when `key` has no valid host.
+    #[must_use]
+    pub fn effective_accept<K>(&self, key: K, global: &HashSet<StatusCode>) -> HashSet<StatusCode>
+    where
+        HostKey: TryFrom<K>,
+    {
+        match HostKey::try_from(key) {
+            Ok(host_key) => self
+                .host_configs
+                .get(&host_key)
+                .map_or_else(|| global.clone(), |config| config.effective_accept(global)),
+            Err(_) => global.clone(),
+        }
     }
 
     /// Get an existing host or create a new one for the given hostname

--- a/lychee-lib/src/types/status_code_selector.rs
+++ b/lychee-lib/src/types/status_code_selector.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, fmt::Display, hash::BuildHasher, str::FromStr, sync::LazyLock};
 
 use http::StatusCode;
-use serde::{Deserialize, de::Visitor};
+use serde::{Deserialize, Serialize, Serializer, de::Visitor};
 use thiserror::Error;
 
 use crate::{StatusRangeError, types::accept::StatusRange};
@@ -117,6 +117,17 @@ impl<S: BuildHasher + Default> From<StatusCodeSelector> for HashSet<StatusCode, 
             .into_iter()
             .flat_map(<HashSet<StatusCode>>::from)
             .collect()
+    }
+}
+
+impl Serialize for StatusCodeSelector {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Serialize as the `Display` string (e.g. `200..=299,429`), which
+        // round-trips through the `FromStr`-based deserializer.
+        serializer.serialize_str(&self.to_string())
     }
 }
 

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -232,3 +232,6 @@ concurrency = 5
 request_interval = "0" # zero disables rate limiting
 # Merge global `header` values with the following `headers` for this host
 headers = { "A" = "B" }
+# Overwrite the global `accept` status codes for this host.
+# This fully REPLACES the global `accept` set (it is not merged with it).
+accept = [200, 429]


### PR DESCRIPTION
Closes #2223.

Adds a per-host `accept` override so a host can define its own set of accepted HTTP status codes, alongside the existing per-host `concurrency` / `request_interval` / `headers`:

```toml
[hosts."example.com"]
accept = [200, 429]
```

## Semantics

Per-host `accept` **replaces** the global `accept` for that host (it does not union with it), matching how the other per-host options override their globals. This follows the direction discussed in the issue (a host's accepted codes are exactly what's listed). Hosts without an override keep using the global `accept`, so existing configs are unaffected.

## Implementation

- `HostConfig` gains `accept: Option<StatusCodeSelector>` plus an `effective_accept(global)` resolver (mirrors `effective_concurrency` / `effective_request_interval`), with `merge` and `Default` handling.
- `HostPool::effective_accept` resolves the accepted set for a given URL/URI, falling back to the global set when the host has no override.
- The website checker and the cache-hit path both resolve per-host before turning a status code into a `Status`. The cache path resolves from the post-remap cache-key host, so cross-host cache hits are judged by the correct host's codes.
- Added a `Serialize` impl for `StatusCodeSelector` (round-trips through its existing `FromStr`), needed now that `HostConfig` carries one.

## Tests

- `effective_accept` replace semantics + fallback to global, and `merge` precedence.
- `StatusCodeSelector` serialize/deserialize round-trip (ranges and single codes).
- Live-check path (wiremock): a per-host `accept: 429` makes a 429 response succeed, and a host without the override still fails on 429.
- Cache: a cached status is judged by the cache-key host's override, verified with a genuine request-host to cache-key-host remap.

`cargo test`, `cargo clippy --all-targets -- -D warnings`, and `cargo fmt` are all clean.

## Note

One pre-existing behavior to flag: `Status::from_cache_status` returns a cached `Ok` as success without re-checking it against the accept set, so a *more restrictive* per-host override won't re-downgrade codes already cached as OK from a previous run (same as tightening the global `accept` between runs today). The common case here (accepting *more* codes, e.g. 429) goes through the cached-`Error` branch, which does re-check. Happy to address the cached-`Ok` reinterpretation separately if you'd like.
