### PR TITLE
feat: add --cache-location to configure the request cache path

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,11 @@ Options:
           comma-separated list of excluded status codes. This example will not cache results
           with a status code of 429, 500 and 501.
 
+      --cache-location <PATH>
+          Filesystem path used to store the on-disk request cache
+
+          [default: .lycheecache]
+
       --cookie-jar <COOKIE_JAR>
           Read and write cookies using the given file. Cookies will be stored in the
           cookie jar and sent with requests. New cookies will be stored in the cookie jar

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -275,6 +275,12 @@ pub(crate) struct Config {
     #[arg(long, verbatim_doc_comment)]
     cache_exclude_status: Option<StatusCodeSelector>,
 
+    /// Filesystem path used to store the on-disk request cache
+    ///
+    /// [default: .lycheecache]
+    #[arg(long, value_name = "PATH")]
+    cache_location: Option<PathBuf>,
+
     /// Don't perform any link checking.
     /// Instead, dump all the links extracted from inputs that would be checked
     #[arg(long, optional_bool_flag())]
@@ -821,6 +827,13 @@ impl Config {
         self.cache.unwrap_or(false)
     }
 
+    /// Filesystem path used to store the on-disk request cache
+    pub(crate) fn cache_location(&self) -> PathBuf {
+        self.cache_location
+            .clone()
+            .unwrap_or_else(|| PathBuf::from(LYCHEE_CACHE_FILE))
+    }
+
     pub(crate) fn dump(&self) -> bool {
         self.dump.unwrap_or(false)
     }
@@ -946,6 +959,7 @@ impl Config {
                 basic_auth,
                 cache,
                 cache_exclude_status,
+                cache_location,
                 cookie_jar,
                 default_extension,
                 dump,
@@ -1117,6 +1131,7 @@ This convention also simplifies our default value testing."
         check_default_values!(
             accept,
             archive,
+            cache_location,
             extensions,
             format,
             max_concurrency,

--- a/lychee-bin/src/main.rs
+++ b/lychee-bin/src/main.rs
@@ -93,7 +93,7 @@ mod verbosity;
 use crate::formatters::stats::{OutputStats, output_hints, output_statistics};
 use crate::{
     cache::Cache,
-    config::{Config, LYCHEE_CACHE_FILE, LYCHEE_IGNORE_FILE, LycheeOptions},
+    config::{Config, LYCHEE_IGNORE_FILE, LycheeOptions},
     formatters::duration::Duration,
     generate::generate,
 };
@@ -224,7 +224,7 @@ fn load_cache(cfg: &Config) -> Option<Cache> {
     // Discard entire cache if it hasn't been updated since `max_cache_age`.
     // This is an optimization, which avoids iterating over the file and
     // checking the age of each entry.
-    match fs::metadata(LYCHEE_CACHE_FILE) {
+    match fs::metadata(cfg.cache_location()) {
         Err(_e) => {
             // No cache found; silently start with empty cache
             return None;
@@ -249,7 +249,7 @@ fn load_cache(cfg: &Config) -> Option<Cache> {
     }
 
     let cache = Cache::load(
-        LYCHEE_CACHE_FILE,
+        cfg.cache_location(),
         max_cache_age.as_secs(),
         &cfg.cache_exclude_status(),
     );
@@ -428,7 +428,7 @@ async fn run(opts: &LycheeOptions) -> Result<i32> {
         output_statistics(stats, &opts.config)?;
 
         if opts.config.cache() {
-            cache.store(LYCHEE_CACHE_FILE)?;
+            cache.store(opts.config.cache_location())?;
         }
 
         if let Some(cookie_jar) = cookie_jar.as_ref() {

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1386,6 +1386,58 @@ The config file should contain every possible key for documentation purposes."
     }
 
     #[tokio::test]
+    async fn test_cache_location_custom_path() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let base_path = dir.path();
+        let custom_cache = base_path.join("custom.cache");
+        let default_cache = base_path.join(LYCHEE_CACHE_FILE);
+
+        // Setup mock server
+        let mock_server_ok = mock_server!(StatusCode::OK);
+
+        // Create test file
+        let file_path = base_path.join("c.md");
+        let mut file = File::create(&file_path)?;
+        writeln!(file, "{}", mock_server_ok.uri().as_str())?;
+        file.sync_all()?;
+
+        // Run with a custom cache location
+        let mut cmd = cargo_bin_cmd!();
+        cmd.current_dir(base_path)
+            .arg(&file_path)
+            .arg("--no-progress")
+            .arg("--cache")
+            .arg("--cache-location")
+            .arg(&custom_cache);
+        cmd.assert().success();
+
+        // Wait for the cache file to be written
+        for _ in 0..20 {
+            if custom_cache.exists() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        assert!(
+            custom_cache.exists(),
+            "Cache was not written to the custom location"
+        );
+        assert!(
+            !default_cache.exists(),
+            "Default cache file should not be created when --cache-location is set"
+        );
+
+        let data = fs::read_to_string(&custom_cache)?;
+        assert!(
+            data.contains(&format!("{}/,200", mock_server_ok.uri())),
+            "Missing OK entry in custom cache file"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_lycheecache_exclude_custom_status_codes() -> Result<()> {
         let dir = tempfile::tempdir()?;
         let base_path = dir.path();

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -37,6 +37,9 @@ max_cache_age = "2d"
 # A list of status codes that will be ignored from the cache
 cache_exclude_status = "500.."
 
+# Filesystem path used to store the on-disk request cache.
+# cache_location = ".lycheecache"
+
 #############################  Runtime  #############################
 
 # File to read and write cookies

--- a/lychee.example.toml
+++ b/lychee.example.toml
@@ -38,7 +38,7 @@ max_cache_age = "2d"
 cache_exclude_status = "500.."
 
 # Filesystem path used to store the on-disk request cache.
-# cache_location = ".lycheecache"
+cache_location = ".lycheecache"
 
 #############################  Runtime  #############################
 


### PR DESCRIPTION
This adds a `--cache-location` option (and matching `cache_location` config key) so the on-disk request cache can be written somewhere other than the hard-coded `.lycheecache` in the current directory.

Closes #1700

The cache path was previously a compile-time constant, so every project that runs with `--cache` accumulates a `.lycheecache` file at the repo root, which then has to be added to `.gitignore`, and there was no way to redirect it into a build/scratch directory or an XDG-style cache dir. This came up a few times on the issue, including a CI setup where writing into the working tree is awkward. With this change you can point the cache wherever you want:

```
lychee --cache --cache-location target/lychee/cache .
```

The default is unchanged: when the option/key is omitted the cache still lives at `.lycheecache`, so existing setups keep working exactly as before.

A few notes on the implementation:

- Following the repo convention of avoiding clap's own defaults, the field is a private `Option<PathBuf>` with the default annotated in the doc comment (`[default: .lycheecache]`) and resolved in a `cache_location()` getter. It's wired into `check_default_values!`, so the existing `test_default_values` test verifies the documented default matches the actual one.
- The three call sites in `main.rs` (cache freshness check, load, store) now use `cfg.cache_location()` instead of the constant.
- Added a CLI test (`test_cache_location_custom_path`) that runs with a custom path and asserts the cache is written there and that no `.lycheecache` is created.
- Documented the key with a commented example in `lychee.example.toml`.

`cargo test` (config unit tests + the cache CLI tests) and `cargo clippy` pass locally.