### PR TITLE
Add a Debian install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,14 @@ snap install lychee
 apk add lychee
 ```
 
+### Debian
+
+Available in the [pkg.haus](https://pkg.haus) archive. Follow the [setup instructions](https://pkg.haus) to configure the repository, then install with:
+
+```sh
+sudo apt install lychee
+```
+
 ### macOS
 
 Via [Homebrew](https://brew.sh):


### PR DESCRIPTION
[pkg.haus](https://pkg.haus) is a signed APT archive carrying lychee for Debian stable, testing and unstable (amd64/arm64), built from source at upstream release tags. This adds a Debian section next to the other package managers.