### PR TITLE
Add recursive website link checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ lychee .
 # check links in specific local file(s):
 lychee README.md test.html info.txt
 
-# check links on a website:
-lychee https://endler.dev
+# check all links on a website recursively:
+lychee --recursive https://endler.dev
 ```
 
 For more examples check out our
@@ -671,6 +671,11 @@ Options:
 
           [default: 128]
 
+      --max-depth <DEPTH>
+          Maximum number of link levels to follow when using `--recursive`.
+
+          A value of 0 only checks links found in the input documents.
+
       --max-retries <MAX_RETRIES>
           Maximum number of retries per request
 
@@ -735,6 +740,17 @@ Options:
           Minimum wait time in seconds between retries of failed requests
 
           [default: 1]
+
+  -R, --recursive[=<false|true>]
+          Recursively check links discovered on remote input websites.
+
+          Links on the input domains are followed; external links are checked once
+          but are not crawled. Use `--recursed-domains` to allow more domains.
+
+      --recursed-domains <DOMAIN>
+          Additional domains that may be followed when using `--recursive`.
+
+          Multiple domains can be separated by commas. Subdomains are included.
 
       --remap <REMAP>
           Remap URI matching pattern to different URI

--- a/lychee-bin/CHANGELOG.md
+++ b/lychee-bin/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add recursive website link checking with domain and depth limits ([#78](https://github.com/lycheeverse/lychee/issues/78))
+
 ## [0.24.2](https://github.com/lycheeverse/lychee/compare/lychee-v0.24.1...lychee-v0.24.2) - 2026-04-30
 
 ### Added

--- a/lychee-bin/src/commands/check.rs
+++ b/lychee-bin/src/commands/check.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::pin::pin;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -16,14 +17,89 @@ use lychee_lib::archive::Archive;
 use lychee_lib::async_lib::stream::StreamExt as _;
 use lychee_lib::async_lib::waiter::{WaitGroup, WaitGuard};
 use lychee_lib::ratelimit::HostPool;
-use lychee_lib::{Client, ErrorKind, Request, Response};
+use lychee_lib::{Client, Collector, ErrorKind, FileExtensions, Input, Request, Response};
 use tokio_stream::wrappers::ReceiverStream;
 
 use crate::CommandParams;
+use crate::config::Config;
 use crate::formatters::stats::ResponseStats;
 use crate::formatters::suggestion::Suggestion;
 use crate::progress::Progress;
 use crate::{ExitCode, cache::Cache};
+
+type RecursiveRequest = (WaitGuard, Request, usize);
+
+#[derive(Clone)]
+struct Recursion {
+    enabled: bool,
+    max_depth: Option<usize>,
+    domains: Arc<HashSet<String>>,
+    crawled_urls: Arc<Mutex<HashSet<Url>>>,
+    collector: Collector,
+    extensions: FileExtensions,
+}
+
+impl Recursion {
+    fn new(cfg: &Config, collector: Collector, mut input_domains: HashSet<String>) -> Self {
+        input_domains.extend(
+            cfg.recursed_domains()
+                .iter()
+                .filter_map(|domain| normalize_domain(domain)),
+        );
+        Self {
+            enabled: cfg.recursive(),
+            max_depth: cfg.max_depth(),
+            domains: Arc::new(input_domains),
+            crawled_urls: Arc::new(Mutex::new(HashSet::new())),
+            collector,
+            extensions: cfg.extensions(),
+        }
+    }
+
+    fn target(&self, response: &Response, depth: usize) -> Option<Url> {
+        if !self.enabled
+            || self.max_depth.is_some_and(|limit| depth >= limit)
+            || !response.status().is_success()
+        {
+            return None;
+        }
+
+        if let InputSource::RemoteUrl(source) = response.source() {
+            self.crawled_urls
+                .lock()
+                .unwrap()
+                .insert(canonical_url(source));
+        }
+
+        let url = response.redirects().map_or_else(
+            || Url::try_from(response.body().uri.as_str()).ok(),
+            |redirects| Some(redirects.destination().clone()),
+        )?;
+        let url = canonical_url(&url);
+        can_recurse_into(&url, &self.domains).then_some(url)
+    }
+
+    async fn requests_for(
+        &self,
+        url: Option<Url>,
+        guard: WaitGuard,
+        depth: usize,
+    ) -> Vec<RecursiveRequest> {
+        let Some(url) = url else {
+            return Vec::new();
+        };
+
+        if !self.crawled_urls.lock().unwrap().insert(url.clone()) {
+            return Vec::new();
+        }
+
+        collect_recursive_requests(self.collector.clone(), url, self.extensions.clone())
+            .await
+            .into_iter()
+            .map(|request| (guard.clone(), request, depth + 1))
+            .collect()
+    }
+}
 
 #[allow(clippy::match_bool, reason = "more readable and compact")]
 #[allow(
@@ -37,7 +113,9 @@ pub(crate) async fn check(
     let CommandParams {
         client,
         cache,
+        collector,
         requests,
+        recursion_domains,
         cfg,
         is_stdin_input,
     } = params;
@@ -51,6 +129,7 @@ pub(crate) async fn check(
 
     let accept = cfg.accept().into();
     let cache_exclude_status = cfg.cache_exclude_status().into();
+    let recursion = Recursion::new(&cfg, collector, recursion_domains);
 
     let progress = Progress::new("Extracting links", hide_bar, level, &cfg.mode());
 
@@ -71,10 +150,10 @@ pub(crate) async fn check(
         .map(move |request| (request, wait_guard.clone()))
         .chain(futures::stream::empty())
         .map(|(request, guard)| match request {
-            Ok(request) => Ok((guard, request)),
+            Ok(request) => Ok((guard, request, 0)),
             Err(request_error) => Err((guard, request_error)),
         })
-        .partition_result::<(WaitGuard, Request), (WaitGuard, RequestError)>();
+        .partition_result::<(WaitGuard, Request, usize), (WaitGuard, RequestError)>();
 
     // Further partition the request errors into request building errors (like
     // unresolved relative URLs) and fatal errors when fetching a user input fails.
@@ -86,15 +165,15 @@ pub(crate) async fn check(
             },
         )
         .partition_result::<(WaitGuard, Response), (WaitGuard, ErrorKind)>();
+    let request_building_errors =
+        request_building_errors.map(|(guard, response)| (guard, response, 0));
 
     let (recursive_channel_send, recursive_channel_recv) = mpsc::channel(max_concurrency);
 
-    let send_recursive_req = async |(guard, req)| {
-        progress.inc_length(1);
-        recursive_channel_send
-            .send((guard, req))
-            .await
-            .unwrap_or_else(|e| warn!("unable to send recursive uri {:?} - channel closed?", e.0));
+    let send_recursive_req = |request| {
+        let progress = progress.clone();
+        let recursive_channel_send = recursive_channel_send.clone();
+        async move { send_recursive_request(recursive_channel_send, &progress, request) }
     };
 
     // Combine recursive requests and input requests.
@@ -108,28 +187,32 @@ pub(crate) async fn check(
 
     // Perform requests. This is the only part of the main pipeline that happens concurrently.
     let check_responses = requests
-        .map(async |(guard, request)| -> (WaitGuard, Response) {
-            let check_url = |r| check_url(&client, r);
-            // TODO: eventually, this should be a checker that uses a cache, rather than
-            // a cache that uses a checker.
-            let response = cache
-                .handle(&client, &cache_exclude_status, &accept, request, check_url)
-                .await;
-            (guard, response)
-        })
+        .map(
+            async |(guard, request, depth)| -> (WaitGuard, Response, usize) {
+                let check_url = |r| check_url(&client, r);
+                // TODO: eventually, this should be a checker that uses a cache, rather than
+                // a cache that uses a checker.
+                let response = cache
+                    .handle(&client, &cache_exclude_status, &accept, request, check_url)
+                    .await;
+                (guard, response, depth)
+            },
+        )
         .buffer_unordered(max_concurrency);
 
     let responses = futures::stream::select(check_responses, request_building_errors);
 
     // Increment stats and extract recursive uris from responses.
-    let recursive_uris = responses.map(|(_guard, response)| -> Vec<(WaitGuard, Request)> {
-        progress.update(Some(response.body()));
-        stats.add(response);
+    let recursive_uris = responses
+        .map(|(guard, response, depth)| {
+            progress.update(Some(response.body()));
+            let recursive_url = recursion.target(&response, depth);
+            stats.add(response);
 
-        let recursive_uris = vec![]; // currently unused.
-
-        recursive_uris
-    });
+            let recursion = recursion.clone();
+            async move { recursion.requests_for(recursive_url, guard, depth).await }
+        })
+        .buffer_unordered(max_concurrency);
 
     // Send recursive uris back to the initial channel. This will terminate
     // only when all requests are finished and all `WaitGuard`s are dropped.
@@ -168,15 +251,96 @@ pub(crate) async fn check(
         suggest_archived_links(archive, &mut stats, progress, max_concurrency, timeout).await;
     }
 
-    let is_success = match cfg.accept_timeouts() {
-        true => stats.is_success_ignoring_timeouts(),
-        false => stats.is_success(),
-    };
-    let code = match is_success {
-        true => ExitCode::Success,
-        false => ExitCode::LinkCheckFailure,
-    };
+    let code = exit_code(&cfg, &stats);
     Ok((stats, cache, code, client.host_pool()))
+}
+
+fn exit_code(cfg: &Config, stats: &ResponseStats) -> ExitCode {
+    let is_success = if cfg.accept_timeouts() {
+        stats.is_success_ignoring_timeouts()
+    } else {
+        stats.is_success()
+    };
+    if is_success {
+        ExitCode::Success
+    } else {
+        ExitCode::LinkCheckFailure
+    }
+}
+
+fn send_recursive_request(
+    sender: mpsc::Sender<RecursiveRequest>,
+    progress: &Progress,
+    request: RecursiveRequest,
+) {
+    progress.inc_length(1);
+    // Sending must happen independently from response processing. Otherwise a
+    // full bounded channel would stop us from polling its receiver and deadlock.
+    tokio::spawn(async move {
+        sender.send(request).await.unwrap_or_else(|e| {
+            warn!("unable to send recursive uri {:?} - channel closed?", e.0);
+        });
+    });
+}
+
+fn canonical_url(url: &Url) -> Url {
+    let mut url = url.clone();
+    url.set_fragment(None);
+    url
+}
+
+fn normalize_domain(domain: &str) -> Option<String> {
+    let domain = domain.trim();
+    if domain.is_empty() {
+        return None;
+    }
+
+    let url = if domain.contains("://") {
+        Url::parse(domain).ok()?
+    } else {
+        Url::parse(&format!("http://{domain}")).ok()?
+    };
+
+    url.host_str()
+        .map(|host| host.trim_end_matches('.').to_ascii_lowercase())
+}
+
+fn can_recurse_into(url: &Url, domains: &HashSet<String>) -> bool {
+    if !matches!(url.scheme(), "http" | "https") {
+        return false;
+    }
+
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+
+    domains
+        .iter()
+        .any(|domain| host == *domain || host.ends_with(&format!(".{domain}")))
+}
+
+async fn collect_recursive_requests(
+    collector: Collector,
+    url: Url,
+    extensions: FileExtensions,
+) -> Vec<Request> {
+    let input = Input::from_input_source(InputSource::RemoteUrl(Box::new(url.clone())));
+    let results = collector
+        .collect_links_from_file_types(HashSet::from([input]), extensions)
+        .collect::<Vec<_>>()
+        .await;
+
+    results
+        .into_iter()
+        .filter_map(|result| match result {
+            Ok(request) => Some(request),
+            Err(error) => {
+                warn!("unable to collect links recursively from {url}: {error}");
+                None
+            }
+        })
+        .collect()
 }
 
 async fn suggest_archived_links(

--- a/lychee-bin/src/commands/mod.rs
+++ b/lychee-bin/src/commands/mod.rs
@@ -14,13 +14,16 @@ use std::path::PathBuf;
 use crate::cache::Cache;
 use crate::config::Config;
 use lychee_lib::RequestError;
-use lychee_lib::{Client, Request};
+use lychee_lib::{Client, Collector, Request};
+use std::collections::HashSet;
 
 /// Parameters passed to every command
 pub(crate) struct CommandParams<S: futures::Stream<Item = Result<Request, RequestError>>> {
     pub(crate) client: Client,
     pub(crate) cache: Cache,
+    pub(crate) collector: Collector,
     pub(crate) requests: S,
+    pub(crate) recursion_domains: HashSet<String>,
     pub(crate) cfg: Config,
     pub(crate) is_stdin_input: bool,
 }

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -321,6 +321,32 @@ pub(crate) struct Config {
     #[arg(long)]
     max_concurrency: Option<NonZeroUsize>,
 
+    /// Recursively check links discovered on remote input websites.
+    ///
+    /// Links on the input domains are followed; external links are checked once
+    /// but are not crawled. Use `--recursed-domains` to allow more domains.
+    #[arg(short = 'R', long, optional_bool_flag(), verbatim_doc_comment)]
+    #[serde(default)]
+    recursive: Option<bool>,
+
+    /// Maximum number of link levels to follow when using `--recursive`.
+    ///
+    /// A value of 0 only checks links found in the input documents.
+    #[arg(long, value_name = "DEPTH", verbatim_doc_comment)]
+    max_depth: Option<usize>,
+
+    /// Additional domains that may be followed when using `--recursive`.
+    ///
+    /// Multiple domains can be separated by commas. Subdomains are included.
+    #[arg(
+        long,
+        value_delimiter = ',',
+        value_name = "DOMAIN",
+        verbatim_doc_comment
+    )]
+    #[serde(default)]
+    recursed_domains: Vec<String>,
+
     /// Default maximum concurrent requests per host (default: 10)
     ///
     /// This limits the maximum amount of requests that are sent simultaneously
@@ -792,6 +818,21 @@ impl Config {
         self.max_concurrency.unwrap_or(DEFAULT_MAX_CONCURRENCY)
     }
 
+    /// Whether links on input domains should be followed recursively
+    pub(crate) fn recursive(&self) -> bool {
+        self.recursive.unwrap_or(false)
+    }
+
+    /// Maximum recursion depth, if configured
+    pub(crate) const fn max_depth(&self) -> Option<usize> {
+        self.max_depth
+    }
+
+    /// Additional domains allowed for recursive crawling
+    pub(crate) fn recursed_domains(&self) -> &[String] {
+        &self.recursed_domains
+    }
+
     /// Maximum number of allowed redirects
     pub(crate) fn max_redirects(&self) -> usize {
         self.max_redirects.unwrap_or(DEFAULT_MAX_REDIRECTS)
@@ -984,10 +1025,12 @@ impl Config {
                 verbose,
                 max_cache_age,
                 max_concurrency,
+                max_depth,
                 max_redirects,
                 max_retries,
                 method,
                 mode,
+                recursive,
                 retry_wait_time,
                 timeout,
                 user_agent,
@@ -998,6 +1041,7 @@ impl Config {
                 include,
                 fallback_extensions,
                 remap,
+                recursed_domains,
                 scheme,
                 header,
             },
@@ -1063,6 +1107,7 @@ This convention also simplifies our default value testing."
             // they are not public because they are only used internally.
             "default_extension",
             "files_from",
+            "max_depth",
         ];
 
         let mut default_values = default_field
@@ -1205,6 +1250,26 @@ This convention also simplifies our default value testing."
                 ("accept".to_string(), "text/html".to_string()),
                 ("x-test".to_string(), "check=this".to_string()),
             ])
+        );
+    }
+
+    #[test]
+    fn test_recursive_options() {
+        let opts = parse_options(vec![
+            "lychee",
+            "--recursive",
+            "--max-depth",
+            "3",
+            "--recursed-domains",
+            "docs.example.com,assets.example.com",
+            "https://example.com",
+        ]);
+
+        assert!(opts.config.recursive());
+        assert_eq!(opts.config.max_depth(), Some(3));
+        assert_eq!(
+            opts.config.recursed_domains(),
+            ["docs.example.com", "assets.example.com"]
         );
     }
 

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -336,6 +336,16 @@ fn underlying_io_error_kind(error: &Error) -> Option<io::ErrorKind> {
 async fn run(opts: &LycheeOptions) -> Result<i32> {
     let inputs = opts.inputs()?;
 
+    let recursion_domains = inputs
+        .iter()
+        .filter_map(|input| match &input.source {
+            lychee_lib::InputSource::RemoteUrl(url) => url
+                .host_str()
+                .map(|host| host.trim_end_matches('.').to_ascii_lowercase()),
+            _ => None,
+        })
+        .collect();
+
     // Hide the progress bar only when stdin is the sole input and it is
     // interactive (TTY).
     //
@@ -403,11 +413,15 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         collector
     };
 
-    let requests = collector.collect_links_from_file_types(inputs, opts.config.extensions());
+    let requests = collector
+        .clone()
+        .collect_links_from_file_types(inputs, opts.config.extensions());
     let params = CommandParams {
         client,
         cache,
+        collector,
         requests,
+        recursion_domains,
         cfg: opts.config.clone(),
         is_stdin_input,
     };

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -2671,6 +2671,228 @@ The config file should contain every possible key for documentation purposes."
             .stdout(contains("0 Errors"));
     }
 
+    async fn recursive_test_server() -> wiremock::MockServer {
+        let mock_server = wiremock::MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/index.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/level-one.html">one</a>"#, "text/html"),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/level-one.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/level-two.html">two</a>"#, "text/html"),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/level-two.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/broken.html">broken</a>"#, "text/html"),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/broken.html"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&mock_server)
+            .await;
+
+        mock_server
+    }
+
+    #[tokio::test]
+    async fn test_recursive_link_checking() {
+        let mock_server = recursive_test_server().await;
+
+        cargo_bin_cmd!()
+            .arg("--recursive")
+            .arg("--verbose")
+            .arg(format!("{}/index.html", mock_server.uri()))
+            .assert()
+            .code(2)
+            .stdout(contains("/broken.html"))
+            .stdout(contains("1 Error"));
+    }
+
+    #[tokio::test]
+    async fn test_recursive_link_checking_respects_max_depth() {
+        let mock_server = recursive_test_server().await;
+
+        cargo_bin_cmd!()
+            .arg("--recursive")
+            .arg("--max-depth")
+            .arg("1")
+            .arg("--verbose")
+            .arg(format!("{}/index.html", mock_server.uri()))
+            .assert()
+            .success()
+            .stdout(contains("/broken.html").not())
+            .stdout(contains("2 Total"))
+            .stdout(contains("0 Errors"));
+    }
+
+    async fn external_recursive_test_servers()
+    -> (wiremock::MockServer, wiremock::MockServer, String) {
+        let root_server = wiremock::MockServer::start().await;
+        let external_server = wiremock::MockServer::start().await;
+        let external_url = external_server.uri().replace("127.0.0.1", "localhost");
+
+        Mock::given(method("GET"))
+            .and(path("/index.html"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                format!(r#"<a href="{external_url}/external.html">external</a>"#),
+                "text/html",
+            ))
+            .mount(&root_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/external.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/broken.html">broken</a>"#, "text/html"),
+            )
+            .mount(&external_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/broken.html"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&external_server)
+            .await;
+
+        (root_server, external_server, external_url)
+    }
+
+    #[tokio::test]
+    async fn test_recursive_link_checking_does_not_follow_external_domains() {
+        let (root_server, _external_server, _external_url) =
+            external_recursive_test_servers().await;
+
+        cargo_bin_cmd!()
+            .arg("--recursive")
+            .arg("--verbose")
+            .arg(format!("{}/index.html", root_server.uri()))
+            .assert()
+            .success()
+            .stdout(contains("/broken.html").not())
+            .stdout(contains("1 Total"))
+            .stdout(contains("0 Errors"));
+    }
+
+    #[tokio::test]
+    async fn test_recursive_link_checking_follows_configured_domains() {
+        let (root_server, _external_server, external_url) = external_recursive_test_servers().await;
+
+        cargo_bin_cmd!()
+            .arg("--recursive")
+            .arg("--recursed-domains")
+            .arg("localhost")
+            .arg("--verbose")
+            .arg(format!("{}/index.html", root_server.uri()))
+            .assert()
+            .code(2)
+            .stdout(contains(format!("{external_url}/broken.html")))
+            .stdout(contains("1 Error"));
+    }
+
+    #[tokio::test]
+    async fn test_recursive_link_checking_does_not_follow_external_redirects() {
+        let root_server = wiremock::MockServer::start().await;
+        let external_server = wiremock::MockServer::start().await;
+        let external_url = external_server.uri().replace("127.0.0.1", "localhost");
+
+        Mock::given(method("GET"))
+            .and(path("/index.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/redirect">redirect</a>"#, "text/html"),
+            )
+            .mount(&root_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/redirect"))
+            .respond_with(
+                ResponseTemplate::new(302)
+                    .insert_header("Location", format!("{external_url}/external.html")),
+            )
+            .mount(&root_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/external.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/broken.html">broken</a>"#, "text/html"),
+            )
+            .mount(&external_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/broken.html"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&external_server)
+            .await;
+
+        cargo_bin_cmd!()
+            .arg("--recursive")
+            .arg("--verbose")
+            .arg(format!("{}/index.html", root_server.uri()))
+            .assert()
+            .success()
+            .stdout(contains("/broken.html").not())
+            .stdout(contains("1 Total"))
+            .stdout(contains("0 Errors"));
+    }
+
+    #[tokio::test]
+    async fn test_recursive_link_checking_with_full_bounded_channel() {
+        let mock_server = wiremock::MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path("/index.html"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_raw(r#"<a href="/page.html">page</a>"#, "text/html"),
+            )
+            .mount(&mock_server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/page.html"))
+            .respond_with(ResponseTemplate::new(200).set_body_raw(
+                r#"
+                    <a href="/a.html">a</a>
+                    <a href="/b.html">b</a>
+                    <a href="/c.html">c</a>
+                "#,
+                "text/html",
+            ))
+            .mount(&mock_server)
+            .await;
+        for path_value in ["/a.html", "/b.html", "/c.html"] {
+            Mock::given(method("GET"))
+                .and(path(path_value))
+                .respond_with(ResponseTemplate::new(200))
+                .mount(&mock_server)
+                .await;
+        }
+
+        cargo_bin_cmd!()
+            .arg("--recursive")
+            .arg("--max-depth")
+            .arg("1")
+            .arg("--max-concurrency")
+            .arg("1")
+            .arg(format!("{}/index.html", mock_server.uri()))
+            .assert()
+            .success()
+            .stdout(contains("4 Total"))
+            .stdout(contains("0 Errors"));
+    }
+
     #[tokio::test]
     async fn test_json_format_in_config() -> Result<()> {
         let mock_server = mock_server!(StatusCode::OK);

--- a/lychee-lib/src/types/redirect_history.rs
+++ b/lychee-lib/src/types/redirect_history.rs
@@ -59,6 +59,14 @@ impl Redirects {
         self.redirects.len()
     }
 
+    /// Final URL reached after following the redirect chain.
+    #[must_use]
+    pub fn destination(&self) -> &Url {
+        self.redirects
+            .last()
+            .map_or(&self.origin, |redirect| &redirect.url)
+    }
+
     /// Record a new redirect
     pub fn push(&mut self, redirect: Redirect) {
         self.redirects.push(redirect);

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -55,6 +55,15 @@ max_retries = 2
 # Maximum number of concurrent link checks.
 max_concurrency = 14
 
+# Recursively follow links on remote input domains.
+recursive = false
+
+# Maximum number of link levels to follow when recursively checking a website.
+max_depth = 3
+
+# Additional domains that may be followed recursively.
+recursed_domains = ["docs.example.com", "assets.example.com"]
+
 # extension applied to files without extension
 default_extension = "md"
 


### PR DESCRIPTION
Closes #78.

## Summary

- add `-R` / `--recursive` website crawling, limited to input domains by default
- add `--max-depth` and `--recursed-domains` controls
- reuse the configured collector and shared host pool for recursively discovered pages
- deduplicate crawled pages after fragment normalization and stop recursion at external redirect destinations
- preserve checks for external links without following them

## Pipeline and termination

Recursive requests carry the existing `WaitGuard`, so the pipeline terminates only after all dynamically discovered work completes. Sends into the bounded feedback channel are spawned independently from response processing; this avoids the full-channel deadlock that affected earlier attempts while retaining backpressure. Page collection also remains bounded by `max_concurrency`.

## Validation

- `cargo test --workspace --features check_example_domains`
- `cargo clippy --workspace --all-targets --features check_example_domains -- -D warnings`

The CLI tests cover nested broken links, depth limits, default and configured domain boundaries, external redirects, and the bounded-channel case at `--max-concurrency 1`.