### PR TITLE
Revert "Wayback reinstate network test"

### DIFF
--- a/lychee-lib/src/archive/wayback/mod.rs
+++ b/lychee-lib/src/archive/wayback/mod.rs
@@ -117,13 +117,17 @@ mod tests {
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(20);
 
-    /// Checks that we can get a snapshot URL from the real Wayback Machine, so
-    /// we notice if it ever changes how it responds.
+    /// Both cases run in a single test (and therefore a single Tokio runtime)
+    /// on purpose: `get_archive_snapshot` uses a process-wide static
+    /// `reqwest::Client` whose connection pool is bound to the runtime that
+    /// first initializes it. Splitting these into two `#[tokio::test]`s would
+    /// give each its own runtime and let one reuse a pooled connection whose
+    /// runtime has already been torn down, failing with `DispatchGone`.
     ///
-    /// Both cases share one runtime because the static `reqwest::Client`'s
-    /// connection pool is bound to the first runtime that uses it, so separate
-    /// `#[tokio::test]`s would risk `DispatchGone` from cross-runtime reuse.
+    /// Hits the live Wayback Machine, which is flaky, so it's ignored to
+    /// keep CI deterministic.
     #[tokio::test]
+    #[ignore = "requires network access to web.archive.org"]
     async fn wayback_suggestion_real() -> Result<(), Box<dyn Error>> {
         // Real Wayback request: `example.com` is archived many times over,
         // so this should resolve to a concrete timestamped snapshot URL.


### PR DESCRIPTION
Reverts lycheeverse/lychee#2226

Very sadly, this does seem to still be flaky
```
        FAIL [  15.782s] (594/594) lychee-lib archive::wayback::tests::wayback_suggestion_real
  stdout ───

    running 1 test
    test archive::wayback::tests::wayback_suggestion_real ... FAILED

    failures:

    failures:
        archive::wayback::tests::wayback_suggestion_real

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 493 filtered out; finished in 15.78s
    
  stderr ───
    Error: reqwest::Error { kind: Request, url: "https://web.archive.org/web/https://example.com/", source: hyper_util::client::legacy::Error(Connect, ConnectError("tcp connect error", 207.241.237.3:443, Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) }
```
https://github.com/lycheeverse/lychee/actions/runs/30441368621/job/90541206127

Maybe we just disable it.. 