### PR TITLE
Feature: state why requests were excluded

### DIFF
--- a/lychee-bin/src/cache.rs
+++ b/lychee-bin/src/cache.rs
@@ -149,8 +149,8 @@ fn cache_hit(
     cache_key: &Uri,
     value: &CacheValue,
 ) -> Response {
-    let status = if client.is_excluded(cache_key) {
-        Status::Excluded
+    let status = if let Some(reason) = client.exclusion_reason(cache_key) {
+        Status::Excluded(reason)
     } else {
         // Can't impl `Status::from(v.value().status)` here because the
         // `accepted` status codes might have changed from the previous run

--- a/lychee-bin/src/formatters/response/color.rs
+++ b/lychee-bin/src/formatters/response/color.rs
@@ -18,7 +18,7 @@ impl ColorFormatter {
     fn status_color(status: &Status) -> &'static LazyLock<console::Style> {
         match status {
             Status::Ok(_) | Status::Cached(CacheStatus::Ok(_)) => &GREEN,
-            Status::Excluded
+            Status::Excluded(_)
             | Status::Unsupported(_)
             | Status::Cached(CacheStatus::Excluded | CacheStatus::Unsupported) => &DIM,
             Status::UnknownStatusCode(_) | Status::UnknownMailStatus(_) | Status::Timeout(_) => {

--- a/lychee-bin/src/formatters/response/emoji.rs
+++ b/lychee-bin/src/formatters/response/emoji.rs
@@ -14,7 +14,7 @@ impl EmojiFormatter {
     const fn emoji_for_status(status: &Status) -> &'static str {
         match status {
             Status::Ok(_) | Status::Cached(CacheStatus::Ok(_)) => "✅",
-            Status::Excluded => "👻",
+            Status::Excluded(_) => "👻",
             Status::Unsupported(_)
             | Status::Cached(CacheStatus::Excluded | CacheStatus::Unsupported) => "🚫",
             Status::UnknownStatusCode(_) | Status::UnknownMailStatus(_) | Status::Timeout(_) => {
@@ -38,7 +38,7 @@ impl ResponseFormatter for EmojiFormatter {
 mod emoji_tests {
     use super::*;
     use http::StatusCode;
-    use lychee_lib::{ErrorKind, Redirects, ResponseBody, Status, Uri};
+    use lychee_lib::{ErrorKind, ExcludeReason, Redirects, ResponseBody, Status, Uri};
     use test_utils::mock_response_body;
 
     #[test]
@@ -64,10 +64,13 @@ mod emoji_tests {
     #[test]
     fn test_format_response_with_excluded_status() {
         let formatter = EmojiFormatter;
-        let body = mock_response_body!(Status::Excluded, "https://example.com/not-checked");
+        let body = mock_response_body!(
+            Status::Excluded(ExcludeReason::Pattern("example\\.com".to_owned())),
+            "https://example.com/not-checked"
+        );
         assert_eq!(
             formatter.format_response(&body),
-            "👻 https://example.com/not-checked | This is due to your 'exclude' values"
+            "👻 https://example.com/not-checked | Excluded by pattern: `example\\.com`"
         );
     }
 

--- a/lychee-bin/src/formatters/response/plain.rs
+++ b/lychee-bin/src/formatters/response/plain.rs
@@ -22,7 +22,7 @@ impl ResponseFormatter for PlainFormatter {
 mod plain_tests {
     use super::*;
     use http::StatusCode;
-    use lychee_lib::{ErrorKind, Status, Uri};
+    use lychee_lib::{ErrorKind, ExcludeReason, Status, Uri};
     use lychee_lib::{Redirect, Redirects};
     use test_utils::mock_response_body;
 
@@ -52,10 +52,13 @@ mod plain_tests {
     #[test]
     fn test_format_response_with_excluded_status() {
         let formatter = PlainFormatter;
-        let body = mock_response_body!(Status::Excluded, "https://example.com/not-checked");
+        let body = mock_response_body!(
+            Status::Excluded(ExcludeReason::Pattern("example\\.com".to_owned())),
+            "https://example.com/not-checked"
+        );
         assert_eq!(
             formatter.format_response(&body),
-            "[EXCLUDED] https://example.com/not-checked | This is due to your 'exclude' values"
+            "[EXCLUDED] https://example.com/not-checked | Excluded by pattern: `example\\.com`"
         );
     }
 

--- a/lychee-bin/src/formatters/response/task.rs
+++ b/lychee-bin/src/formatters/response/task.rs
@@ -13,7 +13,7 @@ impl ResponseFormatter for TaskFormatter {
 mod task_tests {
     use super::*;
     use http::StatusCode;
-    use lychee_lib::{ErrorKind, Redirect, Redirects, Status, Uri};
+    use lychee_lib::{ErrorKind, ExcludeReason, Redirect, Redirects, Status, Uri};
     use test_utils::mock_response_body;
 
     #[test]
@@ -42,10 +42,13 @@ mod task_tests {
     #[test]
     fn test_format_response_with_excluded_status() {
         let formatter = TaskFormatter;
-        let body = mock_response_body!(Status::Excluded, "https://example.com/not-checked");
+        let body = mock_response_body!(
+            Status::Excluded(ExcludeReason::Pattern("example\\.com".to_owned())),
+            "https://example.com/not-checked"
+        );
         assert_eq!(
             formatter.format_response(&body),
-            "- [ ] [EXCLUDED] https://example.com/not-checked | This is due to your 'exclude' values"
+            "- [ ] [EXCLUDED] https://example.com/not-checked | Excluded by pattern: `example\\.com`"
         );
     }
 

--- a/lychee-bin/src/formatters/stats/junit.rs
+++ b/lychee-bin/src/formatters/stats/junit.rs
@@ -115,8 +115,8 @@ mod tests {
             <system-out>https://github.com/mre/idiomatic-rust-doesnt-exist-man (at 1:1) | 404 Not Found</system-out>
         </testcase>
         <testcase name="Excluded https://excluded.org/" time="0.042" file="https://example.com/">
-            <skipped message="https://excluded.org/ | This is due to your &apos;exclude&apos; values"/>
-            <system-out>https://excluded.org/ | This is due to your &apos;exclude&apos; values</system-out>
+            <skipped message="https://excluded.org/ | Excluded by pattern: `excluded\.org`"/>
+            <system-out>https://excluded.org/ | Excluded by pattern: `excluded\.org`</system-out>
         </testcase>
         <testcase name="Successful https://success.org/" time="1.000" file="https://example.com/">
             <system-out>https://success.org/</system-out>
@@ -151,7 +151,9 @@ mod tests {
             source.clone(),
             HashSet::from([ResponseBody {
                 uri: "https://excluded.org".try_into().unwrap(),
-                status: Status::Excluded,
+                status: Status::Excluded(lychee_lib::ExcludeReason::Pattern(
+                    r"excluded\.org".to_owned(),
+                )),
                 redirects: None,
                 remap: None,
                 span: None,

--- a/lychee-bin/src/formatters/stats/response.rs
+++ b/lychee-bin/src/formatters/stats/response.rs
@@ -87,7 +87,7 @@ impl ResponseStats {
             Status::Error(_) | Status::RequestError(_) => self.errors += 1,
             Status::UnknownStatusCode(_) | Status::UnknownMailStatus(_) => self.unknown += 1,
             Status::Timeout(_) => self.timeouts += 1,
-            Status::Excluded => self.excludes += 1,
+            Status::Excluded(_) => self.excludes += 1,
             Status::Unsupported(_) => self.unsupported += 1,
             Status::Cached(cache_status) => {
                 self.cached += 1;
@@ -199,7 +199,9 @@ mod tests {
     }
 
     fn dummy_excluded() -> Response {
-        mock_response(Status::Excluded)
+        mock_response(Status::Excluded(lychee_lib::ExcludeReason::Pattern(
+            r"excluded\.org".to_owned(),
+        )))
     }
 
     #[tokio::test]

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -976,6 +976,29 @@ mod cli {
             .stdout(contains("4 Excluded"));
     }
 
+    #[test]
+    fn test_exclude_reasons() {
+        cargo_bin_cmd!()
+            .arg("--verbose")
+            .arg("--no-progress")
+            .arg("--exclude")
+            .arg(r"wikipedia\.org")
+            .arg("--exclude")
+            .arg(r"example\.com")
+            .arg("-")
+            .write_stdin(
+                "https://en.wikipedia.org/wiki/Static_program_analysis\nmailto:test@example.com",
+            )
+            .assert()
+            .success()
+            .stderr(contains(
+                "[EXCLUDED] https://en.wikipedia.org/wiki/Static_program_analysis (at 1:1) | Excluded by pattern: `wikipedia\\.org`",
+            ))
+            .stderr(contains(
+                "[EXCLUDED] mailto:test@example.com (at 2:8) | Excluded: mail checking is disabled (use --include-mail to enable)",
+            ));
+    }
+
     #[tokio::test]
     async fn test_empty_config() {
         let mock_server = mock_server!(StatusCode::OK);
@@ -1611,7 +1634,7 @@ The config file should contain every possible key for documentation purposes."
                 "[IGNORED] {unsupported_url} (at 1:1) | Unsupported: Failed to create HTTP request client: builder error for url (slack://user)"
             )))
             .stderr(contains(format!(
-                "[EXCLUDED] {excluded_url} (at 2:1) | This is due to your 'exclude' values\n"
+                "[EXCLUDED] {excluded_url} (at 2:1) | Excluded by pattern: `{excluded_url}`\n"
             )));
 
         // The cache file should be empty, because the only checked URL is
@@ -2055,7 +2078,7 @@ The config file should contain every possible key for documentation purposes."
                 "url": "https://bbb.com/",
                 "status": {
                   "text": "Excluded",
-                  "details": "This is due to your 'exclude' values"
+                  "details": "Excluded by pattern: `bbb`"
                 },
                 "remap": {
                     "new": {

--- a/lychee-lib/src/chain/mod.rs
+++ b/lychee-lib/src/chain/mod.rs
@@ -11,7 +11,7 @@
 //! the handler to the chain.
 //!
 //! [pattern]: https://github.com/lpxxn/rust-design-pattern/blob/master/behavioral/chain_of_responsibility.rs
-use crate::Status;
+use crate::{ExcludeReason, Status};
 use async_trait::async_trait;
 use core::fmt::Debug;
 use std::sync::Arc;
@@ -224,7 +224,7 @@ impl<'a> ClientRequestChains<'a> {
 
         // Consider the request to be excluded if no chain element has converted
         // it to a `ChainResult::Done`
-        Status::Excluded
+        Status::Excluded(ExcludeReason::RequestChain)
     }
 }
 

--- a/lychee-lib/src/checker/mail.rs
+++ b/lychee-lib/src/checker/mail.rs
@@ -28,7 +28,7 @@ impl MailChecker {
         reason = "Match the signature of the function with the email-check feature"
     )]
     pub(crate) async fn check_mail(&self, _uri: &Uri) -> Status {
-        Status::Excluded
+        Status::Excluded(crate::ExcludeReason::MailFeatureDisabled)
     }
 }
 

--- a/lychee-lib/src/client.rs
+++ b/lychee-lib/src/client.rs
@@ -13,7 +13,7 @@
     clippy::default_trait_access,
     clippy::used_underscore_binding
 )]
-use crate::{BasicAuthExtractor, remap::Remap};
+use crate::{BasicAuthExtractor, ExcludeReason, remap::Remap};
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use http::{
@@ -566,12 +566,14 @@ impl Client {
         let start = std::time::Instant::now(); // Measure check time
         let remap = self.remap(&mut uri)?.inspect(|r| debug!("Remapping {r}"));
 
-        let (status, redirects) = match uri.scheme() {
-            _ if self.is_excluded(&uri) => (Status::Excluded, None),
-            _ if uri.is_tel() => (Status::Excluded, None), // We don't check tel: URIs
-            _ if uri.is_file() => (self.check_file(&uri).await, None),
-            _ if uri.is_mail() => (self.check_mail(&uri).await, None),
-            _ => self.check_website(&uri).await,
+        let (status, redirects) = if let Some(reason) = self.exclusion_reason(&uri) {
+            (Status::Excluded(reason), None)
+        } else {
+            match uri.scheme() {
+                _ if uri.is_file() => (self.check_file(&uri).await, None),
+                _ if uri.is_mail() => (self.check_mail(&uri).await, None),
+                _ => self.check_website(&uri).await,
+            }
         };
 
         Ok(Response::new(
@@ -614,6 +616,12 @@ impl Client {
     #[must_use]
     pub fn is_excluded(&self, uri: &Uri) -> bool {
         self.filter.is_excluded(uri)
+    }
+
+    /// Returns why the given `uri` should be ignored from checking.
+    #[must_use]
+    pub fn exclusion_reason(&self, uri: &Uri) -> Option<ExcludeReason> {
+        self.filter.exclusion_reason(uri)
     }
 
     /// Checks the given URI of a website.
@@ -678,7 +686,7 @@ mod tests {
 
     use super::ClientBuilder;
     use crate::{
-        BasicAuthExtractor, ErrorKind, Redirect, Redirects, Request, Status, Uri,
+        BasicAuthExtractor, ErrorKind, ExcludeReason, Redirect, Redirects, Request, Status, Uri,
         chain::{ChainResult, Handler, RequestChain},
         remap::{Remap, Remaps},
     };
@@ -1077,7 +1085,7 @@ mod tests {
         #[async_trait]
         impl Handler<Request, Status> for ExampleHandler {
             async fn handle(&mut self, _: Request) -> ChainResult<Request, Status> {
-                ChainResult::Done(Status::Excluded)
+                ChainResult::Done(Status::Excluded(ExcludeReason::RequestChain))
             }
         }
 
@@ -1091,6 +1099,6 @@ mod tests {
 
         let result = client.check("http://example.com");
         let res = result.await.unwrap();
-        assert_eq!(res.status(), &Status::Excluded);
+        assert_eq!(res.status(), &Status::Excluded(ExcludeReason::RequestChain));
     }
 }

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -15,7 +15,7 @@ pub type Excludes = regex_filter::RegexFilter;
 /// You can exclude paths and files based on regex patterns.
 pub type PathExcludes = regex_filter::RegexFilter;
 
-use crate::Uri;
+use crate::{ExcludeReason, Uri};
 
 /// These domains are explicitly defined by RFC 2606, section 3 Reserved Example
 /// Second Level Domain Names for describing example cases and should not be
@@ -193,8 +193,69 @@ impl Filter {
     }
 
     #[inline]
-    fn is_excludes_match(&self, input: &str) -> bool {
-        matches!(self.excludes, Some(ref excludes) if excludes.is_match(input))
+    fn matching_exclude_pattern(&self, input: &str) -> Option<&str> {
+        self.excludes
+            .as_ref()
+            .and_then(|excludes| excludes.matching_pattern(input))
+    }
+
+    /// Determine why a given [`Uri`] should be excluded.
+    #[must_use]
+    pub fn exclusion_reason(&self, uri: &Uri) -> Option<ExcludeReason> {
+        if self.is_scheme_excluded(uri) {
+            return Some(ExcludeReason::Scheme);
+        }
+        if self.is_host_excluded(uri) {
+            return Some(ExcludeReason::Host);
+        }
+        if self.is_ip_excluded(uri) {
+            return Some(ExcludeReason::Ip);
+        }
+        if self.is_mail_excluded(uri) {
+            return Some(ExcludeReason::Mail);
+        }
+        if uri.is_tel() {
+            return Some(ExcludeReason::Telephone);
+        }
+
+        let input = uri.as_str();
+
+        // Prefer a matching user-provided exclude pattern when a built-in domain
+        // exclusion also applies. This makes the configured rule visible without
+        // changing include precedence.
+        if is_example_domain(uri) {
+            if !self.is_includes_match(input)
+                && let Some(pattern) = self.matching_exclude_pattern(input)
+            {
+                return Some(ExcludeReason::Pattern(pattern.to_owned()));
+            }
+            return Some(ExcludeReason::ExampleDomain);
+        }
+        if is_unsupported_domain(uri) {
+            if !self.is_includes_match(input)
+                && let Some(pattern) = self.matching_exclude_pattern(input)
+            {
+                return Some(ExcludeReason::Pattern(pattern.to_owned()));
+            }
+            return Some(ExcludeReason::UnsupportedDomain);
+        }
+
+        if self.is_includes_empty() {
+            if self.is_excludes_empty() {
+                return is_false_positive(input).then_some(ExcludeReason::FalsePositive);
+            }
+        } else if self.is_includes_match(input) {
+            return None;
+        }
+
+        if is_false_positive(input) {
+            return Some(ExcludeReason::FalsePositive);
+        }
+        if self.is_excludes_empty() {
+            return Some(ExcludeReason::NotIncluded);
+        }
+        self.matching_exclude_pattern(input)
+            .map(|pattern| ExcludeReason::Pattern(pattern.to_owned()))
     }
 
     /// Determine whether a given [`Uri`] should be excluded.
@@ -218,44 +279,7 @@ impl Filter {
     ///    - When the excludes rules matches the URI, it's *explicitly excluded*.
     #[must_use]
     pub fn is_excluded(&self, uri: &Uri) -> bool {
-        // Skip mail address, specific IP, specific host and scheme
-        if self.is_scheme_excluded(uri)
-            || self.is_host_excluded(uri)
-            || self.is_ip_excluded(uri)
-            || self.is_mail_excluded(uri)
-            || uri.is_tel()
-            || is_example_domain(uri)
-            || is_unsupported_domain(uri)
-        {
-            return true;
-        }
-
-        let input = uri.as_str();
-
-        if self.is_includes_empty() {
-            if self.is_excludes_empty() {
-                // Both excludes and includes rules are empty:
-                // *Presumably included* unless it's a false positive
-                return is_false_positive(input);
-            }
-        } else if self.is_includes_match(input) {
-            // *Explicitly included* (Includes take precedence over excludes)
-            return false;
-        }
-
-        // Exclude well-known false-positives
-        // Performed after checking includes to allow user-overwrites
-        if is_false_positive(input)
-                // Previous checks imply input is not explicitly included.
-                // If exclude rules are empty, then *presumably excluded*
-                || self.is_excludes_empty()
-                // If exclude rules match input, then *explicitly excluded*
-                || self.is_excludes_match(input)
-        {
-            return true;
-        }
-
-        false
+        self.exclusion_reason(uri).is_some()
     }
 }
 
@@ -266,7 +290,7 @@ mod tests {
     use url::Host;
 
     use super::{Excludes, Filter, Includes};
-    use crate::Uri;
+    use crate::{ExcludeReason, Uri};
 
     // Note: the standard library, as of Rust stable 1.47.0, does not expose
     // "link-local" or "private" IPv6 checks. However, one might argue
@@ -417,6 +441,28 @@ mod tests {
 
         assert!(!filter.is_excluded(&website!("http://bar.dev")));
         assert!(filter.is_excluded(&mail!("foo@bar.dev")));
+    }
+
+    #[test]
+    fn test_exclusion_reason() {
+        let excludes = Excludes::new([r"example\.com", r"https://example"]).unwrap();
+        let filter = Filter {
+            excludes: Some(excludes),
+            ..Filter::default()
+        };
+
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://example.com")),
+            Some(ExcludeReason::Pattern(r"example\.com".to_owned()))
+        );
+        assert_eq!(
+            filter.exclusion_reason(&mail!("test@example.com")),
+            Some(ExcludeReason::Mail)
+        );
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://other.org")),
+            None
+        );
     }
     #[test]
     fn test_exclude_include_regex() {

--- a/lychee-lib/src/filter/mod.rs
+++ b/lychee-lib/src/filter/mod.rs
@@ -192,24 +192,72 @@ impl Filter {
         matches!(self.includes, Some(ref includes) if includes.is_match(input))
     }
 
+    /// The reason the IP address of `uri` is excluded, if it is
+    ///
+    /// Mirrors [`Self::is_ip_excluded`], but reports which of the address
+    /// ranges matched so the corresponding flag can be named.
+    fn ip_reason(&self, uri: &Uri) -> Option<ExcludeReason> {
+        // Only reached for URIs with an IP host, so `host_ip` is always `Some`
+        let address = || uri.host_ip().map(|ip| ip.to_string()).unwrap_or_default();
+
+        if self.exclude_loopback_ips && uri.is_loopback() {
+            return Some(ExcludeReason::LoopbackIp(address()));
+        }
+        if self.exclude_private_ips && uri.is_private() {
+            return Some(ExcludeReason::PrivateIp(address()));
+        }
+        if self.exclude_link_local_ips && uri.is_link_local() {
+            return Some(ExcludeReason::LinkLocalIp(address()));
+        }
+        None
+    }
+
+    /// The reason for the first user-provided exclude pattern matching `input`,
+    /// if there is one
     #[inline]
-    fn matching_exclude_pattern(&self, input: &str) -> Option<&str> {
+    fn pattern_reason(&self, input: &str) -> Option<ExcludeReason> {
         self.excludes
             .as_ref()
             .and_then(|excludes| excludes.matching_pattern(input))
+            .map(|pattern| ExcludeReason::Pattern(pattern.to_owned()))
     }
 
-    /// Determine why a given [`Uri`] should be excluded.
+    /// Determine why a given [`Uri`] should be excluded, or `None` if it should
+    /// be checked.
+    ///
+    /// # Details
+    ///
+    /// 1. If any of the following conditions are met, the URI is excluded:
+    ///    - If the scheme of URI is not the allowed scheme.
+    ///    - If the host belongs to a type that is configured to exclude.
+    ///    - If the IP address belongs to a type that is configured to exclude.
+    ///    - If it's a mail address and it's not configured to include mail addresses.
+    ///    - If it's a telephone link.
+    ///    - If the domain is a reserved example domain or a known unsupported
+    ///      domain. A matching user-provided exclude pattern is reported in
+    ///      preference to the built-in reason, because that is the rule the user
+    ///      can act on.
+    /// 2. Decide whether the URI is *presumably included* or *explicitly included*:
+    ///    - When both excludes and includes rules are empty, it's *presumably included* unless
+    ///      it's a known false positive.
+    ///    - When the includes rules matches the URI, it's *explicitly included*.
+    /// 3. When it's a known *false positive* pattern, it's *explicitly excluded*.
+    /// 4. Decide whether the URI is *presumably excluded* or *explicitly excluded*:
+    ///    - When excludes rules is empty, but includes rules doesn't match the URI, it's
+    ///      *presumably excluded*.
+    ///    - When the excludes rules matches the URI, it's *explicitly excluded*.
     #[must_use]
     pub fn exclusion_reason(&self, uri: &Uri) -> Option<ExcludeReason> {
         if self.is_scheme_excluded(uri) {
-            return Some(ExcludeReason::Scheme);
+            return Some(ExcludeReason::Scheme(uri.scheme().to_owned()));
         }
         if self.is_host_excluded(uri) {
-            return Some(ExcludeReason::Host);
+            return Some(ExcludeReason::Host(
+                uri.domain().unwrap_or_default().to_owned(),
+            ));
         }
-        if self.is_ip_excluded(uri) {
-            return Some(ExcludeReason::Ip);
+        if let Some(reason) = self.ip_reason(uri) {
+            return Some(reason);
         }
         if self.is_mail_excluded(uri) {
             return Some(ExcludeReason::Mail);
@@ -220,24 +268,21 @@ impl Filter {
 
         let input = uri.as_str();
 
-        // Prefer a matching user-provided exclude pattern when a built-in domain
-        // exclusion also applies. This makes the configured rule visible without
-        // changing include precedence.
-        if is_example_domain(uri) {
-            if !self.is_includes_match(input)
-                && let Some(pattern) = self.matching_exclude_pattern(input)
-            {
-                return Some(ExcludeReason::Pattern(pattern.to_owned()));
+        let builtin_domain_reason = if is_example_domain(uri) {
+            Some(ExcludeReason::ExampleDomain)
+        } else if is_unsupported_domain(uri) {
+            Some(ExcludeReason::UnsupportedDomain)
+        } else {
+            None
+        };
+        if let Some(builtin) = builtin_domain_reason {
+            // Built-in domain rules exclude the URI either way. Still prefer
+            // reporting a matching user-provided pattern, which makes the
+            // configured rule visible without changing include precedence.
+            if self.is_includes_match(input) {
+                return Some(builtin);
             }
-            return Some(ExcludeReason::ExampleDomain);
-        }
-        if is_unsupported_domain(uri) {
-            if !self.is_includes_match(input)
-                && let Some(pattern) = self.matching_exclude_pattern(input)
-            {
-                return Some(ExcludeReason::Pattern(pattern.to_owned()));
-            }
-            return Some(ExcludeReason::UnsupportedDomain);
+            return Some(self.pattern_reason(input).unwrap_or(builtin));
         }
 
         if self.is_includes_empty() {
@@ -254,29 +299,13 @@ impl Filter {
         if self.is_excludes_empty() {
             return Some(ExcludeReason::NotIncluded);
         }
-        self.matching_exclude_pattern(input)
-            .map(|pattern| ExcludeReason::Pattern(pattern.to_owned()))
+        self.pattern_reason(input)
     }
 
     /// Determine whether a given [`Uri`] should be excluded.
     ///
-    /// # Details
-    ///
-    /// 1. If any of the following conditions are met, the URI is excluded:
-    ///   - If it's a mail address and it's not configured to include mail addresses.
-    ///   - If the IP address belongs to a type that is configured to exclude.
-    ///   - If the host belongs to a type that is configured to exclude.
-    ///   - If the scheme of URI is not the allowed scheme.
-    /// 2. Decide whether the URI is *presumably included* or *explicitly included*:
-    ///    - When both excludes and includes rules are empty, it's *presumably included* unless
-    ///      it's a known false positive.
-    ///    - When the includes rules matches the URI, it's *explicitly included*.
-    /// 3. When it's a known *false positive* pattern, it's *explicitly excluded*.
-    /// 4. Decide whether the URI is *presumably excluded* or *explicitly excluded*:
-    ///    - When excludes rules is empty, but includes rules doesn't match the URI, it's
-    ///      *presumably excluded*.
-    ///    - When the excludes rules matches the URI, it's *explicitly excluded*.
-    ///    - When the excludes rules matches the URI, it's *explicitly excluded*.
+    /// See [`Self::exclusion_reason`] for the rules that are applied, and to
+    /// find out *why* a URI is excluded.
     #[must_use]
     pub fn is_excluded(&self, uri: &Uri) -> bool {
         self.exclusion_reason(uri).is_some()
@@ -286,6 +315,7 @@ impl Filter {
 #[cfg(test)]
 mod tests {
     use reqwest::Url;
+    use std::collections::HashSet;
     use test_utils::{mail, website};
     use url::Host;
 
@@ -464,6 +494,145 @@ mod tests {
             None
         );
     }
+
+    #[test]
+    fn test_exclusion_reason_scheme() {
+        let filter = Filter {
+            schemes: HashSet::from(["https".to_string()]),
+            ..Filter::default()
+        };
+
+        assert_eq!(
+            filter.exclusion_reason(&website!("http://foo.org")),
+            Some(ExcludeReason::Scheme("http".to_owned()))
+        );
+        assert_eq!(filter.exclusion_reason(&website!("https://foo.org")), None);
+    }
+
+    #[test]
+    fn test_exclusion_reason_host() {
+        let filter = Filter {
+            exclude_loopback_ips: true,
+            ..Filter::default()
+        };
+
+        assert_eq!(
+            filter.exclusion_reason(&website!("http://localhost/foo")),
+            Some(ExcludeReason::Host("localhost".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_exclusion_reason_ips_name_the_matching_range() {
+        let filter = Filter {
+            exclude_loopback_ips: true,
+            exclude_private_ips: true,
+            exclude_link_local_ips: true,
+            ..Filter::default()
+        };
+
+        assert_eq!(
+            filter.exclusion_reason(&website!(V4_LOOPBACK)),
+            Some(ExcludeReason::LoopbackIp("127.0.0.1".to_owned()))
+        );
+        assert_eq!(
+            filter.exclusion_reason(&website!(V6_LOOPBACK)),
+            Some(ExcludeReason::LoopbackIp("::1".to_owned()))
+        );
+        assert_eq!(
+            filter.exclusion_reason(&website!(V4_PRIVATE_CLASS_C)),
+            Some(ExcludeReason::PrivateIp("192.168.0.1".to_owned()))
+        );
+        assert_eq!(
+            filter.exclusion_reason(&website!(V4_LINK_LOCAL_1)),
+            Some(ExcludeReason::LinkLocalIp("169.254.0.1".to_owned()))
+        );
+    }
+
+    #[test]
+    fn test_exclusion_reason_ips_only_report_enabled_ranges() {
+        // A private IP is not excluded when only loopback IPs are excluded
+        let filter = Filter {
+            exclude_loopback_ips: true,
+            ..Filter::default()
+        };
+
+        assert_eq!(filter.exclusion_reason(&website!(V4_PRIVATE_CLASS_A)), None);
+    }
+
+    #[test]
+    fn test_exclusion_reason_telephone() {
+        let filter = Filter::default();
+        let uri = Uri::try_from("tel:+1234567890").unwrap();
+
+        assert_eq!(
+            filter.exclusion_reason(&uri),
+            Some(ExcludeReason::Telephone)
+        );
+    }
+
+    #[test]
+    fn test_exclusion_reason_false_positive() {
+        let filter = Filter::default();
+
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://ogp.me/ns#")),
+            Some(ExcludeReason::FalsePositive)
+        );
+    }
+
+    #[test]
+    fn test_exclusion_reason_not_included() {
+        let filter = Filter {
+            includes: Some(Includes::new([r"foo\.org"]).unwrap()),
+            ..Filter::default()
+        };
+
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://bar.org")),
+            Some(ExcludeReason::NotIncluded)
+        );
+        assert_eq!(filter.exclusion_reason(&website!("https://foo.org")), None);
+    }
+
+    #[test]
+    fn test_exclusion_reason_unsupported_domain() {
+        let filter = Filter::default();
+
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://twitter.com/lycheeverse")),
+            Some(ExcludeReason::UnsupportedDomain)
+        );
+    }
+
+    /// A user-provided pattern is reported in preference to a built-in domain
+    /// rule, because that is the rule the user can act on. Includes still take
+    /// precedence over the user's excludes.
+    ///
+    /// Note: this exercises the same branch as reserved example domains, which
+    /// cannot be tested here because `EXAMPLE_DOMAINS` is empty under `cfg(test)`.
+    #[test]
+    fn test_exclusion_reason_prefers_user_pattern_over_builtin_domain() {
+        let filter = Filter {
+            excludes: Some(Excludes::new([r"twitter\.com"]).unwrap()),
+            ..Filter::default()
+        };
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://twitter.com/lycheeverse")),
+            Some(ExcludeReason::Pattern(r"twitter\.com".to_owned()))
+        );
+
+        let filter = Filter {
+            includes: Some(Includes::new([r"twitter\.com"]).unwrap()),
+            excludes: Some(Excludes::new([r"twitter\.com"]).unwrap()),
+            ..Filter::default()
+        };
+        assert_eq!(
+            filter.exclusion_reason(&website!("https://twitter.com/lycheeverse")),
+            Some(ExcludeReason::UnsupportedDomain)
+        );
+    }
+
     #[test]
     fn test_exclude_include_regex() {
         let includes = Includes::new([r"foo.example.com"]).unwrap();

--- a/lychee-lib/src/filter/regex_filter.rs
+++ b/lychee-lib/src/filter/regex_filter.rs
@@ -36,6 +36,17 @@ impl RegexFilter {
         self.regex.is_match(input)
     }
 
+    /// Returns the first regular expression that matches the input.
+    #[must_use]
+    pub fn matching_pattern(&self, input: &str) -> Option<&str> {
+        self.regex
+            .matches(input)
+            .iter()
+            .next()
+            .and_then(|index| self.regex.patterns().get(index))
+            .map(String::as_str)
+    }
+
     #[inline]
     #[must_use]
     /// Whether there were no regular expressions defined
@@ -47,5 +58,21 @@ impl RegexFilter {
 impl From<RegexSet> for RegexFilter {
     fn from(regex: RegexSet) -> Self {
         Self { regex }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RegexFilter;
+
+    #[test]
+    fn finds_first_matching_pattern() {
+        let filter = RegexFilter::new([r"example\.com", r"https://example"]).unwrap();
+
+        assert_eq!(
+            filter.matching_pattern("https://example.com"),
+            Some(r"example\.com")
+        );
+        assert_eq!(filter.matching_pattern("https://other.org"), None);
     }
 }

--- a/lychee-lib/src/lib.rs
+++ b/lychee-lib/src/lib.rs
@@ -101,10 +101,10 @@ pub use crate::{
     remap::Remap,
     types::{
         BaseInfo, BasicAuthCredentials, BasicAuthSelector, CacheStatus, CookieJar, ErrorKind,
-        FileExtensions, FileType, Input, InputContent, InputResolver, InputSource, LycheeResult,
-        Methods, MethodsError, Preprocessor, Redirect, Redirects, Request, RequestError,
-        ResolvedInputSource, Response, ResponseBody, Result, Status, StatusCodeSelector,
-        StatusRange, StatusRangeError, hints::*, uri::raw::RawUri, uri::raw::RawUriSpan,
-        uri::valid::Uri,
+        ExcludeReason, FileExtensions, FileType, Input, InputContent, InputResolver, InputSource,
+        LycheeResult, Methods, MethodsError, Preprocessor, Redirect, Redirects, Request,
+        RequestError, ResolvedInputSource, Response, ResponseBody, Result, Status,
+        StatusCodeSelector, StatusRange, StatusRangeError, hints::*, uri::raw::RawUri,
+        uri::raw::RawUriSpan, uri::valid::Uri,
     },
 };

--- a/lychee-lib/src/retry.rs
+++ b/lychee-lib/src/retry.rs
@@ -112,7 +112,7 @@ impl RetryExt for Status {
             | Status::RequestError(_)
             | Status::UnknownStatusCode(_)
             | Status::UnknownMailStatus(_)
-            | Status::Excluded
+            | Status::Excluded(_)
             | Status::Unsupported(_)
             | Status::Cached(_) => false,
         }

--- a/lychee-lib/src/types/cache.rs
+++ b/lychee-lib/src/types/cache.rs
@@ -111,7 +111,7 @@ impl From<&Status> for CacheStatus {
             // TODO: Use accepted status codes to decide whether this is a
             // success or failure
             Status::Ok(code) | Status::UnknownStatusCode(code) => Self::Ok(*code),
-            Status::Excluded => Self::Excluded,
+            Status::Excluded(_) => Self::Excluded,
             Status::Unsupported(_) => Self::Unsupported,
             Status::Timeout(code) => Self::Error(*code),
             Status::Error(e) => match e {

--- a/lychee-lib/src/types/mod.rs
+++ b/lychee-lib/src/types/mod.rs
@@ -34,7 +34,7 @@ pub use redirect_history::{Redirect, Redirects};
 pub use request::Request;
 pub use request_error::RequestError;
 pub use response::{Response, ResponseBody};
-pub use status::Status;
+pub use status::{ExcludeReason, Status};
 pub use status_code_selector::*;
 
 /// The lychee `Result` type

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -16,6 +16,59 @@ const ICON_ERROR: &str = "✗";
 const ICON_TIMEOUT: &str = "⧖";
 const ICON_CACHED: &str = "↻";
 
+/// The reason why a resource was excluded from checking.
+#[derive(Debug, Hash, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExcludeReason {
+    /// A user-provided exclude pattern matched the resource.
+    Pattern(String),
+    /// Mail checking is disabled.
+    Mail,
+    /// The URI scheme is not enabled.
+    Scheme,
+    /// The host is excluded.
+    Host,
+    /// The IP address is excluded.
+    Ip,
+    /// Telephone links are not checked.
+    Telephone,
+    /// Reserved example domains are not checked.
+    ExampleDomain,
+    /// The domain is not supported.
+    UnsupportedDomain,
+    /// The resource is a known false positive.
+    FalsePositive,
+    /// No user-provided include pattern matched the resource.
+    NotIncluded,
+    /// Mail checking support is not enabled in this build.
+    MailFeatureDisabled,
+    /// A request chain excluded the resource.
+    RequestChain,
+}
+
+impl Display for ExcludeReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pattern(pattern) => write!(f, "Excluded by pattern: `{pattern}`"),
+            Self::Mail => {
+                f.write_str("Excluded: mail checking is disabled (use --include-mail to enable)")
+            }
+            Self::Scheme => f.write_str("Excluded: URI scheme is not enabled"),
+            Self::Host => f.write_str("Excluded: host is excluded"),
+            Self::Ip => f.write_str("Excluded: IP address is excluded"),
+            Self::Telephone => f.write_str("Excluded: telephone links are not checked"),
+            Self::ExampleDomain => f.write_str("Excluded: example domains are not checked"),
+            Self::UnsupportedDomain => f.write_str("Excluded: domain is not supported"),
+            Self::FalsePositive => f.write_str("Excluded: known false positive"),
+            Self::NotIncluded => f.write_str("Excluded: no include pattern matched"),
+            Self::MailFeatureDisabled => {
+                f.write_str("Excluded: mail checking support is not enabled in this build")
+            }
+            Self::RequestChain => f.write_str("Excluded by request chain"),
+        }
+    }
+}
+
 /// Response status of the request.
 #[allow(variant_size_differences)]
 #[derive(Debug, Hash, PartialEq, Eq)]
@@ -35,7 +88,7 @@ pub enum Status {
     /// mail servers (blocklisting) or your ISP (port filtering).
     UnknownMailStatus(String),
     /// Resource was excluded from checking
-    Excluded,
+    Excluded(ExcludeReason),
     /// The request type is currently not supported,
     /// for example when the URL scheme is `slack://`.
     /// See <https://github.com/lycheeverse/lychee/issues/199>
@@ -56,7 +109,7 @@ impl Display for Status {
             Status::Error(e) => write!(f, "{e}"),
             Status::RequestError(e) => write!(f, "{e}"),
             Status::Cached(status) => write!(f, "{status}"),
-            Status::Excluded => f.write_str("Excluded"),
+            Status::Excluded(_) => f.write_str("Excluded"),
         }
     }
 }
@@ -142,7 +195,7 @@ impl Status {
             Status::RequestError(e) => e.error().details(),
             Status::UnknownMailStatus(reason) => reason.clone(),
             Status::Timeout(_) => "Request timed out".into(),
-            Status::Excluded => "This is due to your 'exclude' values".into(),
+            Status::Excluded(reason) => reason.to_string(),
             Status::Unsupported(_) | Status::Cached(_) | Status::UnknownStatusCode(_) => {
                 self.to_string()
             }
@@ -175,7 +228,7 @@ impl Status {
     pub const fn is_excluded(&self) -> bool {
         matches!(
             self,
-            Status::Excluded | Status::Cached(CacheStatus::Excluded)
+            Status::Excluded(_) | Status::Cached(CacheStatus::Excluded)
         )
     }
 
@@ -213,7 +266,7 @@ impl Status {
         match self {
             Status::Ok(_) => ICON_OK,
             Status::UnknownStatusCode(_) | Status::UnknownMailStatus(_) => ICON_UNKNOWN,
-            Status::Excluded => ICON_EXCLUDED,
+            Status::Excluded(_) => ICON_EXCLUDED,
             Status::Error(_) | Status::RequestError(_) => ICON_ERROR,
             Status::Timeout(_) => ICON_TIMEOUT,
             Status::Unsupported(_) => ICON_UNSUPPORTED,
@@ -246,7 +299,7 @@ impl Status {
         match self {
             Status::Ok(code) | Status::UnknownStatusCode(code) => code.as_u16().to_string(),
             Status::UnknownMailStatus(_) => "UNKNOWN".to_string(),
-            Status::Excluded => "EXCLUDED".to_string(),
+            Status::Excluded(_) => "EXCLUDED".to_string(),
             Status::Error(e) => match e {
                 ErrorKind::RejectedStatusCode(code) => code.as_u16().to_string(),
                 ErrorKind::ReadResponseBody(e) | ErrorKind::BuildRequestClient(e) => {
@@ -300,7 +353,7 @@ impl From<ErrorKind> for Status {
 
 #[cfg(test)]
 mod tests {
-    use crate::{CacheStatus, ErrorKind, Status};
+    use crate::{CacheStatus, ErrorKind, ExcludeReason, Status};
     use http::StatusCode;
 
     #[test]
@@ -358,7 +411,7 @@ mod tests {
         );
         assert_eq!(Status::Timeout(None).code(), None);
         assert_eq!(Status::Cached(CacheStatus::Error(None)).code(), None);
-        assert_eq!(Status::Excluded.code(), None);
+        assert_eq!(Status::Excluded(ExcludeReason::Mail).code(), None);
         assert_eq!(
             Status::Unsupported(ErrorKind::InvalidStatusCode(999)).code(),
             None

--- a/lychee-lib/src/types/status.rs
+++ b/lychee-lib/src/types/status.rs
@@ -24,12 +24,16 @@ pub enum ExcludeReason {
     Pattern(String),
     /// Mail checking is disabled.
     Mail,
-    /// The URI scheme is not enabled.
-    Scheme,
+    /// The URI scheme is not among the accepted schemes.
+    Scheme(String),
     /// The host is excluded.
-    Host,
-    /// The IP address is excluded.
-    Ip,
+    Host(String),
+    /// The IP address is in the loopback range.
+    LoopbackIp(String),
+    /// The IP address is in a private range.
+    PrivateIp(String),
+    /// The IP address is in the link-local range.
+    LinkLocalIp(String),
     /// Telephone links are not checked.
     Telephone,
     /// Reserved example domains are not checked.
@@ -53,9 +57,28 @@ impl Display for ExcludeReason {
             Self::Mail => {
                 f.write_str("Excluded: mail checking is disabled (use --include-mail to enable)")
             }
-            Self::Scheme => f.write_str("Excluded: URI scheme is not enabled"),
-            Self::Host => f.write_str("Excluded: host is excluded"),
-            Self::Ip => f.write_str("Excluded: IP address is excluded"),
+            Self::Scheme(scheme) => {
+                write!(
+                    f,
+                    "Excluded: scheme `{scheme}` is not among the accepted schemes"
+                )
+            }
+            Self::Host(host) => write!(
+                f,
+                "Excluded: host `{host}` resolves to a loopback address (use --exclude-loopback=false to check it)"
+            ),
+            Self::LoopbackIp(addr) => write!(
+                f,
+                "Excluded: `{addr}` is a loopback IP address (use --exclude-loopback=false to check it)"
+            ),
+            Self::PrivateIp(addr) => write!(
+                f,
+                "Excluded: `{addr}` is a private IP address (use --exclude-private=false to check it)"
+            ),
+            Self::LinkLocalIp(addr) => write!(
+                f,
+                "Excluded: `{addr}` is a link-local IP address (use --exclude-link-local=false to check it)"
+            ),
             Self::Telephone => f.write_str("Excluded: telephone links are not checked"),
             Self::ExampleDomain => f.write_str("Excluded: example domains are not checked"),
             Self::UnsupportedDomain => f.write_str("Excluded: domain is not supported"),
@@ -355,6 +378,78 @@ impl From<ErrorKind> for Status {
 mod tests {
     use crate::{CacheStatus, ErrorKind, ExcludeReason, Status};
     use http::StatusCode;
+
+    /// The rendered reason is what users see for every excluded link, so pin
+    /// down the wording of every variant.
+    ///
+    /// This also covers the variants that cannot be reached from the filter
+    /// unit tests: `ExampleDomain` (the example domain set is empty under
+    /// `cfg(test)`) and `MailFeatureDisabled` (only produced when the
+    /// `email-check` feature is off).
+    #[test]
+    fn test_exclude_reason_messages() {
+        let cases = [
+            (
+                ExcludeReason::Pattern(r"example\.com".to_owned()),
+                r"Excluded by pattern: `example\.com`",
+            ),
+            (
+                ExcludeReason::Mail,
+                "Excluded: mail checking is disabled (use --include-mail to enable)",
+            ),
+            (
+                ExcludeReason::Scheme("http".to_owned()),
+                "Excluded: scheme `http` is not among the accepted schemes",
+            ),
+            (
+                ExcludeReason::Host("localhost".to_owned()),
+                "Excluded: host `localhost` resolves to a loopback address (use --exclude-loopback=false to check it)",
+            ),
+            (
+                ExcludeReason::LoopbackIp("127.0.0.1".to_owned()),
+                "Excluded: `127.0.0.1` is a loopback IP address (use --exclude-loopback=false to check it)",
+            ),
+            (
+                ExcludeReason::PrivateIp("192.168.0.1".to_owned()),
+                "Excluded: `192.168.0.1` is a private IP address (use --exclude-private=false to check it)",
+            ),
+            (
+                ExcludeReason::LinkLocalIp("169.254.0.1".to_owned()),
+                "Excluded: `169.254.0.1` is a link-local IP address (use --exclude-link-local=false to check it)",
+            ),
+            (
+                ExcludeReason::Telephone,
+                "Excluded: telephone links are not checked",
+            ),
+            (
+                ExcludeReason::ExampleDomain,
+                "Excluded: example domains are not checked",
+            ),
+            (
+                ExcludeReason::UnsupportedDomain,
+                "Excluded: domain is not supported",
+            ),
+            (
+                ExcludeReason::FalsePositive,
+                "Excluded: known false positive",
+            ),
+            (
+                ExcludeReason::NotIncluded,
+                "Excluded: no include pattern matched",
+            ),
+            (
+                ExcludeReason::MailFeatureDisabled,
+                "Excluded: mail checking support is not enabled in this build",
+            ),
+            (ExcludeReason::RequestChain, "Excluded by request chain"),
+        ];
+
+        for (reason, expected) in cases {
+            assert_eq!(reason.to_string(), expected);
+            // The reason is what ends up in the report and in JSON output
+            assert_eq!(Status::Excluded(reason).details(), expected);
+        }
+    }
 
     #[test]
     fn test_status_serialization() {


### PR DESCRIPTION
Closes https://github.com/lycheeverse/lychee/issues/2142.

```
Excluded links now name the rule that excluded them instead of all printing This is due to your 'exclude' values:

[EXCLUDED] https://en.wikipedia.org/wiki/Static_program_analysis (at 7:1) | Excluded by pattern: `wikipedia\.org`
[EXCLUDED] https://licensebuttons.net/p/zero/1.0/88x31.png (at 16:2) | Excluded by pattern: `licensebuttons\.net`
[EXCLUDED] http://example.com/ (at 20:1) | Excluded by pattern: `example\.com`
[EXCLUDED] https://example.com/ (at 21:1) | Excluded by pattern: `example\.com`
[EXCLUDED] mailto:test@example.com (at 23:1) | Excluded: mail checking is disabled (use --include-mail to enable)
[EXCLUDED] mailto:test2@example.com (at 24:8) | Excluded: mail checking is disabled (use --include-mail to enable)
```

Status::Excluded carries an ExcludeReason now, so all the formatters (plain, color, emoji, task, JSON, JUnit) get this for free. Built-in exclusions name the flag that controls them where there is one, e.g. Excluded: `192.168.1.5` is a private IP address (use --exclude-private=false to check it).

One deviation from what we agreed in the issue: I'd suggested keeping the generic message by default and adding "check verbose mode for details". That turns out not to work as non-verbose runs don't print excluded lines at all, so the hint has nowhere to appear, and the only non-verbose surfaces are --format json/junit, where sending a machine-readable consumer back to -v seems worse. So the reason is just always in the status. Happy to gate it if you'd rather.

Breaking for library users: Status::Excluded becomes Status::Excluded(ExcludeReason), and the details string in JSON / message in JUnit change.

(FalsePositive still just says "known false positive" without naming which built-in rule matched. FALSE_POSITIVE_SET is a RegexSet too so the same trick works, but it means changing the signature of the public is_false_positive — left it out, can add if you want it here.)