### PR TITLE
feat: generate a JSON schema for the config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "reqwest_cookie_store",
  "ring",
  "rlimit",
+ "schemars 1.2.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -3696,8 +3697,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3791,6 +3805,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Options:
       --generate <GENERATE>
           Generate special output (e.g. the man page) instead of performing link checking
 
-          [possible values: man, complete-bash, complete-elvish, complete-fish, complete-powershell, complete-zsh]
+          [possible values: man, config-schema, complete-bash, complete-elvish, complete-fish, complete-powershell, complete-zsh]
 
       --github-token <GITHUB_TOKEN>
           GitHub API token to use when checking github.com links, to avoid rate limiting
@@ -824,6 +824,24 @@ If the `--cache` flag is set, lychee will cache responses in a file called
 then the cache will be loaded on startup. This can greatly speed up future runs.
 Note that by default lychee will not store any data on disk.
 This is explained in more detail in [our documentation](https://lychee.cli.rs/recipes/caching/).
+
+### Configuration file schema
+
+lychee can emit a [JSON schema](https://json-schema.org/) for its configuration
+file:
+
+```sh
+lychee --generate config-schema > lychee.schema.json
+```
+
+The schema describes every available key (along with its documentation) and can
+be used by editors with a TOML language server such as
+[Taplo](https://taplo.tamasfe.dev/) to get autocompletion and validation for
+`lychee.toml`. For example, using a Taplo directive at the top of the file:
+
+```toml
+#:schema ./lychee.schema.json
+```
 
 ## Supported file formats
 

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -40,6 +40,7 @@ regex = "1.12.2"
 reqwest = "0.13.4"
 reqwest_cookie_store = { version = "0.10.0", features = ["serde"] }
 rlimit = "0.11.0"
+schemars = "1.0.4"
 # Make build work on Apple Silicon.
 # See https://github.com/briansmith/ring/issues/1163
 # This is necessary for the homebrew build

--- a/lychee-bin/src/commands/generate.rs
+++ b/lychee-bin/src/commands/generate.rs
@@ -10,10 +10,12 @@ use clap_mangen::{
     Man,
     roff::{Roff, roman},
 };
+use schemars::JsonSchema;
 use serde::Deserialize;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 use crate::LycheeOptions;
+use crate::config::Config;
 
 const CONTRIBUTOR_THANK_NOTE: &str = "\n\nA huge thank you to all the wonderful contributors who helped make this project a success.";
 
@@ -71,13 +73,17 @@ const EXIT_CODE_SECTION: &str = "
 ";
 
 /// What to generate when providing the --generate flag
-#[derive(Debug, Deserialize, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq)]
+#[derive(
+    Debug, Deserialize, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq, JsonSchema,
+)]
 #[non_exhaustive]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum GenerateMode {
     /// Generate roff used for the man page
     Man,
+    /// Generate a JSON schema for the configuration file
+    ConfigSchema,
     /// Generate shell completion for Bash
     CompleteBash,
     /// Generate shell completion for Elvish
@@ -94,12 +100,23 @@ pub(crate) enum GenerateMode {
 pub(crate) fn generate(mode: &GenerateMode) -> Result<String> {
     match mode {
         GenerateMode::Man => man_page(),
+        GenerateMode::ConfigSchema => config_schema(),
         GenerateMode::CompleteBash => shell_completion(Shell::Bash),
         GenerateMode::CompleteElvish => shell_completion(Shell::Elvish),
         GenerateMode::CompleteFish => shell_completion(Shell::Fish),
         GenerateMode::CompletePowershell => shell_completion(Shell::PowerShell),
         GenerateMode::CompleteZsh => shell_completion(Shell::Zsh),
     }
+}
+
+/// Generate a JSON schema for the `lychee.toml` configuration file.
+///
+/// The schema is derived from the [`Config`] type. It can be referenced from a
+/// config file via the `$schema` key (or a `taplo`/editor setting) to get
+/// autocompletion and validation while editing.
+fn config_schema() -> Result<String> {
+    let schema = schemars::schema_for!(Config);
+    Ok(serde_json::to_string_pretty(&schema)?)
 }
 
 /// Generate shell completion for the given shell
@@ -166,9 +183,40 @@ fn render_section(title: &str, content: &str, buffer: &mut Vec<u8>) -> Result<()
 
 #[cfg(test)]
 mod tests {
-    use super::man_page;
+    use super::{config_schema, man_page};
     use crate::generate::{CONTRIBUTOR_THANK_NOTE, EXIT_CODE_SECTION};
     use anyhow::Result;
+
+    #[test]
+    fn test_config_schema() -> Result<()> {
+        let schema: serde_json::Value = serde_json::from_str(&config_schema()?)?;
+
+        // The schema describes the config file (i.e. the `Config` type).
+        assert_eq!(schema["title"], "Config");
+
+        // `deny_unknown_fields` on `Config` should forbid unknown keys.
+        assert_eq!(schema["additionalProperties"], false);
+
+        // A few representative options should be present, including their
+        // documentation lifted from the doc comments.
+        let properties = &schema["properties"];
+        assert!(properties["max_retries"].is_object());
+        assert!(properties["accept"].is_object());
+        assert!(
+            properties["timeout"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("timeout")
+        );
+
+        // Enum options should expose their allowed values.
+        let modes = schema["$defs"]["StatsFormat"]["enum"]
+            .as_array()
+            .expect("StatsFormat should be represented as an enum");
+        assert!(modes.iter().any(|value| value == "json"));
+
+        Ok(())
+    }
 
     #[test]
     fn test_man_page() -> Result<()> {

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -30,6 +30,7 @@ use lychee_lib::{
     FragmentCheckerOptions, Input, Methods, StatusCodeSelector, archive::Archive,
 };
 use lychee_lib::{DEFAULT_USER_AGENT, Preprocessor};
+use schemars::JsonSchema;
 use secrecy::SecretString;
 use serde::{Deserialize, Deserializer};
 use std::collections::{HashMap, HashSet};
@@ -75,7 +76,7 @@ impl ArgBoolOptionalExt for Arg {
 }
 
 /// Values for `--include-fragments` option, which controls how URL fragments are checked.
-#[derive(Debug, Clone, Copy, Deserialize, EnumString)]
+#[derive(Debug, Clone, Copy, Deserialize, EnumString, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 enum FragmentMode {
@@ -177,8 +178,12 @@ where
 }
 
 /// The main configuration for lychee
+///
+/// This mirrors the structure of the `lychee.toml` configuration file. It is
+/// also used to derive a JSON schema (see `lychee --generate config-schema`),
+/// which editors can use for autocompletion and validation of the config file.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Parser, Debug, Deserialize, Clone, Default)]
+#[derive(Parser, Debug, Deserialize, Clone, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// Read input filenames from the given file or stdin (if path is '-').
@@ -228,6 +233,7 @@ pub(crate) struct Config {
     ///
     /// [default: md,markdown,mdx,qmd,rmd,mkd,mkdn,mdwn,mdown,mkdown,html,htm,css,txt,xml]
     #[arg(long, verbatim_doc_comment)]
+    #[schemars(with = "String")]
     extensions: Option<FileExtensions>,
 
     /// Parse input sources without a recognised file type by using the given
@@ -256,6 +262,7 @@ pub(crate) struct Config {
     /// [default: 1d]
     #[arg(long, value_parser = humantime::parse_duration)]
     #[serde(default, with = "humantime_serde")]
+    #[schemars(with = "String")]
     max_cache_age: Option<Duration>,
 
     /// A list of status codes that will be ignored from the cache
@@ -273,6 +280,7 @@ pub(crate) struct Config {
     /// comma-separated list of excluded status codes. This example will not cache results
     /// with a status code of 429, 500 and 501.
     #[arg(long, verbatim_doc_comment)]
+    #[schemars(with = "String")]
     cache_exclude_status: Option<StatusCodeSelector>,
 
     /// Don't perform any link checking.
@@ -291,6 +299,7 @@ pub(crate) struct Config {
     ///
     /// [default: wayback]
     #[arg(long, value_parser = PossibleValuesParser::new(Archive::VARIANTS).map(|s| s.parse::<Archive>().unwrap()))]
+    #[schemars(with = "String")]
     archive: Option<Archive>,
 
     /// Suggest link replacements for broken links, using a web archive.
@@ -346,6 +355,7 @@ pub(crate) struct Config {
     ///   --host-request-interval 1s     # Conservative for rate-limited APIs
     #[arg(long, value_parser = humantime::parse_duration, verbatim_doc_comment)]
     #[serde(default, with = "humantime_serde")]
+    #[schemars(with = "String")]
     pub(crate) host_request_interval: Option<Duration>,
 
     /// Number of threads to utilize.
@@ -484,6 +494,7 @@ pub(crate) struct Config {
     )]
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_headers")]
+    #[schemars(with = "std::collections::HashMap<String, String>")]
     header: Vec<(String, String)>,
 
     /// A List of accepted status codes for valid links
@@ -503,6 +514,7 @@ pub(crate) struct Config {
     ///
     /// [default: 100..=103,200..=299]
     #[arg(short, long, verbatim_doc_comment)]
+    #[schemars(with = "String")]
     accept: Option<StatusCodeSelector>,
 
     /// Accept timed out requests and return exit code 0
@@ -560,6 +572,7 @@ pub(crate) struct Config {
     /// [default: get]
     // Using `-X` as a short param similar to curl
     #[arg(short = 'X', long)]
+    #[schemars(with = "String")]
     method: Option<Methods>,
 
     /// Base URL to use when resolving relative URLs in local files. If specified,
@@ -587,6 +600,7 @@ pub(crate) struct Config {
         value_parser = parse_base_info,
         verbatim_doc_comment
     )]
+    #[schemars(with = "String")]
     pub(crate) base_url: Option<BaseInfo>,
 
     /// Root directory to use when checking absolute links in local files. This option is
@@ -606,10 +620,12 @@ pub(crate) struct Config {
 
     /// Basic authentication support. E.g. `http://example.com username:password`
     #[arg(long)]
+    #[schemars(with = "Vec<String>")]
     pub(crate) basic_auth: Option<Vec<BasicAuthSelector>>,
 
     /// GitHub API token to use when checking github.com links, to avoid rate limiting
     #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    #[schemars(with = "String")]
     pub(crate) github_token: Option<SecretString>,
 
     /// Skip missing input files (default is to error if they don't exist)
@@ -702,11 +718,13 @@ pub(crate) struct Config {
     /// esac
     /// ```
     #[arg(short, long, value_name = "COMMAND", verbatim_doc_comment)]
+    #[schemars(with = "String")]
     pub(crate) preprocess: Option<Preprocessor>,
 
     /// Host-specific configurations from config file
     #[arg(skip)]
     #[serde(default)]
+    #[schemars(with = "std::collections::HashMap<String, serde_json::Value>")]
     pub(crate) hosts: HostConfigs,
 }
 
@@ -1051,10 +1069,12 @@ This convention also simplifies our default value testing."
 
         let default_value_annotation = Regex::new(r"\s*\[default: (?<value>.*)\]").unwrap();
         // Matches last line of rustdoc comment, then skips a line (expected to be `#[arg(...)]`),
-        // then matches a *private* field of type Option.
-        let default_field =
-            Regex::new(r"(?m)^\s+///(?<comment>.*)\n.*\n\s+(?<ident>\w+):\s*Option<.*>,?$")
-                .unwrap();
+        // optionally skips a `#[schemars(...)]` attribute line (used for config schema
+        // generation), then matches a *private* field of type Option.
+        let default_field = Regex::new(
+            r"(?m)^\s+///(?<comment>.*)\n.*\n(?:\s*#\[schemars[^\n]*\n)?\s+(?<ident>\w+):\s*Option<.*>,?$",
+        )
+        .unwrap();
 
         let undocumented_default_fields = [
             "verbose",              // the flag takes no argument

--- a/lychee-bin/src/config/output.rs
+++ b/lychee-bin/src/config/output.rs
@@ -4,12 +4,15 @@
 //! such as color modes and output formats (e.g. JSON, Compact, Detailed).
 
 use anyhow::{Error, Result, anyhow};
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::str::FromStr;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 /// The format to use for the final status report
-#[derive(Debug, Deserialize, Default, Clone, Display, EnumIter, VariantNames, PartialEq)]
+#[derive(
+    Debug, Deserialize, Default, Clone, Display, EnumIter, VariantNames, PartialEq, JsonSchema,
+)]
 #[non_exhaustive]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -42,7 +45,16 @@ impl FromStr for StatsFormat {
 /// This decides over whether to use color,
 /// emojis, or plain text for the output.
 #[derive(
-    Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq,
+    Debug,
+    Deserialize,
+    Default,
+    Clone,
+    Display,
+    EnumIter,
+    EnumString,
+    VariantNames,
+    PartialEq,
+    JsonSchema,
 )]
 #[non_exhaustive]
 pub(crate) enum OutputMode {

--- a/lychee-bin/src/config/tls.rs
+++ b/lychee-bin/src/config/tls.rs
@@ -3,11 +3,22 @@
 //! Provides types for specifying minimum accepted TLS versions for network requests.
 
 use reqwest::tls;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 #[derive(
-    Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq, Eq,
+    Debug,
+    Deserialize,
+    Default,
+    Clone,
+    Display,
+    EnumIter,
+    EnumString,
+    VariantNames,
+    PartialEq,
+    Eq,
+    JsonSchema,
 )]
 #[non_exhaustive]
 pub(crate) enum TlsVersion {

--- a/lychee-bin/src/verbosity.rs
+++ b/lychee-bin/src/verbosity.rs
@@ -1,5 +1,6 @@
 use log::Level;
 use log::LevelFilter;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -13,7 +14,7 @@ use std::str::FromStr;
 /// - `-v` show info
 /// - `-vv` show debug
 /// - `-vvv` show trace
-#[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq)]
+#[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq, JsonSchema)]
 #[command(arg_required_else_help = true)]
 pub(crate) struct Verbosity {
     /// Pass many times for more log output


### PR DESCRIPTION
This adds a `config-schema` mode to `--generate` that prints a JSON schema for the config file, picking up #1382.

The schema is derived from the `Config` struct with `schemars`, so the field names and their descriptions come straight from the existing definitions and stay in sync automatically. With a TOML language server like Taplo you can then point `lychee.toml` at it for autocompletion and validation:

```sh
lychee --generate config-schema > lychee.schema.json
```

```toml
#:schema ./lychee.schema.json
```

A couple of implementation notes:

- I kept `schemars` in `lychee-bin` only. Types that come from `lychee-lib` (and things like `Duration` or `SecretString`) are described via `#[schemars(with = ...)]` using their serialized form, so the lib crate is left untouched. Enums defined in the bin (`StatsFormat`, `OutputMode`, `TlsVersion`, `FragmentMode`) derive `JsonSchema` directly, so they expose their allowed values in the schema.
- `test_default_values` scrapes the source for the doc-comment/`#[arg]`/field layout to verify documented defaults. I taught its regex to skip an optional `#[schemars(...)]` line so that convention still holds.

Happy to instead derive `JsonSchema` in `lychee-lib` for the lib-owned types (`StatusCodeSelector` and friends) if you would rather have richer schemas for those fields.