### PR TITLE
test: add missing `cfg(test)` and fix new 1.97 warnings

### DIFF
--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -176,9 +176,9 @@ mod cli {
         let bad_gateway = mock_server!(StatusCode::BAD_GATEWAY);
         let contents = format!(
             "{} {} {}",
-            &not_found.uri(),
-            &internal_server_error.uri(),
-            &bad_gateway.uri(),
+            not_found.uri(),
+            internal_server_error.uri(),
+            bad_gateway.uri(),
         );
 
         let mut cmd = cargo_bin_cmd!();

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -228,6 +228,7 @@ impl<'a> ClientRequestChains<'a> {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::{
         ChainResult,
@@ -236,7 +237,6 @@ mod test {
     };
     use async_trait::async_trait;
 
-    #[allow(dead_code)] // work-around
     #[derive(Debug)]
     struct Add(usize);
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -962,7 +962,7 @@ mod tests {
     async fn test_max_redirects() {
         let mock_server = wiremock::MockServer::start().await;
 
-        let redirect_uri = format!("{}/redirect", &mock_server.uri());
+        let redirect_uri = format!("{}/redirect", mock_server.uri());
         let redirect = wiremock::ResponseTemplate::new(StatusCode::PERMANENT_REDIRECT)
             .insert_header("Location", redirect_uri.as_str());
 


### PR DESCRIPTION
I'm guessing that this was accidentally missed. Or, is there a reason that this `mod test` should not be `cfg(test)`?

After this, https://github.com/lycheeverse/lychee/pull/2262 should be unblocked.