### PR TITLE
fix: align generated config schema with accepted values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2348,6 +2348,7 @@ dependencies = [
  "reqwest_cookie_store",
  "ring",
  "rlimit",
+ "schemars 1.2.1",
  "secrecy",
  "serde",
  "serde_json",
@@ -3696,8 +3697,21 @@ checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3791,6 +3805,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +283,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +311,12 @@ checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "bs58"
@@ -1216,6 +1251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52e0387578e845beb7a1acff126228499f26cb18edf12919cc513bb863266464"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1309,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1300,6 +1357,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e246562084dde8ebbcc943b261c406ce4f68e5032ec28029a251a47d6a295500"
+dependencies = [
+ "num",
+ "num-bigint",
 ]
 
 [[package]]
@@ -1571,6 +1638,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2192,6 +2270,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b68339c3d874e48151d74ffe256d93a58cffa240983cb0967d3cbaea083a44fe"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6307b5b51216ec9b941b52244c74043fa0b1d6b657b56199f57cb1416d3641c5"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0230ac05e09c6111e96c147b75c390579f5cbd45654b980c68ac60fe17b3f129"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "getrandom 0.3.4",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+ "zmij",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2468,7 @@ dependencies = [
  "humantime",
  "humantime-serde",
  "indicatif",
+ "jsonschema",
  "log",
  "lychee-lib",
  "numeric-sort",
@@ -2458,6 +2590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2547,10 +2685,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
-name = "num-bigint"
-version = "0.4.6"
+name = "num"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -2570,6 +2722,21 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2594,6 +2761,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -2699,6 +2877,12 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -3356,6 +3540,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "referencing"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a196a5b4a8a12f46b6353174df865a05d41a6055aff212ec30877492788618b6"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -4678,6 +4879,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4750,10 +4957,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vte"
@@ -5599,6 +5822,6 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ Options:
       --generate <GENERATE>
           Generate special output (e.g. the man page) instead of performing link checking
 
-          [possible values: man, complete-bash, complete-elvish, complete-fish, complete-powershell, complete-zsh]
+          [possible values: man, config-schema, complete-bash, complete-elvish, complete-fish, complete-powershell, complete-zsh]
 
       --github-token <GITHUB_TOKEN>
           GitHub API token to use when checking github.com links, to avoid rate limiting
@@ -824,6 +824,24 @@ If the `--cache` flag is set, lychee will cache responses in a file called
 then the cache will be loaded on startup. This can greatly speed up future runs.
 Note that by default lychee will not store any data on disk.
 This is explained in more detail in [our documentation](https://lychee.cli.rs/recipes/caching/).
+
+### Configuration file schema
+
+lychee can emit a [JSON schema](https://json-schema.org/) for its configuration
+file:
+
+```sh
+lychee --generate config-schema > lychee.schema.json
+```
+
+The schema describes every available key (along with its documentation) and can
+be used by editors with a TOML language server such as
+[Taplo](https://taplo.tamasfe.dev/) to get autocompletion and validation for
+`lychee.toml`. For example, using a Taplo directive at the top of the file:
+
+```toml
+#:schema ./lychee.schema.json
+```
 
 ## Supported file formats
 

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -60,6 +60,7 @@ quick-junit = "0.7.0"
 
 [dev-dependencies]
 assert_cmd = "2.2.2"
+jsonschema = { version = "0.55.1", default-features = false }
 cookie_store = "0.22.1"
 predicates = "3.1.4"
 pretty_assertions = "1.4.1"

--- a/lychee-bin/Cargo.toml
+++ b/lychee-bin/Cargo.toml
@@ -40,6 +40,7 @@ regex = "1.12.2"
 reqwest = "0.13.4"
 reqwest_cookie_store = { version = "0.10.0", features = ["serde"] }
 rlimit = "0.11.0"
+schemars = "1.0.4"
 # Make build work on Apple Silicon.
 # See https://github.com/briansmith/ring/issues/1163
 # This is necessary for the homebrew build

--- a/lychee-bin/src/commands/generate.rs
+++ b/lychee-bin/src/commands/generate.rs
@@ -10,10 +10,12 @@ use clap_mangen::{
     Man,
     roff::{Roff, roman},
 };
+use schemars::JsonSchema;
 use serde::Deserialize;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 use crate::LycheeOptions;
+use crate::config::Config;
 
 const CONTRIBUTOR_THANK_NOTE: &str = "\n\nA huge thank you to all the wonderful contributors who helped make this project a success.";
 
@@ -71,13 +73,17 @@ const EXIT_CODE_SECTION: &str = "
 ";
 
 /// What to generate when providing the --generate flag
-#[derive(Debug, Deserialize, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq)]
+#[derive(
+    Debug, Deserialize, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq, JsonSchema,
+)]
 #[non_exhaustive]
 #[strum(serialize_all = "kebab-case")]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum GenerateMode {
     /// Generate roff used for the man page
     Man,
+    /// Generate a JSON schema for the configuration file
+    ConfigSchema,
     /// Generate shell completion for Bash
     CompleteBash,
     /// Generate shell completion for Elvish
@@ -94,12 +100,23 @@ pub(crate) enum GenerateMode {
 pub(crate) fn generate(mode: &GenerateMode) -> Result<String> {
     match mode {
         GenerateMode::Man => man_page(),
+        GenerateMode::ConfigSchema => config_schema(),
         GenerateMode::CompleteBash => shell_completion(Shell::Bash),
         GenerateMode::CompleteElvish => shell_completion(Shell::Elvish),
         GenerateMode::CompleteFish => shell_completion(Shell::Fish),
         GenerateMode::CompletePowershell => shell_completion(Shell::PowerShell),
         GenerateMode::CompleteZsh => shell_completion(Shell::Zsh),
     }
+}
+
+/// Generate a JSON schema for the `lychee.toml` configuration file.
+///
+/// The schema is derived from the [`Config`] type. It can be referenced from a
+/// config file via the `$schema` key (or a `taplo`/editor setting) to get
+/// autocompletion and validation while editing.
+fn config_schema() -> Result<String> {
+    let schema = schemars::schema_for!(Config);
+    Ok(serde_json::to_string_pretty(&schema)?)
 }
 
 /// Generate shell completion for the given shell
@@ -166,9 +183,40 @@ fn render_section(title: &str, content: &str, buffer: &mut Vec<u8>) -> Result<()
 
 #[cfg(test)]
 mod tests {
-    use super::man_page;
+    use super::{config_schema, man_page};
     use crate::generate::{CONTRIBUTOR_THANK_NOTE, EXIT_CODE_SECTION};
     use anyhow::Result;
+
+    #[test]
+    fn test_config_schema() -> Result<()> {
+        let schema: serde_json::Value = serde_json::from_str(&config_schema()?)?;
+
+        // The schema describes the config file (i.e. the `Config` type).
+        assert_eq!(schema["title"], "Config");
+
+        // `deny_unknown_fields` on `Config` should forbid unknown keys.
+        assert_eq!(schema["additionalProperties"], false);
+
+        // A few representative options should be present, including their
+        // documentation lifted from the doc comments.
+        let properties = &schema["properties"];
+        assert!(properties["max_retries"].is_object());
+        assert!(properties["accept"].is_object());
+        assert!(
+            properties["timeout"]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("timeout")
+        );
+
+        // Enum options should expose their allowed values.
+        let modes = schema["$defs"]["StatsFormat"]["enum"]
+            .as_array()
+            .expect("StatsFormat should be represented as an enum");
+        assert!(modes.iter().any(|value| value == "json"));
+
+        Ok(())
+    }
 
     #[test]
     fn test_man_page() -> Result<()> {

--- a/lychee-bin/src/commands/generate.rs
+++ b/lychee-bin/src/commands/generate.rs
@@ -184,24 +184,32 @@ fn render_section(title: &str, content: &str, buffer: &mut Vec<u8>) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::{config_schema, man_page};
+    use crate::config::Config;
     use crate::generate::{CONTRIBUTOR_THANK_NOTE, EXIT_CODE_SECTION};
-    use anyhow::Result;
+    use anyhow::{Result, bail};
+    use serde_json::{Value, json};
+
+    fn config_schema_value() -> Result<Value> {
+        Ok(serde_json::from_str(&config_schema()?)?)
+    }
+
+    fn toml_to_json(config: &str) -> Result<Value> {
+        let config: toml::Value = toml::from_str(config)?;
+        Ok(serde_json::to_value(config)?)
+    }
 
     #[test]
     fn test_config_schema() -> Result<()> {
-        let schema: serde_json::Value = serde_json::from_str(&config_schema()?)?;
+        let schema = config_schema_value()?;
 
-        // The schema describes the config file (i.e. the `Config` type).
+        assert!(jsonschema::draft202012::meta::is_valid(&schema));
         assert_eq!(schema["title"], "Config");
-
-        // `deny_unknown_fields` on `Config` should forbid unknown keys.
         assert_eq!(schema["additionalProperties"], false);
+        assert!(schema.get("required").is_none());
+        assert_eq!(schema["properties"]["header"]["default"], json!({}));
 
-        // A few representative options should be present, including their
-        // documentation lifted from the doc comments.
         let properties = &schema["properties"];
         assert!(properties["max_retries"].is_object());
-        assert!(properties["accept"].is_object());
         assert!(
             properties["timeout"]["description"]
                 .as_str()
@@ -209,11 +217,91 @@ mod tests {
                 .contains("timeout")
         );
 
-        // Enum options should expose their allowed values.
         let modes = schema["$defs"]["StatsFormat"]["enum"]
             .as_array()
             .expect("StatsFormat should be represented as an enum");
         assert!(modes.iter().any(|value| value == "json"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_config_schema_accepts_supported_config_forms() -> Result<()> {
+        let schema = config_schema_value()?;
+        let validator = jsonschema::draft202012::new(&schema)?;
+        let configs = [
+            ("empty config", ""),
+            (
+                "example config",
+                include_str!("../../../lychee.example.toml"),
+            ),
+            (
+                "custom deserializers",
+                r#"
+verbose = "Warning"
+extensions = ["md", "html"]
+cache_exclude_status = [429, "500.."]
+archive = "wayback"
+accept = 200
+method = ["head", "get"]
+base_url = "https://example.com"
+basic_auth = ["example.com user:password"]
+github_token = "secret"
+preprocess = { command = "preprocess.sh", ignored = true }
+
+[hosts."example.com"]
+concurrency = 2
+request_interval = "100ms"
+headers = { Accept = "text/html" }
+"#,
+            ),
+        ];
+
+        for (name, config) in configs {
+            if let Err(error) = toml::from_str::<Config>(config) {
+                bail!("{name} should deserialize as Config: {error}");
+            }
+
+            let instance = toml_to_json(config)?;
+            if let Err(error) = validator.validate(&instance) {
+                bail!("{name} should match the generated schema: {error}");
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_config_schema_rejects_unsupported_config_forms() -> Result<()> {
+        let schema = config_schema_value()?;
+        let validator = jsonschema::draft202012::new(&schema)?;
+        let configs = [
+            ("unknown root option", "unknown = true"),
+            (
+                "unknown host option",
+                "[hosts.\"example.com\"]\nunknown = true",
+            ),
+            ("unsupported archive", "archive = \"unknown\""),
+            ("unsupported verbosity", "verbose = \"loud\""),
+            ("empty method list", "method = []"),
+            ("empty method string", "method = \"\""),
+            ("status below minimum", "accept = 42"),
+            ("status string below minimum", "accept = \"42\""),
+            ("malformed basic auth", "basic_auth = [\"user:password\"]"),
+        ];
+
+        for (name, config) in configs {
+            assert!(
+                toml::from_str::<Config>(config).is_err(),
+                "{name} should not deserialize as Config"
+            );
+
+            let instance = toml_to_json(config)?;
+            assert!(
+                !validator.is_valid(&instance),
+                "{name} should not match the generated schema"
+            );
+        }
 
         Ok(())
     }

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -9,6 +9,7 @@
 pub(crate) mod header;
 pub(crate) mod loaders;
 pub(crate) mod output;
+mod schema;
 pub(crate) mod tls;
 
 pub(crate) use header::*;
@@ -208,6 +209,7 @@ pub(crate) struct Config {
 
     /// Verbose program output
     #[clap(flatten)]
+    #[schemars(with = "Option<schema::Verbosity>")]
     verbose: Option<Verbosity>,
 
     /// Do not show progress bar.
@@ -233,7 +235,7 @@ pub(crate) struct Config {
     ///
     /// [default: md,markdown,mdx,qmd,rmd,mkd,mkdn,mdwn,mdown,mkdown,html,htm,css,txt,xml]
     #[arg(long, verbatim_doc_comment)]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<Vec<String>>")]
     extensions: Option<FileExtensions>,
 
     /// Parse input sources without a recognised file type by using the given
@@ -262,7 +264,7 @@ pub(crate) struct Config {
     /// [default: 1d]
     #[arg(long, value_parser = humantime::parse_duration)]
     #[serde(default, with = "humantime_serde")]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<String>")]
     max_cache_age: Option<Duration>,
 
     /// A list of status codes that will be ignored from the cache
@@ -280,7 +282,7 @@ pub(crate) struct Config {
     /// comma-separated list of excluded status codes. This example will not cache results
     /// with a status code of 429, 500 and 501.
     #[arg(long, verbatim_doc_comment)]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<schema::StatusCodeSelector>")]
     cache_exclude_status: Option<StatusCodeSelector>,
 
     /// Don't perform any link checking.
@@ -299,7 +301,7 @@ pub(crate) struct Config {
     ///
     /// [default: wayback]
     #[arg(long, value_parser = PossibleValuesParser::new(Archive::VARIANTS).map(|s| s.parse::<Archive>().unwrap()))]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<schema::Archive>")]
     archive: Option<Archive>,
 
     /// Suggest link replacements for broken links, using a web archive.
@@ -355,7 +357,7 @@ pub(crate) struct Config {
     ///   --host-request-interval 1s     # Conservative for rate-limited APIs
     #[arg(long, value_parser = humantime::parse_duration, verbatim_doc_comment)]
     #[serde(default, with = "humantime_serde")]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<String>")]
     pub(crate) host_request_interval: Option<Duration>,
 
     /// Number of threads to utilize.
@@ -494,7 +496,10 @@ pub(crate) struct Config {
     )]
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_headers")]
-    #[schemars(with = "std::collections::HashMap<String, String>")]
+    #[schemars(
+        with = "std::collections::HashMap<String, String>",
+        default = "schema::empty_string_map"
+    )]
     header: Vec<(String, String)>,
 
     /// A List of accepted status codes for valid links
@@ -514,7 +519,7 @@ pub(crate) struct Config {
     ///
     /// [default: 100..=103,200..=299]
     #[arg(short, long, verbatim_doc_comment)]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<schema::StatusCodeSelector>")]
     accept: Option<StatusCodeSelector>,
 
     /// Accept timed out requests and return exit code 0
@@ -572,7 +577,7 @@ pub(crate) struct Config {
     /// [default: get]
     // Using `-X` as a short param similar to curl
     #[arg(short = 'X', long)]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<schema::Methods>")]
     method: Option<Methods>,
 
     /// Base URL to use when resolving relative URLs in local files. If specified,
@@ -600,7 +605,7 @@ pub(crate) struct Config {
         value_parser = parse_base_info,
         verbatim_doc_comment
     )]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<String>")]
     pub(crate) base_url: Option<BaseInfo>,
 
     /// Root directory to use when checking absolute links in local files. This option is
@@ -620,12 +625,12 @@ pub(crate) struct Config {
 
     /// Basic authentication support. E.g. `http://example.com username:password`
     #[arg(long)]
-    #[schemars(with = "Vec<String>")]
+    #[schemars(with = "Option<Vec<schema::BasicAuthSelector>>")]
     pub(crate) basic_auth: Option<Vec<BasicAuthSelector>>,
 
     /// GitHub API token to use when checking github.com links, to avoid rate limiting
     #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<String>")]
     pub(crate) github_token: Option<SecretString>,
 
     /// Skip missing input files (default is to error if they don't exist)
@@ -718,13 +723,13 @@ pub(crate) struct Config {
     /// esac
     /// ```
     #[arg(short, long, value_name = "COMMAND", verbatim_doc_comment)]
-    #[schemars(with = "String")]
+    #[schemars(with = "Option<schema::Preprocessor>")]
     pub(crate) preprocess: Option<Preprocessor>,
 
     /// Host-specific configurations from config file
     #[arg(skip)]
     #[serde(default)]
-    #[schemars(with = "std::collections::HashMap<String, serde_json::Value>")]
+    #[schemars(with = "std::collections::HashMap<String, schema::HostConfig>")]
     pub(crate) hosts: HostConfigs,
 }
 

--- a/lychee-bin/src/config/mod.rs
+++ b/lychee-bin/src/config/mod.rs
@@ -30,6 +30,7 @@ use lychee_lib::{
     FragmentCheckerOptions, Input, Methods, StatusCodeSelector, archive::Archive,
 };
 use lychee_lib::{DEFAULT_USER_AGENT, Preprocessor};
+use schemars::JsonSchema;
 use secrecy::SecretString;
 use serde::{Deserialize, Deserializer};
 use std::collections::{HashMap, HashSet};
@@ -75,7 +76,7 @@ impl ArgBoolOptionalExt for Arg {
 }
 
 /// Values for `--include-fragments` option, which controls how URL fragments are checked.
-#[derive(Debug, Clone, Copy, Deserialize, EnumString)]
+#[derive(Debug, Clone, Copy, Deserialize, EnumString, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 enum FragmentMode {
@@ -177,8 +178,12 @@ where
 }
 
 /// The main configuration for lychee
+///
+/// This mirrors the structure of the `lychee.toml` configuration file. It is
+/// also used to derive a JSON schema (see `lychee --generate config-schema`),
+/// which editors can use for autocompletion and validation of the config file.
 #[allow(clippy::struct_excessive_bools)]
-#[derive(Parser, Debug, Deserialize, Clone, Default)]
+#[derive(Parser, Debug, Deserialize, Clone, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub(crate) struct Config {
     /// Read input filenames from the given file or stdin (if path is '-').
@@ -228,6 +233,7 @@ pub(crate) struct Config {
     ///
     /// [default: md,markdown,mdx,qmd,rmd,mkd,mkdn,mdwn,mdown,mkdown,html,htm,css,txt,xml]
     #[arg(long, verbatim_doc_comment)]
+    #[schemars(with = "String")]
     extensions: Option<FileExtensions>,
 
     /// Parse input sources without a recognised file type by using the given
@@ -256,6 +262,7 @@ pub(crate) struct Config {
     /// [default: 1d]
     #[arg(long, value_parser = humantime::parse_duration)]
     #[serde(default, with = "humantime_serde")]
+    #[schemars(with = "String")]
     max_cache_age: Option<Duration>,
 
     /// A list of status codes that will be ignored from the cache
@@ -273,6 +280,7 @@ pub(crate) struct Config {
     /// comma-separated list of excluded status codes. This example will not cache results
     /// with a status code of 429, 500 and 501.
     #[arg(long, verbatim_doc_comment)]
+    #[schemars(with = "String")]
     cache_exclude_status: Option<StatusCodeSelector>,
 
     /// Don't perform any link checking.
@@ -291,6 +299,7 @@ pub(crate) struct Config {
     ///
     /// [default: wayback]
     #[arg(long, value_parser = PossibleValuesParser::new(Archive::VARIANTS).map(|s| s.parse::<Archive>().unwrap()))]
+    #[schemars(with = "String")]
     archive: Option<Archive>,
 
     /// Suggest link replacements for broken links, using a web archive.
@@ -346,6 +355,7 @@ pub(crate) struct Config {
     ///   --host-request-interval 1s     # Conservative for rate-limited APIs
     #[arg(long, value_parser = humantime::parse_duration, verbatim_doc_comment)]
     #[serde(default, with = "humantime_serde")]
+    #[schemars(with = "String")]
     pub(crate) host_request_interval: Option<Duration>,
 
     /// Number of threads to utilize.
@@ -484,6 +494,7 @@ pub(crate) struct Config {
     )]
     #[serde(default)]
     #[serde(deserialize_with = "deserialize_headers")]
+    #[schemars(with = "std::collections::HashMap<String, String>")]
     header: Vec<(String, String)>,
 
     /// A List of accepted status codes for valid links
@@ -503,6 +514,7 @@ pub(crate) struct Config {
     ///
     /// [default: 100..=103,200..=299]
     #[arg(short, long, verbatim_doc_comment)]
+    #[schemars(with = "String")]
     accept: Option<StatusCodeSelector>,
 
     /// Accept timed out requests and return exit code 0
@@ -560,6 +572,7 @@ pub(crate) struct Config {
     /// [default: get]
     // Using `-X` as a short param similar to curl
     #[arg(short = 'X', long)]
+    #[schemars(with = "String")]
     method: Option<Methods>,
 
     /// Base URL to use when resolving relative URLs in local files. If specified,
@@ -587,6 +600,7 @@ pub(crate) struct Config {
         value_parser = parse_base_info,
         verbatim_doc_comment
     )]
+    #[schemars(with = "String")]
     pub(crate) base_url: Option<BaseInfo>,
 
     /// Root directory to use when checking absolute links in local files. This option is
@@ -606,10 +620,12 @@ pub(crate) struct Config {
 
     /// Basic authentication support. E.g. `http://example.com username:password`
     #[arg(long)]
+    #[schemars(with = "Vec<String>")]
     pub(crate) basic_auth: Option<Vec<BasicAuthSelector>>,
 
     /// GitHub API token to use when checking github.com links, to avoid rate limiting
     #[arg(long, env = "GITHUB_TOKEN", hide_env_values = true)]
+    #[schemars(with = "String")]
     pub(crate) github_token: Option<SecretString>,
 
     /// Skip missing input files (default is to error if they don't exist)
@@ -702,11 +718,13 @@ pub(crate) struct Config {
     /// esac
     /// ```
     #[arg(short, long, value_name = "COMMAND", verbatim_doc_comment)]
+    #[schemars(with = "String")]
     pub(crate) preprocess: Option<Preprocessor>,
 
     /// Host-specific configurations from config file
     #[arg(skip)]
     #[serde(default)]
+    #[schemars(with = "std::collections::HashMap<String, serde_json::Value>")]
     pub(crate) hosts: HostConfigs,
 }
 
@@ -1051,10 +1069,12 @@ This convention also simplifies our default value testing."
 
         let default_value_annotation = Regex::new(r"\s*\[default: (?<value>.*)\]").unwrap();
         // Matches last line of rustdoc comment, then skips a line (expected to be `#[arg(...)]`),
-        // then matches a *private* field of type Option.
-        let default_field =
-            Regex::new(r"(?m)^\s+///(?<comment>.*)\n.*\n\s+(?<ident>\w+):\s*Option<.*>,?$")
-                .unwrap();
+        // optionally skips a `#[schemars(...)]` attribute line (used for config schema
+        // generation), then matches a *private* field of type Option.
+        let default_field = Regex::new(
+            r"(?m)^\s+///(?<comment>.*)\n.*\n(?:\s*#\[schemars[^\n]*\n)?\s+(?<ident>\w+):\s*Option<.*>,?$",
+        )
+        .unwrap();
 
         let undocumented_default_fields = [
             "verbose",              // the flag takes no argument

--- a/lychee-bin/src/config/output.rs
+++ b/lychee-bin/src/config/output.rs
@@ -4,12 +4,15 @@
 //! such as color modes and output formats (e.g. JSON, Compact, Detailed).
 
 use anyhow::{Error, Result, anyhow};
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::str::FromStr;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 /// The format to use for the final status report
-#[derive(Debug, Deserialize, Default, Clone, Display, EnumIter, VariantNames, PartialEq)]
+#[derive(
+    Debug, Deserialize, Default, Clone, Display, EnumIter, VariantNames, PartialEq, JsonSchema,
+)]
 #[non_exhaustive]
 #[strum(serialize_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -42,7 +45,16 @@ impl FromStr for StatsFormat {
 /// This decides over whether to use color,
 /// emojis, or plain text for the output.
 #[derive(
-    Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq,
+    Debug,
+    Deserialize,
+    Default,
+    Clone,
+    Display,
+    EnumIter,
+    EnumString,
+    VariantNames,
+    PartialEq,
+    JsonSchema,
 )]
 #[non_exhaustive]
 pub(crate) enum OutputMode {

--- a/lychee-bin/src/config/schema.rs
+++ b/lychee-bin/src/config/schema.rs
@@ -1,0 +1,111 @@
+//! JSON Schema representations for config values with custom deserializers.
+//!
+//! These types describe the file format accepted by Serde. They are separate
+//! from the runtime types because several runtime types intentionally expose a
+//! different command-line representation or live in `lychee-lib`, which should
+//! not need to depend on Schemars.
+
+#![allow(dead_code)]
+
+use schemars::JsonSchema;
+use std::collections::HashMap;
+
+/// Log levels accepted by the case-insensitive verbosity deserializer.
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct Verbosity(
+    #[schemars(regex(
+        pattern = "^([Ee][Rr][Rr][Oo][Rr]|[Ww][Aa][Rr][Nn]([Ii][Nn][Gg])?|[Ii][Nn][Ff][Oo]|[Dd][Ee][Bb][Uu][Gg]|[Tt][Rr][Aa][Cc][Ee])$"
+    ))]
+    String,
+);
+
+/// A status-code selector accepts a single integer, a selector string, or a
+/// mixed list of integers and selector strings.
+#[derive(JsonSchema)]
+#[schemars(untagged)]
+pub(super) enum StatusCodeSelector {
+    Integer(StatusCode),
+    String(StatusCodeSelectorString),
+    List(Vec<StatusCodeSelectorValue>),
+}
+
+#[derive(JsonSchema)]
+#[schemars(untagged)]
+pub(super) enum StatusCodeSelectorValue {
+    Integer(StatusCode),
+    String(StatusRangeString),
+}
+
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct StatusCode(#[schemars(range(min = 100, max = 999))] u16);
+
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct StatusCodeSelectorString(
+    #[schemars(regex(
+        pattern = r"^\s*$|^\s*([1-9][0-9]{2}|([1-9][0-9]{2})?\.\.(=?[1-9][0-9]{2})?)(\s*,\s*([1-9][0-9]{2}|([1-9][0-9]{2})?\.\.(=?[1-9][0-9]{2})?))*\s*$"
+    ))]
+    String,
+);
+
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct StatusRangeString(
+    #[schemars(regex(pattern = r"^([1-9][0-9]{2}|([1-9][0-9]{2})?\.\.(=?[1-9][0-9]{2})?)$"))]
+    String,
+);
+
+/// Request methods accept either a comma-separated string or a non-empty list.
+#[derive(JsonSchema)]
+#[schemars(untagged)]
+pub(super) enum Methods {
+    String(HttpMethodsString),
+    List(#[schemars(length(min = 1))] Vec<HttpMethod>),
+}
+
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct HttpMethodsString(
+    #[schemars(regex(
+        pattern = r"^\s*[!#$%&'*+.^_`|~0-9A-Za-z-]+(\s*,\s*[!#$%&'*+.^_`|~0-9A-Za-z-]+)*\s*$"
+    ))]
+    String,
+);
+
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct HttpMethod(#[schemars(regex(pattern = r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$"))] String);
+
+/// Basic-auth selectors use `<uri-regex> <username>:<password>` syntax.
+#[derive(JsonSchema)]
+#[schemars(transparent)]
+pub(super) struct BasicAuthSelector(#[schemars(regex(pattern = r"^\S+ [^:\s]+:[^:\s]+$"))] String);
+
+/// Archives supported in configuration files.
+#[derive(JsonSchema)]
+pub(super) enum Archive {
+    #[schemars(rename = "wayback")]
+    WaybackMachine,
+}
+
+/// File-based preprocessor configuration.
+#[derive(JsonSchema)]
+pub(super) struct Preprocessor {
+    command: String,
+}
+
+/// Per-host request settings accepted below the `hosts` table.
+#[derive(JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub(super) struct HostConfig {
+    concurrency: Option<usize>,
+    request_interval: Option<String>,
+    #[schemars(default)]
+    headers: HashMap<String, String>,
+}
+
+pub(super) fn empty_string_map() -> HashMap<String, String> {
+    HashMap::new()
+}

--- a/lychee-bin/src/config/tls.rs
+++ b/lychee-bin/src/config/tls.rs
@@ -3,11 +3,22 @@
 //! Provides types for specifying minimum accepted TLS versions for network requests.
 
 use reqwest::tls;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use strum::{Display, EnumIter, EnumString, VariantNames};
 
 #[derive(
-    Debug, Deserialize, Default, Clone, Display, EnumIter, EnumString, VariantNames, PartialEq, Eq,
+    Debug,
+    Deserialize,
+    Default,
+    Clone,
+    Display,
+    EnumIter,
+    EnumString,
+    VariantNames,
+    PartialEq,
+    Eq,
+    JsonSchema,
 )]
 #[non_exhaustive]
 pub(crate) enum TlsVersion {

--- a/lychee-bin/src/verbosity.rs
+++ b/lychee-bin/src/verbosity.rs
@@ -1,6 +1,5 @@
 use log::Level;
 use log::LevelFilter;
-use schemars::JsonSchema;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -14,7 +13,7 @@ use std::str::FromStr;
 /// - `-v` show info
 /// - `-vv` show debug
 /// - `-vvv` show trace
-#[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq, JsonSchema)]
+#[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq)]
 #[command(arg_required_else_help = true)]
 pub(crate) struct Verbosity {
     /// Pass many times for more log output

--- a/lychee-bin/src/verbosity.rs
+++ b/lychee-bin/src/verbosity.rs
@@ -1,5 +1,6 @@
 use log::Level;
 use log::LevelFilter;
+use schemars::JsonSchema;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -13,7 +14,7 @@ use std::str::FromStr;
 /// - `-v` show info
 /// - `-vv` show debug
 /// - `-vvv` show trace
-#[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq)]
+#[derive(clap::Args, Debug, Default, Clone, PartialEq, Eq, JsonSchema)]
 #[command(arg_required_else_help = true)]
 pub(crate) struct Verbosity {
     /// Pass many times for more log output


### PR DESCRIPTION
- Builds on https://github.com/lycheeverse/lychee/pull/2286.
- Fixes the generated schema so it matches supported config values.
- Adds coverage for valid and invalid configs.
- @ChrisJr404, could you take a look? The diff to schema PR is [here](https://github.com/ChrisJr404/lychee/compare/config-schema...lycheeverse:lychee:fix/config-schema-validation). Note that it also contains some changes that landed in `master`. You can rebase your branch to see the clean diff if you like. 😃 
